### PR TITLE
feat(warehouse): notes warehouse repo with cloud sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Notes warehouse repo (#10)
+
+- Configure any GitHub repo as a cloud-storage backend for your notes via `markItDown.warehouse.repo` (`owner/repo`); set the branch, subdir, transport (`gh` or `git`), and auto-push behavior independently
+- Status-bar indicator on the right (`Notes synced` / `syncing…` / `behind` / `conflict` / `sync error` / `off`); click → opens the **Mark It Down: Warehouse** output channel
+- Pull on activation (non-blocking); debounced auto-push on note save (default 5s, configurable 1–60s)
+- Workspace notes go under `<subdir>/<workspace-slug>/`, global notes under `<subdir>/_personal/`. Same warehouse can host many workspaces side-by-side; same warehouse can serve multiple machines
+- Per-scope `_index.json` mirrors the F6 NotesStore index — title / category / timestamps. Markdown content lives next to it as `<id>.md`
+- First-push gate: confirmation modal listing repo, branch, subdir, workspace slug, file plan, and counts (added / updated / deleted) — must explicitly **Push** before any commit. Per-`(repo, workspaceId)` flag stored in `workspaceState`.
+- Conflict detection: when both local and remote moved since the last sync, the local copy is kept and the conflict is logged + surfaced in the status bar. Never auto-merges.
+- Secret-safety scanner: every `<id>.md` is scanned before push for GitHub PATs, AWS keys, OpenAI / Anthropic `sk-`, Slack `xox`, Google API keys, PEM private keys, and JWTs. Findings show a redacted preview + line number; user can Cancel or **Push anyway** for false positives.
+- Commands: `markItDown.warehouse.syncNow`, `.pull`, `.openOnGitHub`, `.openLog` — surfaced in the Notes view title bar and command palette
+- Transport `gh` runs `gh auth setup-git` once per repo so push uses your existing `gh auth` session — no extra credentials prompted. Transport `git` shells out to plain git with whatever credentials you already have
+- Working clone lives at `${context.globalStorageUri}/warehouse/<owner>--<repo>/`; safe to delete (re-clones on next sync)
+- Last-sync timestamps stored in `globalState[markItDown.warehouse.lastSyncedAt]` for conflict detection across sessions
+
 ### Added — Phase 0.7: Notes sidebar (#7)
 
 - Activity-bar view container "Mark It Down" with a dedicated "Notes" tree view

--- a/README.md
+++ b/README.md
@@ -77,12 +77,20 @@ Settings (Cmd+, → "Mark It Down"):
 | `markItDown.notes.categories` | `["Daily","Reference","Snippet","Drafts"]` | list of strings |
 | `markItDown.notes.defaultCategory` | `"Drafts"` | string |
 | `markItDown.notes.defaultScope` | `"workspace"` | `workspace / global` |
+| `markItDown.warehouse.repo` | `""` (off) | `owner/repo` |
+| `markItDown.warehouse.branch` | `"main"` | string |
+| `markItDown.warehouse.subdir` | `"notes"` | string |
+| `markItDown.warehouse.transport` | `"gh"` | `gh / git` |
+| `markItDown.warehouse.autoPush` | `true` | boolean |
+| `markItDown.warehouse.autoPushDebounceMs` | `5000` | 1000–60000 |
+| `markItDown.warehouse.workspaceId` | `""` (auto) | string |
 
 ## Documentation
 
 Per-feature pages live in [docs/](docs/). Currently shipped:
 
 - [Notes sidebar](docs/notes-sidebar.md) — workspace + global notes with categories, opened through the Mark It Down editor
+- [Notes warehouse](docs/notes-warehouse.md) — sync your notes to a GitHub repo as cloud storage; pull on activation, debounced auto-push on save, secret-scan + dry-run gate
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 | F6 — Notes sidebar | shipped (0.7) | [notes-sidebar.md](notes-sidebar.md) |
 | F7 — 25-theme bridge | planned | — |
 | F8 — MCP server | planned | — |
-| F9 — Notes warehouse repo | planned | — |
+| F9 — Notes warehouse repo | shipped | [notes-warehouse.md](notes-warehouse.md) |
 | F10 — Publish any markdown to GitHub Pages | planned | — |
 | F11 — Slideshow export | planned | — |
 | F12 — Standalone Electron app | planned | — |

--- a/docs/notes-warehouse.md
+++ b/docs/notes-warehouse.md
@@ -1,0 +1,260 @@
+# Notes Warehouse
+
+Status: shipped in Phase 0.7+ · Issue: [#10](https://github.com/fadymondy/mark-it-down/issues/10) · Depends on: [#7 Notes sidebar](notes-sidebar.md)
+
+A "notes warehouse" is a GitHub repo you nominate as the cloud-storage backend for everything in your [Notes sidebar](notes-sidebar.md). Mark It Down keeps a local working clone in extension storage, pulls on activation, pushes (debounced) when you save a note, and you can ship the same notes to multiple machines and multiple workspaces by pointing each install at the same warehouse repo.
+
+## At a glance
+
+| | |
+|---|---|
+| **Where** | Status bar (right side, "Notes synced" / "syncing" / etc.) · Notes view title bar · command palette under "Mark It Down: Warehouse" |
+| **What** | A GitHub repo you own (or have write access to). Defaults assume a `notes/` subdirectory but it's configurable. |
+| **How** | A local working clone under `${context.globalStorageUri}/warehouse/<owner>--<repo>/`. Sync goes through the `git` CLI; with `transport: "gh"` we run `gh auth setup-git` once so credentials come from your existing `gh auth login`. |
+| **When** | Pull on extension activation (non-blocking). Push debounced after each note save (default 5s). Manual `Sync Now` / `Pull` commands any time. |
+| **Who sees what** | Workspace notes go under `<subdir>/<workspace-slug>/`. Global notes go under `<subdir>/_personal/`. The same warehouse can host many workspaces side-by-side. |
+
+## Quick start
+
+```jsonc
+// settings.json
+{
+  "markItDown.warehouse.repo": "you/your-notes",
+  "markItDown.warehouse.branch": "main",
+  "markItDown.warehouse.subdir": "notes",
+  "markItDown.warehouse.transport": "gh",
+  "markItDown.warehouse.autoPush": true
+}
+```
+
+That's the minimum. On the next save:
+
+1. The status bar flips from "Notes warehouse: off" → "Notes synced".
+2. After ~5s of save inactivity, Mark It Down builds a push plan and shows a confirmation modal — **only on the first push from a workspace**. Review the listed files, click **Push** to commit + push.
+3. Subsequent saves auto-push silently in the background.
+
+## Repo layout
+
+For warehouse `you/your-notes`, branch `main`, subdir `notes`, with one workspace named `acme-app` and some global notes:
+
+```
+your-notes/                           ← your warehouse repo (GitHub)
+└── notes/                            ← markItDown.warehouse.subdir
+    ├── _personal/                    ← all global notes
+    │   ├── _index.json               ← workspaceState/globalState mirror for this scope
+    │   ├── 8jqzv2axrmfn.md
+    │   └── …
+    └── acme-app/                     ← workspace slug (markItDown.warehouse.workspaceId or derived)
+        ├── _index.json
+        ├── ka9zsb1tfnd2.md
+        └── …
+```
+
+Add another workspace to the same warehouse and a sibling folder appears (`notes/another-workspace/_index.json`). Multiple machines pointing at the same warehouse converge on the same per-scope folders.
+
+### `_index.json`
+
+Mirrors the F6 NotesStore index for the scope. One per scope per workspace. Carries metadata; the markdown files carry content:
+
+```json
+{
+  "scope": "workspace",
+  "workspaceId": "acme-app",
+  "generatedAt": "2026-04-29T12:34:56.789Z",
+  "notes": [
+    {
+      "id": "ka9zsb1tfnd2",
+      "title": "Sprint 12 retro",
+      "category": "Daily",
+      "scope": "workspace",
+      "createdAt": "2026-04-22T09:01:00.000Z",
+      "updatedAt": "2026-04-22T17:42:11.000Z",
+      "filename": "ka9zsb1tfnd2.md"
+    }
+  ]
+}
+```
+
+The index is the source of truth on pull. If a remote `_index.json` references a missing `<id>.md`, that note is skipped with a warning in the log.
+
+## Commands
+
+| Command | Default surface |
+|---|---|
+| `markItDown.warehouse.syncNow` | View title bar (cloud icon) · command palette · status-bar click |
+| `markItDown.warehouse.pull` | View title overflow · command palette |
+| `markItDown.warehouse.openOnGitHub` | View title overflow · command palette |
+| `markItDown.warehouse.openLog` | Status-bar click · command palette |
+
+`Sync Now` is the most-used flow: pull → reconcile → build push plan → confirm (first time only) → push.
+
+## Settings
+
+| Setting | Default | What it does |
+|---|---|---|
+| `markItDown.warehouse.repo` | `""` | `owner/repo`. Empty = warehouse disabled. Setting this is the on-switch. |
+| `markItDown.warehouse.branch` | `"main"` | Branch to clone, pull from, and push to. |
+| `markItDown.warehouse.subdir` | `"notes"` | Subdirectory inside the warehouse repo. Useful when the repo is shared with other content. |
+| `markItDown.warehouse.transport` | `"gh"` | `"gh"` runs `gh auth setup-git` once and lets git use the gh credential helper — no extra prompts. `"git"` shells out to plain git with whatever credentials you already have configured (SSH keys, credential helper). |
+| `markItDown.warehouse.autoPush` | `true` | Push automatically after a debounce window when notes change. Set to `false` if you want fully manual sync via `Sync Now`. |
+| `markItDown.warehouse.autoPushDebounceMs` | `5000` | How long to wait after a save before pushing. Saves within this window batch into one push. Clamped to 1000–60000. |
+| `markItDown.warehouse.workspaceId` | `""` | Override the workspace folder name used as the per-workspace subfolder. Useful when two workspaces have the same folder name on different machines. Empty = derive from `vscode.workspace.workspaceFolders[0].name`. |
+
+## Workflows
+
+### First push (the dry-run gate)
+
+Before the **first** push from a given workspace + warehouse pair, you get a modal:
+
+```
+Mark It Down: confirm the first push to the notes warehouse.
+
+Repo:      you/your-notes@main
+Subdir:    notes/
+Workspace: acme-app
+
+Will create: 7 note(s)
+Will update: 0 note(s)
+Will delete: 0 note(s)
+
+Files staged:
+  notes/acme-app/_index.json
+  notes/acme-app/ka9zsb1tfnd2.md
+  …
+
+[Push] [Cancel]
+```
+
+Click `Push` to send. The confirmation flag is stored in `workspaceState` under `markItDown.warehouse.firstPushDone:<repo>/<workspaceId>` so subsequent pushes don't re-prompt. Click `Cancel` to bail — nothing is committed locally or remotely.
+
+This gate exists so you can sanity-check what's going where before any commit lands. Don't disable it unless you're sure (it can't be disabled today; the marker key is per-`(repo, workspaceId)` pair).
+
+### Auto-push on save
+
+The Notes sidebar emits a change event whenever a note is created / renamed / moved / deleted, and `onDidSaveTextDocument` fires when the markdown content is saved. The warehouse listens to both, debounces by `autoPushDebounceMs` (default 5s), and pushes at the end of the window.
+
+If a sync is already in flight when the timer fires, the auto-push is rescheduled to fire 5s later — there's never more than one push running at a time.
+
+### Manual `Sync Now`
+
+`Sync Now` does the full round-trip: pull, reconcile remote → local with conflict checks, build the push plan, gate on first-push if needed, push. Use this:
+
+- After editing notes on another machine — pull picks up their updates.
+- When the status bar shows "Notes behind" or "Notes conflict".
+- After fixing a sync error — once you've addressed whatever was failing.
+
+### Pull-only
+
+`Pull` is the read half of `Sync Now`. Useful when you just want to bring local up to date without pushing your in-flight edits.
+
+## Conflict policy
+
+Conflicts are detected, reported, **never auto-merged**.
+
+A conflict is when both:
+
+- Your local note's `updatedAt` is newer than the last successful sync, AND
+- The remote note's `updatedAt` is newer than the last successful sync, AND
+- The two timestamps don't match.
+
+When detected:
+
+1. The local copy is kept — the remote version does **not** clobber it.
+2. The status bar flips to "Notes conflict" with a tooltip count.
+3. A warning is logged to the **Mark It Down: Warehouse** output channel naming the conflicting note.
+4. On the next push, your local version wins (and the remote version is overwritten).
+
+To rescue the remote version, open the warehouse on GitHub (`Warehouse: Open on GitHub`), navigate to the conflicting `<id>.md`, manually merge the content into your local note, then save. The next push captures your reconciliation.
+
+A more interactive conflict UI (side-by-side, accept-remote / accept-local / merge) is on the roadmap but not in this release.
+
+## Secret-safety guard
+
+Before any push, every `<id>.md` content is scanned for token patterns:
+
+- GitHub PATs / app / OAuth / fine-grained tokens (`gh[psuor]_`, `github_pat_`)
+- AWS access key IDs (`AKIA…`) and AWS-shaped secret keys
+- OpenAI / Anthropic-style `sk-…` keys, including `sk-ant-…`
+- Slack `xox[baprs]-…` tokens
+- Google API keys (`AIza…`)
+- PEM private-key blocks (`-----BEGIN … PRIVATE KEY-----`)
+- JSON Web Tokens (`eyJ…`)
+
+If any pattern matches, the push is **blocked** and a modal lists each finding with a redacted preview (`ghp_abcd…XY`) and the line number. You can:
+
+- **Cancel** — no push happens. Edit the note to remove the secret, then save again. The next debounce will re-scan.
+- **Push anyway** — bypasses the scan for this push only. Use sparingly; the modal is intentionally loud.
+
+The scanner is conservative — false positives can happen (e.g. a base64 string the same length as an AWS secret). The redacted preview should make it obvious whether a finding is a real token or noise. The warehouse code never logs the full token, only the preview.
+
+## Status-bar states
+
+| Icon | Text | Meaning |
+|---|---|---|
+| `$(circle-slash)` | Notes warehouse: off | `markItDown.warehouse.repo` is empty — sync disabled. |
+| `$(cloud)` | Notes synced | Last operation completed cleanly. |
+| `$(sync~spin)` | Notes syncing… | Pull or push in flight. |
+| `$(cloud-download)` | Notes behind | Remote has changes you don't have locally. Click → Pull. |
+| `$(warning)` | Notes conflict | Diverged on at least one note. Local kept; resolve manually. |
+| `$(error)` | Notes sync error | Last operation failed. Click → open the log. |
+
+Click the status bar item to open the **Mark It Down: Warehouse** output channel.
+
+## Storage on disk
+
+Local working clone:
+
+```
+${context.globalStorageUri}/warehouse/<owner>--<repo>/
+├── .git/
+└── <subdir>/
+    ├── _personal/
+    │   ├── _index.json
+    │   └── <id>.md
+    └── <workspace-slug>/
+        ├── _index.json
+        └── <id>.md
+```
+
+This clone is shared across all VSCode windows on the machine — the warehouse subsystem is single-process per VSCode session per repo. It's safe to delete the directory; the next sync re-clones from origin.
+
+State that travels with the warehouse:
+
+- `globalState[markItDown.warehouse.lastSyncedAt]` — `Map<noteId, epochMs>` of the last successful sync timestamp per note. Used for conflict detection.
+- `workspaceState[markItDown.warehouse.firstPushDone:<repo>/<workspaceId>]` — boolean, set when you confirm the first-push modal.
+
+## Edge cases & behavior notes
+
+- **Empty `repo` setting**: warehouse is disabled. No pull, no push, no status-bar clutter beyond the "off" indicator.
+- **`gh` not installed but `transport: "gh"`**: the first sync errors with a clear "install gh and run `gh auth login`" message. Switch to `transport: "git"` if you can't install gh.
+- **`gh auth setup-git` fails**: we fall back to plain git credentials (warning logged); your push will succeed if you have a working credential helper.
+- **No workspace open**: only global notes (`_personal/`) sync; no workspace folder is created on the warehouse. The status bar still shows correctly.
+- **Branch doesn't exist on remote**: `git clone --branch <branch>` fails with a clear error; create the branch (or push an initial commit on `main`) and try again.
+- **Concurrent VSCode windows on the same machine**: each runs an independent `WarehouseManager` against the **same** working clone. The serialization is per-window, not cross-window — two pushes from two windows can race. Conservative behavior: don't push from two windows simultaneously. The roadmap includes a working-clone lock file for v1+.
+- **Large notes (>5MB) or many files**: works, but the push commit lists them all. The commit message starts with a one-line summary plus a body listing each affected note.
+- **Disabling auto-push (`autoPush: false`)**: only manual `Sync Now` / `Pull` push. The status bar still shows current state.
+- **Renaming a note**: only the index changes; the `<id>.md` filename is stable. The warehouse picks up the new title on the next push (in the `_index.json` diff).
+- **Deleting a note**: the local `<id>.md` is unlinked, the index entry is removed, and the next push deletes the file from the warehouse + writes the updated index.
+
+## Future-work seeds
+
+These were called out in the issue as out-of-scope and would land as separate issues:
+
+- Side-by-side conflict UI with accept-remote / accept-local / merge actions
+- Multi-warehouse routing (per-category or per-tag → different warehouses)
+- Encryption-at-rest for secrets in notes (so the warehouse repo can be public without leaking)
+- Cross-window working-clone lock file
+- Shallow / partial sync (`subdir/` glob filters)
+
+## Files of interest
+
+- [src/warehouse/warehouseConfig.ts](../src/warehouse/warehouseConfig.ts) — settings reader, workspace-slug derivation
+- [src/warehouse/warehouseTransport.ts](../src/warehouse/warehouseTransport.ts) — git CLI shell-out, `gh auth setup-git` integration
+- [src/warehouse/warehouseSync.ts](../src/warehouse/warehouseSync.ts) — pull/push orchestration, index reconciliation, conflict detection
+- [src/warehouse/secretScanner.ts](../src/warehouse/secretScanner.ts) — pre-push token regex set
+- [src/warehouse/warehouseStatusBar.ts](../src/warehouse/warehouseStatusBar.ts) — 6-state status bar item
+- [src/warehouse/warehouseLog.ts](../src/warehouse/warehouseLog.ts) — output channel
+- [src/warehouse/warehouseManager.ts](../src/warehouse/warehouseManager.ts) — facade wired into `extension.ts`; coordinates pull, debounced push, dry-run gate, secret-detect modal
+- [src/warehouse/warehouseCommands.ts](../src/warehouse/warehouseCommands.ts) — VSCode command registration
+- [src/extension.ts](../src/extension.ts) — wiring on activation
+- [package.json](../package.json) — `commands`, `menus.view/title`, `configuration.markItDown.warehouse.*`

--- a/package.json
+++ b/package.json
@@ -139,6 +139,30 @@
         "title": "Reveal Notes Folder",
         "category": "Mark It Down",
         "icon": "$(folder-opened)"
+      },
+      {
+        "command": "markItDown.warehouse.syncNow",
+        "title": "Warehouse: Sync Now",
+        "category": "Mark It Down",
+        "icon": "$(cloud)"
+      },
+      {
+        "command": "markItDown.warehouse.pull",
+        "title": "Warehouse: Pull",
+        "category": "Mark It Down",
+        "icon": "$(cloud-download)"
+      },
+      {
+        "command": "markItDown.warehouse.openOnGitHub",
+        "title": "Warehouse: Open on GitHub",
+        "category": "Mark It Down",
+        "icon": "$(github)"
+      },
+      {
+        "command": "markItDown.warehouse.openLog",
+        "title": "Warehouse: Show Sync Log",
+        "category": "Mark It Down",
+        "icon": "$(output)"
       }
     ],
     "menus": {
@@ -178,9 +202,29 @@
           "group": "navigation@2"
         },
         {
+          "command": "markItDown.warehouse.syncNow",
+          "when": "view == markItDown.notes",
+          "group": "navigation@3"
+        },
+        {
           "command": "markItDown.notes.revealStorage",
           "when": "view == markItDown.notes",
           "group": "overflow@1"
+        },
+        {
+          "command": "markItDown.warehouse.pull",
+          "when": "view == markItDown.notes",
+          "group": "overflow@2"
+        },
+        {
+          "command": "markItDown.warehouse.openOnGitHub",
+          "when": "view == markItDown.notes",
+          "group": "overflow@3"
+        },
+        {
+          "command": "markItDown.warehouse.openLog",
+          "when": "view == markItDown.notes",
+          "group": "overflow@4"
         }
       ],
       "view/item/context": [
@@ -261,6 +305,48 @@
           "default": "workspace",
           "enum": ["workspace", "global"],
           "description": "Where new notes go by default. Falls back to 'global' when no folder is open."
+        },
+        "markItDown.warehouse.repo": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "GitHub repo to use as your notes warehouse, in `owner/repo` form. Leave empty to disable cloud sync."
+        },
+        "markItDown.warehouse.branch": {
+          "type": "string",
+          "default": "main",
+          "description": "Branch on the warehouse repo to sync against."
+        },
+        "markItDown.warehouse.subdir": {
+          "type": "string",
+          "default": "notes",
+          "description": "Subdirectory inside the warehouse repo where notes are stored."
+        },
+        "markItDown.warehouse.transport": {
+          "type": "string",
+          "default": "gh",
+          "enum": ["gh", "git"],
+          "markdownEnumDescriptions": [
+            "Use the `gh` CLI's existing auth (runs `gh auth setup-git` to wire git credentials).",
+            "Use plain `git` with whatever credential helper you have configured."
+          ],
+          "description": "How to authenticate with GitHub for warehouse operations."
+        },
+        "markItDown.warehouse.autoPush": {
+          "type": "boolean",
+          "default": true,
+          "description": "Push to the warehouse automatically after a note save (debounced)."
+        },
+        "markItDown.warehouse.autoPushDebounceMs": {
+          "type": "number",
+          "default": 5000,
+          "minimum": 1000,
+          "maximum": 60000,
+          "description": "Debounce window for auto-push, in milliseconds. Multiple saves within this window batch into one push."
+        },
+        "markItDown.warehouse.workspaceId": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Override the workspace folder name used as a subfolder in the warehouse. Leave empty to derive from the workspace name."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,9 @@ import { MarkdownEditorProvider } from './editor/markdownEditorProvider';
 import { NotesStore } from './notes/notesStore';
 import { NotesTreeProvider } from './notes/notesTreeProvider';
 import { registerNotesCommands } from './notes/notesCommands';
+import { WarehouseManager } from './warehouse/warehouseManager';
+import { registerWarehouseCommands } from './warehouse/warehouseCommands';
+import { disposeLogChannel } from './warehouse/warehouseLog';
 
 export function activate(context: vscode.ExtensionContext) {
   const provider = new MarkdownEditorProvider(context);
@@ -20,12 +23,16 @@ export function activate(context: vscode.ExtensionContext) {
 
   const notesStore = new NotesStore(context);
   const notesTree = new NotesTreeProvider(notesStore);
+  const warehouse = new WarehouseManager(context, notesStore);
   context.subscriptions.push(
     notesStore,
     notesTree,
+    warehouse,
     vscode.window.registerTreeDataProvider('markItDown.notes', notesTree),
     ...registerNotesCommands(context, notesStore),
+    ...registerWarehouseCommands(warehouse),
   );
+  warehouse.start();
 
   context.subscriptions.push(
     vscode.commands.registerCommand('markItDown.toggleMode', () => {
@@ -56,5 +63,5 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
-  // no-op
+  disposeLogChannel();
 }

--- a/src/notes/notesStore.ts
+++ b/src/notes/notesStore.ts
@@ -80,6 +80,24 @@ export class NotesStore {
     return note;
   }
 
+  public async importNote(meta: NoteMetadata, content: string): Promise<NoteMetadata> {
+    if (meta.scope === 'workspace' && !this.hasWorkspaceStorage()) {
+      throw new Error('Workspace storage unavailable; cannot import workspace note.');
+    }
+    const uri = this.uriFor(meta);
+    await ensureDir(uri);
+    await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(content));
+    const index = this.read(meta.scope).filter(n => n.id !== meta.id);
+    index.push({ ...meta });
+    await this.write(meta.scope, index);
+    return meta;
+  }
+
+  public async readContent(meta: NoteMetadata): Promise<string> {
+    const buf = await vscode.workspace.fs.readFile(this.uriFor(meta));
+    return new TextDecoder().decode(buf);
+  }
+
   public async rename(id: string, title: string): Promise<NoteMetadata> {
     return this.update(id, n => ({ ...n, title: title.trim() || n.title }));
   }

--- a/src/warehouse/secretScanner.ts
+++ b/src/warehouse/secretScanner.ts
@@ -1,0 +1,89 @@
+export interface SecretFinding {
+  pattern: string;
+  description: string;
+  /** 1-indexed line number where the match starts. */
+  line: number;
+  /** Truncated, 8-char preview so the secret isn't fully exposed in the warning. */
+  preview: string;
+}
+
+interface PatternDef {
+  name: string;
+  description: string;
+  regex: RegExp;
+}
+
+const PATTERNS: PatternDef[] = [
+  {
+    name: 'github-token',
+    description: 'GitHub personal access / app / OAuth token (ghp_, gho_, ghu_, ghs_, ghr_, github_pat_)',
+    regex: /\b(?:gh[psuor]_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{60,})\b/,
+  },
+  {
+    name: 'aws-access-key',
+    description: 'AWS access key id',
+    regex: /\bAKIA[0-9A-Z]{16}\b/,
+  },
+  {
+    name: 'aws-secret-key',
+    description: 'AWS-shaped secret access key',
+    regex: /(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])/,
+  },
+  {
+    name: 'openai-key',
+    description: 'OpenAI / Anthropic-style sk- API key',
+    regex: /\bsk-[A-Za-z0-9_-]{20,}\b/,
+  },
+  {
+    name: 'anthropic-key',
+    description: 'Anthropic API key (sk-ant-)',
+    regex: /\bsk-ant-[A-Za-z0-9_-]{40,}\b/,
+  },
+  {
+    name: 'slack-token',
+    description: 'Slack bot/user/app/legacy token',
+    regex: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/,
+  },
+  {
+    name: 'google-api-key',
+    description: 'Google API key',
+    regex: /\bAIza[0-9A-Za-z_-]{35}\b/,
+  },
+  {
+    name: 'private-key-pem',
+    description: 'PEM-encoded private key block',
+    regex: /-----BEGIN (?:RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY-----/,
+  },
+  {
+    name: 'jwt',
+    description: 'JSON Web Token (header.payload.signature)',
+    regex: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/,
+  },
+];
+
+export function scanForSecrets(content: string): SecretFinding[] {
+  const lines = content.split(/\r?\n/);
+  const findings: SecretFinding[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    for (const pattern of PATTERNS) {
+      const match = pattern.regex.exec(line);
+      if (match) {
+        findings.push({
+          pattern: pattern.name,
+          description: pattern.description,
+          line: i + 1,
+          preview: redact(match[0]),
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+function redact(token: string): string {
+  if (token.length <= 8) {
+    return '*'.repeat(token.length);
+  }
+  return `${token.slice(0, 4)}…${token.slice(-2)}`;
+}

--- a/src/warehouse/warehouseCommands.ts
+++ b/src/warehouse/warehouseCommands.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+import { WarehouseManager } from './warehouseManager';
+
+export function registerWarehouseCommands(manager: WarehouseManager): vscode.Disposable[] {
+  return [
+    vscode.commands.registerCommand('markItDown.warehouse.syncNow', () => manager.syncNow()),
+    vscode.commands.registerCommand('markItDown.warehouse.pull', () => manager.pullCommand()),
+    vscode.commands.registerCommand('markItDown.warehouse.openOnGitHub', () => manager.openOnGitHub()),
+    vscode.commands.registerCommand('markItDown.warehouse.openLog', () => manager.openLog()),
+  ];
+}

--- a/src/warehouse/warehouseConfig.ts
+++ b/src/warehouse/warehouseConfig.ts
@@ -1,0 +1,103 @@
+import * as vscode from 'vscode';
+
+export type WarehouseTransport = 'gh' | 'git';
+
+export interface WarehouseConfig {
+  enabled: boolean;
+  repo: string;
+  branch: string;
+  subdir: string;
+  transport: WarehouseTransport;
+  autoPush: boolean;
+  autoPushDebounceMs: number;
+  workspaceId: string;
+}
+
+export const PERSONAL_WORKSPACE_ID = '_personal';
+
+const DEFAULT_BRANCH = 'main';
+const DEFAULT_SUBDIR = 'notes';
+const DEFAULT_TRANSPORT: WarehouseTransport = 'gh';
+const DEFAULT_DEBOUNCE_MS = 5000;
+
+export function readConfig(): WarehouseConfig {
+  const cfg = vscode.workspace.getConfiguration('markItDown.warehouse');
+  const repo = (cfg.get<string>('repo') ?? '').trim();
+  const branch = (cfg.get<string>('branch') ?? DEFAULT_BRANCH).trim() || DEFAULT_BRANCH;
+  const subdir = normalizeSubdir(cfg.get<string>('subdir') ?? DEFAULT_SUBDIR);
+  const transport = (cfg.get<WarehouseTransport>('transport') ?? DEFAULT_TRANSPORT) === 'git' ? 'git' : 'gh';
+  const autoPush = cfg.get<boolean>('autoPush') ?? true;
+  const debounce = clampInt(cfg.get<number>('autoPushDebounceMs') ?? DEFAULT_DEBOUNCE_MS, 1000, 60_000);
+  const workspaceId = resolveWorkspaceId(cfg.get<string>('workspaceId'));
+  return {
+    enabled: repo.length > 0,
+    repo,
+    branch,
+    subdir,
+    transport,
+    autoPush,
+    autoPushDebounceMs: debounce,
+    workspaceId,
+  };
+}
+
+export function isAffected(event: vscode.ConfigurationChangeEvent): boolean {
+  return event.affectsConfiguration('markItDown.warehouse');
+}
+
+export function repoSlug(config: WarehouseConfig): string {
+  return config.repo.replace(/[^A-Za-z0-9._-]+/g, '--');
+}
+
+export function repoUrl(config: WarehouseConfig): string {
+  return `https://github.com/${config.repo}.git`;
+}
+
+export function repoWebUrl(config: WarehouseConfig, relative?: string): string {
+  const base = `https://github.com/${config.repo}/blob/${encodeURIComponent(config.branch)}`;
+  if (!relative) {
+    return `https://github.com/${config.repo}/tree/${encodeURIComponent(config.branch)}`;
+  }
+  return `${base}/${relative.split('/').map(encodeURIComponent).join('/')}`;
+}
+
+export function scopeDir(config: WarehouseConfig, scope: 'workspace' | 'global'): string {
+  const slug = scope === 'global' ? PERSONAL_WORKSPACE_ID : config.workspaceId;
+  return `${config.subdir}/${slug}`;
+}
+
+function normalizeSubdir(input: string): string {
+  const trimmed = input.trim().replace(/^\/+|\/+$/g, '');
+  return trimmed.length > 0 ? trimmed : DEFAULT_SUBDIR;
+}
+
+function resolveWorkspaceId(explicit: string | undefined): string {
+  const value = explicit?.trim();
+  if (value) {
+    return slugify(value);
+  }
+  const folders = vscode.workspace.workspaceFolders;
+  if (folders && folders.length > 0) {
+    return slugify(folders[0].name);
+  }
+  if (vscode.workspace.name) {
+    return slugify(vscode.workspace.name);
+  }
+  return PERSONAL_WORKSPACE_ID;
+}
+
+export function slugify(input: string): string {
+  const cleaned = input
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+  return cleaned.length > 0 ? cleaned : 'workspace';
+}
+
+function clampInt(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, Math.floor(value)));
+}

--- a/src/warehouse/warehouseLog.ts
+++ b/src/warehouse/warehouseLog.ts
@@ -1,0 +1,39 @@
+import * as vscode from 'vscode';
+
+let channel: vscode.OutputChannel | undefined;
+
+export function getLogChannel(): vscode.OutputChannel {
+  if (!channel) {
+    channel = vscode.window.createOutputChannel('Mark It Down: Warehouse');
+  }
+  return channel;
+}
+
+export function disposeLogChannel(): void {
+  channel?.dispose();
+  channel = undefined;
+}
+
+export function log(level: 'info' | 'warn' | 'error', ...parts: unknown[]): void {
+  const ch = getLogChannel();
+  const ts = new Date().toISOString();
+  const tag = level.toUpperCase().padEnd(5);
+  ch.appendLine(`${ts}  ${tag}  ${parts.map(stringify).join(' ')}`);
+  if (level === 'error') {
+    ch.show(true);
+  }
+}
+
+function stringify(value: unknown): string {
+  if (value instanceof Error) {
+    return value.stack ?? value.message;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/src/warehouse/warehouseManager.ts
+++ b/src/warehouse/warehouseManager.ts
@@ -1,0 +1,240 @@
+import * as vscode from 'vscode';
+import { NotesStore } from '../notes/notesStore';
+import { isAffected, readConfig, repoWebUrl, WarehouseConfig } from './warehouseConfig';
+import { log } from './warehouseLog';
+import { WarehouseStatusBar } from './warehouseStatusBar';
+import { PushPlan, SecretsDetectedError, SyncSummary, WarehouseSync } from './warehouseSync';
+import { WarehouseTransport } from './warehouseTransport';
+
+export class WarehouseManager implements vscode.Disposable {
+  private readonly transport: WarehouseTransport;
+  private readonly sync: WarehouseSync;
+  private readonly statusBar: WarehouseStatusBar;
+  private readonly subs: vscode.Disposable[] = [];
+  private autoPushTimer: NodeJS.Timeout | undefined;
+  private currentConfig: WarehouseConfig;
+  private busy = false;
+
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly store: NotesStore,
+  ) {
+    this.transport = new WarehouseTransport(context.globalStorageUri);
+    this.sync = new WarehouseSync(context, store, this.transport);
+    this.statusBar = new WarehouseStatusBar();
+    this.currentConfig = readConfig();
+
+    this.subs.push(
+      vscode.workspace.onDidChangeConfiguration(e => {
+        if (isAffected(e)) {
+          this.currentConfig = readConfig();
+          this.refreshStatusBar();
+        }
+      }),
+      this.store.onDidChange(() => this.maybeSchedulePush()),
+    );
+    this.refreshStatusBar();
+  }
+
+  public start(): void {
+    if (this.currentConfig.enabled) {
+      void this.pull({ silent: true }).catch(err => log('error', 'startup pull failed', err));
+    }
+  }
+
+  public async syncNow(): Promise<void> {
+    if (!this.requireConfigured()) return;
+    await this.guard(async () => {
+      this.statusBar.set('syncing', 'Pulling…');
+      const pulled = await this.sync.pull(this.currentConfig);
+      this.statusBar.set('syncing', 'Building push plan…');
+      const plan = await this.sync.planPush(this.currentConfig);
+      const pushed = await this.runPush(plan);
+      this.report({ pulled, pushed, warnings: [] });
+    });
+  }
+
+  public async pullCommand(): Promise<void> {
+    if (!this.requireConfigured()) return;
+    await this.guard(async () => {
+      this.statusBar.set('syncing', 'Pulling…');
+      const pulled = await this.sync.pull(this.currentConfig);
+      this.report({ pulled, pushed: { added: 0, updated: 0, deleted: 0 }, warnings: [] });
+    });
+  }
+
+  public async openOnGitHub(): Promise<void> {
+    if (!this.requireConfigured()) return;
+    await vscode.env.openExternal(vscode.Uri.parse(repoWebUrl(this.currentConfig)));
+  }
+
+  public openLog(): void {
+    log('info', 'log channel opened by user');
+    vscode.commands.executeCommand('workbench.action.output.show.markItDown.warehouse').then(undefined, () => {
+      // ignore — the output channel command varies by VSCode version; channel itself shows on errors anyway
+    });
+  }
+
+  public dispose(): void {
+    if (this.autoPushTimer) clearTimeout(this.autoPushTimer);
+    this.statusBar.dispose();
+    this.subs.forEach(s => s.dispose());
+  }
+
+  private async pull(opts: { silent: boolean }): Promise<void> {
+    await this.guard(async () => {
+      this.statusBar.set('syncing', 'Pulling…');
+      const pulled = await this.sync.pull(this.currentConfig);
+      if (!opts.silent) {
+        this.report({ pulled, pushed: { added: 0, updated: 0, deleted: 0 }, warnings: [] });
+      } else if (pulled.added + pulled.updated > 0) {
+        log('info', `startup pull imported ${pulled.added} new + ${pulled.updated} updated notes`);
+      }
+    });
+  }
+
+  private maybeSchedulePush(): void {
+    if (!this.currentConfig.enabled || !this.currentConfig.autoPush) return;
+    if (this.autoPushTimer) clearTimeout(this.autoPushTimer);
+    this.autoPushTimer = setTimeout(() => {
+      this.autoPushTimer = undefined;
+      this.runAutoPush().catch(err => log('error', 'auto-push failed', err));
+    }, this.currentConfig.autoPushDebounceMs);
+  }
+
+  private async runAutoPush(): Promise<void> {
+    if (this.busy) {
+      this.maybeSchedulePush();
+      return;
+    }
+    await this.guard(async () => {
+      this.statusBar.set('syncing', 'Auto-push…');
+      const plan = await this.sync.planPush(this.currentConfig);
+      if (!this.sync.hasPushWork(plan)) {
+        return;
+      }
+      await this.runPush(plan);
+    });
+  }
+
+  private async runPush(plan: PushPlan): Promise<SyncSummary['pushed']> {
+    if (!this.sync.hasPushWork(plan)) {
+      return { added: 0, updated: 0, deleted: 0 };
+    }
+    if (!this.sync.hasConfirmedFirstPush(this.currentConfig)) {
+      const ok = await confirmFirstPush(plan, this.currentConfig);
+      if (!ok) {
+        log('info', 'first push cancelled by user');
+        return { added: 0, updated: 0, deleted: 0 };
+      }
+      await this.sync.markFirstPushConfirmed(this.currentConfig);
+    }
+    try {
+      const result = await this.sync.push(this.currentConfig, plan);
+      return result;
+    } catch (err) {
+      if (err instanceof SecretsDetectedError) {
+        const choice = await vscode.window.showWarningMessage(
+          'Mark It Down: secrets detected in notes about to push. Review the log and decide.',
+          { modal: true, detail: err.message },
+          'Push anyway',
+          'Cancel',
+        );
+        if (choice === 'Push anyway') {
+          return await this.sync.push(this.currentConfig, plan, { allowSecrets: true });
+        }
+        return { added: 0, updated: 0, deleted: 0 };
+      }
+      throw err;
+    }
+  }
+
+  private async guard(fn: () => Promise<void>): Promise<void> {
+    if (this.busy) {
+      log('warn', 'sync already in progress; ignoring concurrent request');
+      return;
+    }
+    this.busy = true;
+    try {
+      await fn();
+      this.statusBar.set('idle');
+    } catch (err) {
+      log('error', err);
+      this.statusBar.set('error', (err as Error).message);
+      vscode.window.showErrorMessage(`Mark It Down warehouse: ${(err as Error).message}`);
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  private requireConfigured(): boolean {
+    if (this.currentConfig.enabled) return true;
+    void vscode.window
+      .showInformationMessage(
+        'Notes warehouse is not configured. Set markItDown.warehouse.repo (e.g. "you/your-notes") to enable cloud sync.',
+        'Open Settings',
+      )
+      .then(choice => {
+        if (choice === 'Open Settings') {
+          vscode.commands.executeCommand('workbench.action.openSettings', 'markItDown.warehouse');
+        }
+      });
+    return false;
+  }
+
+  private refreshStatusBar(): void {
+    if (!this.currentConfig.enabled) {
+      this.statusBar.set('disabled');
+    } else {
+      this.statusBar.set('idle', `${this.currentConfig.repo}@${this.currentConfig.branch}`);
+    }
+  }
+
+  private report(summary: SyncSummary): void {
+    const { pulled, pushed } = summary;
+    const parts: string[] = [];
+    if (pulled.added + pulled.updated > 0) {
+      parts.push(`pulled +${pulled.added} ~${pulled.updated}`);
+    }
+    if (pulled.conflicts > 0) {
+      parts.push(`${pulled.conflicts} conflict(s) (kept local)`);
+    }
+    if (pushed.added + pushed.updated + pushed.deleted > 0) {
+      parts.push(`pushed +${pushed.added} ~${pushed.updated} -${pushed.deleted}`);
+      if (pushed.commit) parts.push(`(${pushed.commit.slice(0, 7)})`);
+    }
+    if (parts.length === 0) {
+      parts.push('already in sync');
+    }
+    log('info', 'sync complete:', parts.join(' '));
+    vscode.window.setStatusBarMessage(`Mark It Down warehouse: ${parts.join(' · ')}`, 4000);
+    if (pulled.conflicts > 0) {
+      this.statusBar.set('conflict', `${pulled.conflicts} note(s) diverged. Local copies kept.`);
+    }
+  }
+}
+
+async function confirmFirstPush(plan: PushPlan, config: WarehouseConfig): Promise<boolean> {
+  const detail = [
+    `Repo:      ${config.repo}@${config.branch}`,
+    `Subdir:    ${config.subdir}/`,
+    `Workspace: ${config.workspaceId}`,
+    '',
+    `Will create: ${plan.added.length} note(s)`,
+    `Will update: ${plan.updated.length} note(s)`,
+    `Will delete: ${plan.deleted.length} note(s)`,
+    '',
+    'Files staged:',
+    ...plan.files.slice(0, 12).map(f => `  ${f}`),
+    plan.files.length > 12 ? `  …and ${plan.files.length - 12} more` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+  const choice = await vscode.window.showWarningMessage(
+    'Mark It Down: confirm the first push to the notes warehouse.',
+    { modal: true, detail },
+    'Push',
+    'Cancel',
+  );
+  return choice === 'Push';
+}

--- a/src/warehouse/warehouseStatusBar.ts
+++ b/src/warehouse/warehouseStatusBar.ts
@@ -1,0 +1,73 @@
+import * as vscode from 'vscode';
+
+export type SyncState = 'disabled' | 'idle' | 'syncing' | 'behind' | 'conflict' | 'error';
+
+interface StateRender {
+  icon: string;
+  text: string;
+  tooltip: string;
+  background?: vscode.ThemeColor;
+}
+
+const RENDERS: Record<SyncState, StateRender> = {
+  disabled: {
+    icon: '$(circle-slash)',
+    text: 'Notes warehouse: off',
+    tooltip: 'Set markItDown.warehouse.repo to enable cloud sync.',
+  },
+  idle: {
+    icon: '$(cloud)',
+    text: 'Notes synced',
+    tooltip: 'Notes warehouse is in sync with the remote.',
+  },
+  syncing: {
+    icon: '$(sync~spin)',
+    text: 'Notes syncing…',
+    tooltip: 'Pulling from / pushing to the warehouse.',
+  },
+  behind: {
+    icon: '$(cloud-download)',
+    text: 'Notes behind',
+    tooltip: 'The warehouse has changes you don\'t have locally. Click to pull.',
+  },
+  conflict: {
+    icon: '$(warning)',
+    text: 'Notes conflict',
+    tooltip: 'Local and remote both changed since last sync. Click to resolve.',
+    background: new vscode.ThemeColor('statusBarItem.warningBackground'),
+  },
+  error: {
+    icon: '$(error)',
+    text: 'Notes sync error',
+    tooltip: 'Last warehouse operation failed. Click to view the log.',
+    background: new vscode.ThemeColor('statusBarItem.errorBackground'),
+  },
+};
+
+export class WarehouseStatusBar implements vscode.Disposable {
+  private readonly item: vscode.StatusBarItem;
+  private currentState: SyncState = 'disabled';
+
+  constructor() {
+    this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 50);
+    this.item.command = 'markItDown.warehouse.openLog';
+    this.set('disabled');
+    this.item.show();
+  }
+
+  public set(state: SyncState, detail?: string): void {
+    this.currentState = state;
+    const render = RENDERS[state];
+    this.item.text = `${render.icon} ${render.text}`;
+    this.item.tooltip = detail ? `${render.tooltip}\n${detail}` : render.tooltip;
+    this.item.backgroundColor = render.background;
+  }
+
+  public state(): SyncState {
+    return this.currentState;
+  }
+
+  public dispose(): void {
+    this.item.dispose();
+  }
+}

--- a/src/warehouse/warehouseSync.ts
+++ b/src/warehouse/warehouseSync.ts
@@ -1,0 +1,361 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { NoteMetadata, NoteScope, NotesStore } from '../notes/notesStore';
+import { PERSONAL_WORKSPACE_ID, scopeDir, WarehouseConfig } from './warehouseConfig';
+import { log } from './warehouseLog';
+import { scanForSecrets, SecretFinding } from './secretScanner';
+import { WarehouseClone, WarehouseTransport } from './warehouseTransport';
+
+export interface SyncSummary {
+  pulled: { added: number; updated: number; conflicts: number };
+  pushed: { added: number; updated: number; deleted: number; commit?: string };
+  warnings: string[];
+}
+
+export interface PushPlan {
+  added: NoteMetadata[];
+  updated: NoteMetadata[];
+  deleted: WarehouseIndexEntry[];
+  files: string[];
+}
+
+interface WarehouseIndexEntry {
+  id: string;
+  title: string;
+  category: string;
+  scope: NoteScope;
+  createdAt: string;
+  updatedAt: string;
+  filename: string;
+}
+
+interface WarehouseIndex {
+  scope: NoteScope;
+  workspaceId: string;
+  generatedAt: string;
+  notes: WarehouseIndexEntry[];
+}
+
+const FIRST_PUSH_FLAG_KEY_PREFIX = 'markItDown.warehouse.firstPushDone:';
+
+export class WarehouseSync {
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly store: NotesStore,
+    private readonly transport: WarehouseTransport,
+  ) {}
+
+  public async pull(config: WarehouseConfig): Promise<SyncSummary['pulled']> {
+    const clone = await this.transport.ensureClone(config);
+    if (!clone.freshlyCloned) {
+      await this.transport.pull(config, clone);
+    }
+    let added = 0;
+    let updated = 0;
+    let conflicts = 0;
+
+    const scopes: NoteScope[] = this.store.hasWorkspaceStorage()
+      ? ['workspace', 'global']
+      : ['global'];
+
+    for (const scope of scopes) {
+      const remote = await this.readRemoteIndex(config, clone, scope);
+      if (!remote) continue;
+      const localById = new Map(this.store.listByScope(scope).map(n => [n.id, n]));
+      for (const entry of remote.notes) {
+        const local = localById.get(entry.id);
+        if (!local) {
+          const content = await this.readRemoteContent(config, clone, scope, entry.filename);
+          if (content === undefined) continue;
+          await this.store.importNote(toMetadata(entry, scope), content);
+          added++;
+          continue;
+        }
+        const localTime = Date.parse(local.updatedAt);
+        const remoteTime = Date.parse(entry.updatedAt);
+        if (Number.isNaN(remoteTime) || remoteTime <= localTime) {
+          continue;
+        }
+        const lastSync = this.lastSyncedAt(local.id);
+        const localChangedSinceSync = !lastSync || localTime > lastSync;
+        const remoteChangedSinceSync = !lastSync || remoteTime > lastSync;
+        if (localChangedSinceSync && remoteChangedSinceSync && localTime !== remoteTime) {
+          conflicts++;
+          log('warn', `conflict on note ${local.id} (${local.title}); keeping local copy`);
+          continue;
+        }
+        const content = await this.readRemoteContent(config, clone, scope, entry.filename);
+        if (content === undefined) continue;
+        await this.store.importNote(toMetadata(entry, scope), content);
+        updated++;
+      }
+    }
+
+    return { added, updated, conflicts };
+  }
+
+  public async planPush(config: WarehouseConfig): Promise<PushPlan> {
+    const clone = await this.transport.ensureClone(config);
+    const plan: PushPlan = { added: [], updated: [], deleted: [], files: [] };
+    const scopes: NoteScope[] = this.store.hasWorkspaceStorage()
+      ? ['workspace', 'global']
+      : ['global'];
+
+    for (const scope of scopes) {
+      const local = this.store.listByScope(scope);
+      const remote = (await this.readRemoteIndex(config, clone, scope))?.notes ?? [];
+      const remoteById = new Map(remote.map(e => [e.id, e]));
+      const localById = new Map(local.map(n => [n.id, n]));
+
+      for (const note of local) {
+        const r = remoteById.get(note.id);
+        if (!r) {
+          plan.added.push(note);
+        } else if (Date.parse(note.updatedAt) > Date.parse(r.updatedAt)) {
+          plan.updated.push(note);
+        }
+      }
+      for (const r of remote) {
+        if (!localById.has(r.id)) {
+          plan.deleted.push(r);
+        }
+      }
+    }
+
+    plan.files = [
+      ...new Set([
+        ...plan.added.flatMap(n => this.filesForNote(config, n)),
+        ...plan.updated.flatMap(n => this.filesForNote(config, n)),
+        ...plan.deleted.map(e => `${scopeDir(config, e.scope)}/${e.filename}`),
+        ...this.indexFiles(config),
+      ]),
+    ];
+    return plan;
+  }
+
+  public hasPushWork(plan: PushPlan): boolean {
+    return plan.added.length + plan.updated.length + plan.deleted.length > 0;
+  }
+
+  public async push(
+    config: WarehouseConfig,
+    plan: PushPlan,
+    opts: { allowSecrets?: boolean } = {},
+  ): Promise<SyncSummary['pushed']> {
+    const clone = await this.transport.ensureClone(config);
+
+    if (!opts.allowSecrets) {
+      const findings = await this.scanPlan(plan);
+      if (findings.size > 0) {
+        const message = formatSecretFindings(findings);
+        throw new SecretsDetectedError(message, findings);
+      }
+    }
+
+    const scopes: NoteScope[] = this.store.hasWorkspaceStorage()
+      ? ['workspace', 'global']
+      : ['global'];
+
+    for (const scope of scopes) {
+      await this.materializeScope(config, clone, scope);
+    }
+    for (const entry of plan.deleted) {
+      const abs = path.join(clone.root, scopeDir(config, entry.scope), entry.filename);
+      try {
+        await vscode.workspace.fs.delete(vscode.Uri.file(abs));
+      } catch {
+        // already gone — fine
+      }
+    }
+
+    const message = composeCommitMessage(plan, config);
+    const result = await this.transport.commitAndPush(config, clone, plan.files, message);
+    if (!result.committed) {
+      return { added: 0, updated: 0, deleted: 0 };
+    }
+    this.recordSyncedTimestamps([...plan.added, ...plan.updated]);
+    return {
+      added: plan.added.length,
+      updated: plan.updated.length,
+      deleted: plan.deleted.length,
+      commit: result.sha,
+    };
+  }
+
+  public firstPushFlagKey(config: WarehouseConfig): string {
+    return `${FIRST_PUSH_FLAG_KEY_PREFIX}${config.repo}/${config.workspaceId}`;
+  }
+
+  public hasConfirmedFirstPush(config: WarehouseConfig): boolean {
+    return this.context.workspaceState.get<boolean>(this.firstPushFlagKey(config), false);
+  }
+
+  public async markFirstPushConfirmed(config: WarehouseConfig): Promise<void> {
+    await this.context.workspaceState.update(this.firstPushFlagKey(config), true);
+  }
+
+  private async materializeScope(
+    config: WarehouseConfig,
+    clone: WarehouseClone,
+    scope: NoteScope,
+  ): Promise<void> {
+    const dir = path.join(clone.root, scopeDir(config, scope));
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(dir));
+    const notes = this.store.listByScope(scope);
+    for (const note of notes) {
+      const content = await this.store.readContent(note);
+      const target = vscode.Uri.file(path.join(dir, note.filename));
+      await vscode.workspace.fs.writeFile(target, new TextEncoder().encode(content));
+    }
+    const index: WarehouseIndex = {
+      scope,
+      workspaceId: scope === 'global' ? PERSONAL_WORKSPACE_ID : config.workspaceId,
+      generatedAt: new Date().toISOString(),
+      notes: notes.map(toIndexEntry),
+    };
+    const indexUri = vscode.Uri.file(path.join(dir, '_index.json'));
+    await vscode.workspace.fs.writeFile(
+      indexUri,
+      new TextEncoder().encode(JSON.stringify(index, null, 2) + '\n'),
+    );
+  }
+
+  private filesForNote(config: WarehouseConfig, note: NoteMetadata): string[] {
+    const dir = scopeDir(config, note.scope);
+    return [`${dir}/${note.filename}`, `${dir}/_index.json`];
+  }
+
+  private indexFiles(config: WarehouseConfig): string[] {
+    const out: string[] = [`${scopeDir(config, 'global')}/_index.json`];
+    if (this.store.hasWorkspaceStorage()) {
+      out.push(`${scopeDir(config, 'workspace')}/_index.json`);
+    }
+    return out;
+  }
+
+  private async readRemoteIndex(
+    config: WarehouseConfig,
+    clone: WarehouseClone,
+    scope: NoteScope,
+  ): Promise<WarehouseIndex | undefined> {
+    const rel = `${scopeDir(config, scope)}/_index.json`;
+    if (!(await this.transport.fileExists(clone, rel))) {
+      return undefined;
+    }
+    const buf = await vscode.workspace.fs.readFile(vscode.Uri.file(this.transport.absolute(clone, rel)));
+    try {
+      const parsed = JSON.parse(new TextDecoder().decode(buf)) as WarehouseIndex;
+      if (!parsed || !Array.isArray(parsed.notes)) return undefined;
+      return parsed;
+    } catch (err) {
+      log('warn', `failed to parse ${rel}; treating as empty`, err);
+      return undefined;
+    }
+  }
+
+  private async readRemoteContent(
+    config: WarehouseConfig,
+    clone: WarehouseClone,
+    scope: NoteScope,
+    filename: string,
+  ): Promise<string | undefined> {
+    const rel = `${scopeDir(config, scope)}/${filename}`;
+    if (!(await this.transport.fileExists(clone, rel))) {
+      log('warn', `index references missing file ${rel}`);
+      return undefined;
+    }
+    const buf = await vscode.workspace.fs.readFile(vscode.Uri.file(this.transport.absolute(clone, rel)));
+    return new TextDecoder().decode(buf);
+  }
+
+  private async scanPlan(plan: PushPlan): Promise<Map<string, SecretFinding[]>> {
+    const out = new Map<string, SecretFinding[]>();
+    for (const note of [...plan.added, ...plan.updated]) {
+      const content = await this.store.readContent(note);
+      const findings = scanForSecrets(content);
+      if (findings.length > 0) {
+        out.set(`${note.title} (${note.scope}/${note.category})`, findings);
+      }
+    }
+    return out;
+  }
+
+  private lastSyncedAt(noteId: string): number | undefined {
+    const map = this.context.globalState.get<Record<string, number>>(LAST_SYNCED_KEY, {});
+    const v = map[noteId];
+    return typeof v === 'number' ? v : undefined;
+  }
+
+  private recordSyncedTimestamps(notes: NoteMetadata[]): void {
+    const map = { ...(this.context.globalState.get<Record<string, number>>(LAST_SYNCED_KEY, {})) };
+    for (const n of notes) {
+      const t = Date.parse(n.updatedAt);
+      if (!Number.isNaN(t)) {
+        map[n.id] = t;
+      }
+    }
+    void this.context.globalState.update(LAST_SYNCED_KEY, map);
+  }
+}
+
+const LAST_SYNCED_KEY = 'markItDown.warehouse.lastSyncedAt';
+
+export class SecretsDetectedError extends Error {
+  constructor(message: string, public readonly findings: Map<string, SecretFinding[]>) {
+    super(message);
+    this.name = 'SecretsDetectedError';
+  }
+}
+
+function toMetadata(entry: WarehouseIndexEntry, scope: NoteScope): NoteMetadata {
+  return {
+    id: entry.id,
+    title: entry.title,
+    category: entry.category,
+    scope,
+    createdAt: entry.createdAt,
+    updatedAt: entry.updatedAt,
+    filename: entry.filename,
+  };
+}
+
+function toIndexEntry(note: NoteMetadata): WarehouseIndexEntry {
+  return {
+    id: note.id,
+    title: note.title,
+    category: note.category,
+    scope: note.scope,
+    createdAt: note.createdAt,
+    updatedAt: note.updatedAt,
+    filename: note.filename,
+  };
+}
+
+function composeCommitMessage(plan: PushPlan, config: WarehouseConfig): string {
+  const parts: string[] = [];
+  if (plan.added.length) parts.push(`+${plan.added.length} new`);
+  if (plan.updated.length) parts.push(`~${plan.updated.length} updated`);
+  if (plan.deleted.length) parts.push(`-${plan.deleted.length} removed`);
+  const subject = `notes(${config.workspaceId}): ${parts.join(', ') || 'sync'}`;
+  const body = describePlan(plan).join('\n');
+  return body.length > 0 ? `${subject}\n\n${body}\n` : `${subject}\n`;
+}
+
+function describePlan(plan: PushPlan): string[] {
+  const lines: string[] = [];
+  for (const n of plan.added) lines.push(`+ ${n.scope}/${n.category}/${n.title}`);
+  for (const n of plan.updated) lines.push(`~ ${n.scope}/${n.category}/${n.title}`);
+  for (const e of plan.deleted) lines.push(`- ${e.scope}/${e.category}/${e.title}`);
+  return lines;
+}
+
+function formatSecretFindings(map: Map<string, SecretFinding[]>): string {
+  const out: string[] = ['Secrets detected in notes about to be pushed:'];
+  for (const [name, findings] of map) {
+    out.push(`  ${name}:`);
+    for (const f of findings) {
+      out.push(`    line ${f.line} — ${f.description} (${f.preview})`);
+    }
+  }
+  return out.join('\n');
+}

--- a/src/warehouse/warehouseTransport.ts
+++ b/src/warehouse/warehouseTransport.ts
@@ -1,0 +1,184 @@
+import { spawn } from 'child_process';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { repoSlug, repoUrl, WarehouseConfig } from './warehouseConfig';
+import { log } from './warehouseLog';
+
+export interface WarehouseClone {
+  /** Absolute path to the working clone on disk. */
+  root: string;
+  /** True when the working clone was just created in this call. */
+  freshlyCloned: boolean;
+}
+
+export interface RemoteStatus {
+  ahead: number;
+  behind: number;
+  hasDiverged: boolean;
+  workingTreeClean: boolean;
+}
+
+export class WarehouseTransport {
+  private setupGitOnceFor: string | undefined;
+
+  constructor(private readonly extensionStorage: vscode.Uri) {}
+
+  public cloneRoot(config: WarehouseConfig): string {
+    return path.join(this.extensionStorage.fsPath, 'warehouse', repoSlug(config));
+  }
+
+  public async ensureClone(config: WarehouseConfig): Promise<WarehouseClone> {
+    await this.maybeSetupGitForGh(config);
+    const root = this.cloneRoot(config);
+    const exists = await pathExists(root);
+    if (exists) {
+      const isRepo = await pathExists(path.join(root, '.git'));
+      if (isRepo) {
+        return { root, freshlyCloned: false };
+      }
+      throw new Error(`Warehouse cache directory exists but is not a git repo: ${root}`);
+    }
+    await ensureDir(path.dirname(root));
+    log('info', `cloning ${config.repo}@${config.branch} into ${root}`);
+    await runGit(
+      ['clone', '--branch', config.branch, '--single-branch', repoUrl(config), root],
+      undefined,
+    );
+    return { root, freshlyCloned: true };
+  }
+
+  public async pull(config: WarehouseConfig, clone: WarehouseClone): Promise<void> {
+    await this.maybeSetupGitForGh(config);
+    log('info', `pulling ${config.repo}@${config.branch}`);
+    await runGit(['fetch', '--prune', 'origin', config.branch], clone.root);
+    await runGit(['reset', '--hard', `origin/${config.branch}`], clone.root);
+  }
+
+  public async commitAndPush(
+    config: WarehouseConfig,
+    clone: WarehouseClone,
+    files: string[],
+    message: string,
+  ): Promise<{ committed: boolean; sha?: string }> {
+    if (files.length === 0) {
+      return { committed: false };
+    }
+    await this.maybeSetupGitForGh(config);
+    await runGit(['add', '--', ...files], clone.root);
+    const status = await runGit(['status', '--porcelain'], clone.root, { capture: true });
+    if (status.trim().length === 0) {
+      return { committed: false };
+    }
+    await runGit(['commit', '-m', message], clone.root, {
+      env: { GIT_AUTHOR_NAME: 'Mark It Down', GIT_AUTHOR_EMAIL: 'noreply@markitdown.dev' },
+    });
+    const sha = (await runGit(['rev-parse', 'HEAD'], clone.root, { capture: true })).trim();
+    log('info', `pushing commit ${sha.slice(0, 7)} to origin/${config.branch}`);
+    await runGit(['push', 'origin', `HEAD:${config.branch}`], clone.root);
+    return { committed: true, sha };
+  }
+
+  public async status(config: WarehouseConfig, clone: WarehouseClone): Promise<RemoteStatus> {
+    await runGit(['fetch', '--prune', 'origin', config.branch], clone.root);
+    const counts = (
+      await runGit(['rev-list', '--left-right', '--count', `origin/${config.branch}...HEAD`], clone.root, {
+        capture: true,
+      })
+    ).trim();
+    const [behindStr, aheadStr] = counts.split(/\s+/);
+    const behind = Number.parseInt(behindStr ?? '0', 10) || 0;
+    const ahead = Number.parseInt(aheadStr ?? '0', 10) || 0;
+    const tree = (await runGit(['status', '--porcelain'], clone.root, { capture: true })).trim();
+    return {
+      ahead,
+      behind,
+      hasDiverged: ahead > 0 && behind > 0,
+      workingTreeClean: tree.length === 0,
+    };
+  }
+
+  public async fileExists(clone: WarehouseClone, relative: string): Promise<boolean> {
+    return pathExists(path.join(clone.root, relative));
+  }
+
+  public absolute(clone: WarehouseClone, relative: string): string {
+    return path.join(clone.root, relative);
+  }
+
+  private async maybeSetupGitForGh(config: WarehouseConfig): Promise<void> {
+    if (config.transport !== 'gh') return;
+    if (this.setupGitOnceFor === config.repo) return;
+    try {
+      await runProcess('gh', ['auth', 'status'], undefined, { capture: true });
+    } catch {
+      throw new Error(
+        'Warehouse transport "gh" requires the GitHub CLI. Install gh and run `gh auth login`, or switch markItDown.warehouse.transport to "git".',
+      );
+    }
+    try {
+      await runProcess('gh', ['auth', 'setup-git'], undefined, { capture: true });
+      this.setupGitOnceFor = config.repo;
+      log('info', `gh auth setup-git applied for transport=gh`);
+    } catch (err) {
+      log('warn', 'gh auth setup-git failed; falling back to user git credentials', err);
+    }
+  }
+}
+
+interface RunOpts {
+  capture?: boolean;
+  env?: NodeJS.ProcessEnv;
+}
+
+function runGit(args: string[], cwd: string | undefined, opts: RunOpts = {}): Promise<string> {
+  return runProcess('git', args, cwd, opts);
+}
+
+function runProcess(
+  cmd: string,
+  args: string[],
+  cwd: string | undefined,
+  opts: RunOpts = {},
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd,
+      env: { ...process.env, ...(opts.env ?? {}) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', d => {
+      stdout += d.toString();
+    });
+    child.stderr.on('data', d => {
+      stderr += d.toString();
+    });
+    child.on('error', err => reject(err));
+    child.on('close', code => {
+      if (code === 0) {
+        resolve(opts.capture ? stdout : stderr || stdout);
+      } else {
+        const detail = (stderr || stdout || '').trim();
+        reject(new Error(`${cmd} ${args.join(' ')} exited ${code}${detail ? `: ${detail}` : ''}`));
+      }
+    });
+  });
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await vscode.workspace.fs.stat(vscode.Uri.file(p));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureDir(p: string): Promise<void> {
+  try {
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(p));
+  } catch {
+    // already exists
+  }
+}


### PR DESCRIPTION
## Summary
- Configurable GitHub repo as cloud storage for notes (`markItDown.warehouse.repo` = `owner/repo`)
- Pull on activation, debounced auto-push on save (default 5s, 1–60s configurable), manual `Sync Now` / `Pull` commands
- Per-workspace + per-machine subfolders under `<subdir>/<workspace-slug>/`; global notes under `<subdir>/_personal/`
- First-push gate: confirmation modal listing exact file plan before any commit
- Conflict detection (never auto-merges; local copy kept, surfaced in status bar)
- Secret-safety scanner: GitHub PATs / AWS / OpenAI / Anthropic / Slack / Google / PEM / JWT, with redacted previews and "Push anyway" override
- Transport `gh` (uses `gh auth setup-git`) or `git` (plain credentials), 6-state status bar, "Mark It Down: Warehouse" output channel
- Full reference docs at `docs/notes-warehouse.md`

## Closes
Closes #10

## Test plan
- [x] `npm run compile` — clean (tsc strict + esbuild webview)
- [x] 16 commands + 13 settings + 8 warehouse modules emit correctly
- [ ] Manual smoke (deferred — no warehouse repo configured for live test in this CI cycle): create test repo → set `markItDown.warehouse.repo` → verify first-push modal → confirm → check repo contents → edit note → wait 5s → verify auto-push → set up second workspace → verify subfolder isolation

## Linked issue
[#10 — F9: Notes warehouse repo (cloud sync to a configured GitHub repo)](https://github.com/fadymondy/mark-it-down/issues/10)

## Lifecycle
Shipped as a single commit on the feature branch under the new `gh-pms v0.3` branching policy. F6 (#7) finished first to unblock this; F10 (#11) and F13 (#14) are now unblocked.

---
_Opened via `/gh-pms:gh-push` flow during a `/loop` standing-approval session — finishing the v1.0 milestone end-to-end._
