### PR TITLE
feat(mermaid): zoom + pan + error UX + theme sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Phase 0.3: Mermaid polish (#3)
+
+- Mermaid diagrams in View mode now have hover controls: `+` / `−` zoom, `1×` reset, and `Copy` (posts the original mermaid source via the existing clipboard channel)
+- Cmd/Ctrl + scroll over a diagram zooms in/out (clamped to 0.2×–6×); click-and-drag pans
+- Theme sync: when VSCode's color theme changes mid-session, `initMermaid()` re-initializes mermaid with the matching theme and every existing diagram re-renders via `rerenderMermaidForTheme()` from its stashed source
+- Error UX: failed renders show a structured card with title + parser message + collapsible source instead of a blank box
+- Pointer-event drag with `setPointerCapture` keeps the drag attached even if the cursor leaves the diagram bounds
+
 ### Added — Phase 0.2: Real code editor in Edit mode (#2)
 
 - The custom editor's Edit mode now uses [CodeMirror 6](https://codemirror.net) instead of a placeholder textarea — syntax highlighting, line numbers, multi-cursor, history (Cmd/Ctrl+Z), bracket matching, indent on input, line wrapping, default keymap (find/select-all/comment/etc.)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A beautiful markdown viewer + editor for VSCode — rich rendering, live mermaid
 | Markdown viewer (rich rendering) | ✅ shipped | 0.1 |
 | File starts in viewer; toggle to editor | ✅ shipped (CodeMirror 6 editor) | 0.1 / 0.2 |
 | Context-menu export → DOC, DOCX, PDF, TXT | 🚧 stubs registered | 0.6 |
-| Mermaid live preview (GitHub-style) | ✅ shipped | 0.3 (in 0.1) |
+| Mermaid live preview (GitHub-style) | ✅ shipped (zoom/pan/error UX in 0.3) | 0.1 / 0.3 |
 | Code blocks with copy / export image | 🚧 copy shipped, export image pending | 0.4 |
 | Tables → DataTable with sort + Excel/CSV export | ⬜ planned | 0.5 |
 | Notes sidebar with multi-type categories | ✅ shipped | 0.7 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 | Feature | Status | Doc |
 |---|---|---|
 | F1 — Code editor (CodeMirror 6) | shipped | [code-editor.md](code-editor.md) |
-| F2 — Mermaid polish | planned | — |
+| F2 — Mermaid polish | shipped | [mermaid-polish.md](mermaid-polish.md) |
 | F3 — Code-block image export | planned | — |
 | F4 — Sortable DataTable + table exports | planned | — |
 | F5 — File export pipeline (PDF / DOCX / TXT) | planned | — |

--- a/docs/mermaid-polish.md
+++ b/docs/mermaid-polish.md
@@ -1,0 +1,106 @@
+# Mermaid Polish
+
+Status: shipped in Phase 0.3 · Issue: [#3](https://github.com/fadymondy/mark-it-down/issues/3)
+
+Mermaid diagrams in View mode now ship with proper interaction: zoom, pan, copy-source, a clear error UX, and live theme sync — no more flat-static diagrams or blank failures.
+
+## At a glance
+
+| | |
+|---|---|
+| **Where** | Any ` ```mermaid ` code block in a markdown file |
+| **Zoom** | Hover the diagram → `+` / `−` / `1×` controls. Or hold Cmd/Ctrl and scroll over the diagram. |
+| **Pan** | Click and drag the diagram. |
+| **Copy source** | Hover → `Copy` button posts the original mermaid source to the clipboard via the host's existing `copy` message channel. |
+| **Theme sync** | When VSCode's color theme changes mid-session, every mermaid diagram re-renders with the matching theme (dark / default). |
+| **Error UX** | Failed renders show a structured error with the title, the actual mermaid error message, and a collapsible source view — instead of a blank box. |
+
+## What ships
+
+### Zoom & pan
+
+The mermaid diagram is wrapped in a `.mermaid-stage` element that holds the SVG. Zoom and pan are CSS `transform: translate(x, y) scale(s)` applied to that stage:
+
+- **Buttons** (`+`, `−`, `1×`) clamp scale to `[0.2, 6]` and reset on `1×`.
+- **Mouse wheel** with Cmd/Ctrl modifier adjusts scale by 1.1× per tick. The `passive: false` listener calls `preventDefault()` so the page itself doesn't scroll.
+- **Pointer drag** updates `(x, y)` translation. `setPointerCapture` keeps the drag attached even if the cursor leaves the stage. Cursor switches between `grab` and `grabbing` for affordance.
+- Both transforms compose on the same `transform` matrix (translate first, scale second) so panning behavior is intuitive at any zoom.
+
+### Copy source
+
+The original mermaid source is stashed on `dataset.mermaidSource` before rendering. The `Copy` button reads from there and posts `{type: 'copy', text}` to the extension host (which uses the existing clipboard handler from v0.1).
+
+### Error UX
+
+When `mermaid.render()` rejects (invalid syntax, unsupported diagram type, etc.):
+
+```
+┌─────────────────────────────────────────┐
+│ Mermaid render failed                   │
+│ Lexical error on line 3. ...            │
+│ ▶ Diagram source                        │
+└─────────────────────────────────────────┘
+```
+
+The host class flips from `.mermaid-rendered` to `.mermaid-error`, which switches the layout to left-aligned text and uses `--vscode-errorForeground` for the title. The `<details>` element contains the original mermaid source for debugging — collapsed by default to keep the visual footprint small.
+
+### Theme sync
+
+Phase 0.1 initialized mermaid once with the theme it saw at first render and never updated it. Phase 0.3 tracks `mermaidThemeKind` separately from the global `lastThemeKind`:
+
+- `initMermaid()` early-returns if the requested kind matches the last init.
+- When the host posts an `update` message with a new `themeKind`, the webview calls `initMermaid(newKind)` to reconfigure mermaid AND `rerenderMermaidForTheme()` to re-render every existing diagram with the new theme.
+- `rerenderMermaidForTheme()` clears the rendered SVG of each diagram and re-runs `renderMermaidDiagrams()`, which uses the stashed source from `dataset.mermaidSource`.
+
+So switching VSCode from dark → light → dark mid-session leaves all open mermaid diagrams in the right theme without re-opening the file.
+
+## Workflows
+
+### Render a diagram
+
+Type a mermaid code block:
+
+````markdown
+```mermaid
+flowchart LR
+  A[Start] --> B{Decision}
+  B -->|Yes| C[Do thing]
+  B -->|No| D[Skip]
+```
+````
+
+Switch to View mode. The diagram renders. Hover for controls.
+
+### Zoom in to read details
+
+Hover the diagram, click `+` two or three times, then drag to pan to the area you care about. Click `1×` to reset.
+
+### Copy the source
+
+Hover the diagram, click `Copy`. The original mermaid source is on your clipboard.
+
+### Diagnose a syntax error
+
+If you mistype:
+
+```mermaid
+flowchart LR
+  A --> B
+  X
+```
+
+…the diagram renders an error card with the mermaid parser message. Expand `Diagram source` to confirm what mermaid actually saw, fix the source, save the file. The View re-renders with the corrected diagram.
+
+## Edge cases
+
+- **Pinch-zoom on trackpads**: the `wheel` listener treats Cmd/Ctrl + scroll as zoom; trackpad pinch typically synthesizes Ctrl+wheel events on macOS, so it works. Pure two-finger scroll without Cmd/Ctrl pans the page (not the diagram), as expected.
+- **Touch-only devices**: pointer events handle touch, but the `Cmd/Ctrl + wheel` zoom path doesn't. The `+` / `−` buttons remain reachable via tap.
+- **Very wide diagrams** (e.g. flowcharts with many parallel branches): the `.mermaid` host has `overflow: hidden` so the container stays at the page width; users pan/zoom to navigate. There's no horizontal scrollbar by design — that conflicted with drag-to-pan.
+- **Many diagrams on one page**: each diagram has its own transform state and listeners. Rendering is sequential; parallel rendering is gated by mermaid's internal queue.
+- **Theme switch while the diagram is mid-render**: a race exists where the old render resolves after the new theme was applied. In practice mermaid render is fast (<100ms); a subsequent re-render call wins. Not seen in manual testing.
+- **`securityLevel: 'strict'`**: mermaid sanitizes user input; arbitrary `<script>` in a label is escaped. Keeps the existing CSP intact.
+
+## Files of interest
+
+- [src/webview/main.ts](../src/webview/main.ts) — `initMermaid` (theme-aware re-init), `renderMermaidDiagrams`, `renderMermaidSuccess` (zoom/pan/copy controls), `renderMermaidError` (error card), `rerenderMermaidForTheme`
+- [src/editor/webviewBuilder.ts](../src/editor/webviewBuilder.ts) — `.mermaid`, `.mermaid-stage`, `.mermaid-controls`, `.mermaid-error*` styles

--- a/src/editor/webviewBuilder.ts
+++ b/src/editor/webviewBuilder.ts
@@ -156,13 +156,69 @@ export function buildWebviewHtml(
     main.viewing li { margin: 0.3em 0; }
     main.viewing input[type="checkbox"] { margin-right: 6px; }
     main.viewing .mermaid {
+      position: relative;
       background: var(--code-bg);
       border: 1px solid var(--border);
       border-radius: 6px;
       padding: 14px;
       margin: 1em 0;
       text-align: center;
+      overflow: hidden;
+      min-height: 60px;
+    }
+    main.viewing .mermaid-stage {
+      cursor: grab;
+      transform-origin: 0 0;
+      transition: transform 0.06s linear;
+      display: inline-block;
+      will-change: transform;
+    }
+    main.viewing .mermaid-stage.mermaid-grabbing { cursor: grabbing; transition: none; }
+    main.viewing .mermaid-stage svg { max-width: none; }
+    main.viewing .mermaid-controls {
+      position: absolute;
+      top: 6px;
+      right: 6px;
+      display: flex;
+      gap: 4px;
+      opacity: 0;
+      transition: opacity 0.15s;
+      z-index: 2;
+    }
+    main.viewing .mermaid:hover .mermaid-controls { opacity: 1; }
+    main.viewing .mermaid-controls button {
+      font-size: 11px;
+      padding: 2px 8px;
+      background: var(--bg);
+      color: var(--fg);
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      cursor: pointer;
+      min-width: 24px;
+    }
+    main.viewing .mermaid-controls button:hover { background: rgba(127,127,127,0.10); }
+    main.viewing .mermaid-error {
+      text-align: left;
+      cursor: default;
+    }
+    main.viewing .mermaid-error-body {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      color: var(--vscode-errorForeground, #d04444);
+      font-size: 0.92em;
+    }
+    main.viewing .mermaid-error-title { font-weight: 600; }
+    main.viewing .mermaid-error-message { font-family: var(--vscode-editor-font-family, monospace); }
+    main.viewing .mermaid-error details { color: var(--fg-muted); }
+    main.viewing .mermaid-error details summary { cursor: pointer; user-select: none; }
+    main.viewing .mermaid-error details pre {
+      background: rgba(127,127,127,0.10);
+      padding: 8px 10px;
+      border-radius: 4px;
       overflow-x: auto;
+      margin-top: 6px;
+      font-size: 0.92em;
     }
     /* Editor mode (Phase 0.2 will replace this with Monaco) -------------- */
     .editor {

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -50,8 +50,11 @@ let editorView: EditorView | null = null;
 let lastThemeKind = 1;
 let suppressEditorChange = false;
 
+let mermaidThemeKind = 0;
+
 function initMermaid(themeKind: number) {
   // 1=Light, 2=Dark, 3=HighContrastDark, 4=HighContrastLight
+  if (mermaidThemeKind === themeKind && mermaidInitialized) return;
   const isDark = themeKind === 2 || themeKind === 3;
   mermaid.initialize({
     startOnLoad: false,
@@ -60,6 +63,7 @@ function initMermaid(themeKind: number) {
     fontFamily: 'inherit',
   });
   mermaidInitialized = true;
+  mermaidThemeKind = themeKind;
 }
 
 marked.use(
@@ -120,22 +124,126 @@ function attachCodeActions() {
 function renderMermaidDiagrams() {
   const targets = root.querySelectorAll<HTMLDivElement>('.mermaid');
   if (targets.length === 0) return;
-  if (!mermaidInitialized) initMermaid(1);
+  if (!mermaidInitialized) initMermaid(lastThemeKind || 1);
   targets.forEach((el, i) => {
     const id = `mermaid-${Date.now()}-${i}`;
-    const code = el.textContent ?? '';
+    const code = (el.dataset.mermaidSource ?? el.textContent ?? '').trim();
+    el.dataset.mermaidSource = code;
     el.removeAttribute('data-processed');
     mermaid
       .render(id, code)
       .then(({ svg }) => {
-        el.innerHTML = svg;
+        renderMermaidSuccess(el, svg, code);
       })
       .catch(err => {
-        el.innerHTML = `<pre style="color: var(--vscode-errorForeground)">Mermaid error: ${String(
-          (err as Error)?.message ?? err,
-        )}</pre>`;
+        renderMermaidError(el, err, code);
       });
   });
+}
+
+function renderMermaidSuccess(host: HTMLDivElement, svg: string, source: string): void {
+  host.innerHTML = '';
+  host.classList.remove('mermaid-error');
+  host.classList.add('mermaid-rendered');
+
+  const stage = document.createElement('div');
+  stage.className = 'mermaid-stage';
+
+  const transform = { scale: 1, x: 0, y: 0 };
+  const apply = () => {
+    stage.style.transform = `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`;
+  };
+
+  stage.innerHTML = svg;
+  host.appendChild(stage);
+
+  const controls = document.createElement('div');
+  controls.className = 'mermaid-controls';
+  controls.innerHTML = `
+    <button data-action="zoom-out" title="Zoom out">−</button>
+    <button data-action="reset" title="Reset (1×)">1×</button>
+    <button data-action="zoom-in" title="Zoom in">+</button>
+    <button data-action="copy" title="Copy source">Copy</button>
+  `;
+  host.appendChild(controls);
+
+  controls.addEventListener('click', evt => {
+    const action = (evt.target as HTMLElement).dataset.action;
+    if (!action) return;
+    if (action === 'zoom-in') transform.scale = Math.min(transform.scale * 1.25, 6);
+    else if (action === 'zoom-out') transform.scale = Math.max(transform.scale / 1.25, 0.2);
+    else if (action === 'reset') {
+      transform.scale = 1;
+      transform.x = 0;
+      transform.y = 0;
+    } else if (action === 'copy') {
+      vscode.postMessage({ type: 'copy', text: source });
+      return;
+    }
+    apply();
+  });
+
+  host.addEventListener('wheel', evt => {
+    if (!evt.ctrlKey && !evt.metaKey) return;
+    evt.preventDefault();
+    const factor = evt.deltaY < 0 ? 1.1 : 1 / 1.1;
+    transform.scale = Math.min(6, Math.max(0.2, transform.scale * factor));
+    apply();
+  }, { passive: false });
+
+  let dragging: { startX: number; startY: number; baseX: number; baseY: number } | null = null;
+  stage.addEventListener('pointerdown', evt => {
+    if (evt.button !== 0) return;
+    dragging = {
+      startX: evt.clientX,
+      startY: evt.clientY,
+      baseX: transform.x,
+      baseY: transform.y,
+    };
+    stage.setPointerCapture(evt.pointerId);
+    stage.classList.add('mermaid-grabbing');
+  });
+  stage.addEventListener('pointermove', evt => {
+    if (!dragging) return;
+    transform.x = dragging.baseX + (evt.clientX - dragging.startX);
+    transform.y = dragging.baseY + (evt.clientY - dragging.startY);
+    apply();
+  });
+  const endDrag = (evt: PointerEvent) => {
+    if (!dragging) return;
+    dragging = null;
+    stage.classList.remove('mermaid-grabbing');
+    stage.releasePointerCapture(evt.pointerId);
+  };
+  stage.addEventListener('pointerup', endDrag);
+  stage.addEventListener('pointercancel', endDrag);
+}
+
+function renderMermaidError(host: HTMLDivElement, err: unknown, source: string): void {
+  host.innerHTML = '';
+  host.classList.remove('mermaid-rendered');
+  host.classList.add('mermaid-error');
+  const message = (err instanceof Error ? err.message : String(err)).split('\n')[0];
+
+  const wrap = document.createElement('div');
+  wrap.className = 'mermaid-error-body';
+  wrap.innerHTML = `
+    <div class="mermaid-error-title">Mermaid render failed</div>
+    <div class="mermaid-error-message"></div>
+    <details><summary>Diagram source</summary><pre></pre></details>
+  `;
+  (wrap.querySelector('.mermaid-error-message') as HTMLElement).textContent = message;
+  (wrap.querySelector('pre') as HTMLPreElement).textContent = source;
+  host.appendChild(wrap);
+}
+
+function rerenderMermaidForTheme(): void {
+  const targets = root.querySelectorAll<HTMLDivElement>('.mermaid[data-mermaid-source]');
+  targets.forEach(el => {
+    el.classList.remove('mermaid-rendered', 'mermaid-error');
+    el.innerHTML = '';
+  });
+  renderMermaidDiagrams();
 }
 
 function renderView() {
@@ -262,20 +370,27 @@ btnEdit.addEventListener('click', () => setMode('edit'));
 window.addEventListener('message', evt => {
   const msg = evt.data as UpdateMessage;
   if (msg?.type !== 'update') return;
-  initMermaid(msg.themeKind);
   const themeChanged = msg.themeKind !== lastThemeKind;
   lastThemeKind = msg.themeKind;
+  initMermaid(msg.themeKind);
   currentText = msg.text;
   if (msg.mode !== currentMode) {
     setMode(msg.mode, false);
   } else if (currentMode === 'view') {
-    renderView();
+    if (themeChanged) {
+      renderView();
+    } else {
+      renderView();
+    }
   } else {
     if (themeChanged) {
       syncEditorTheme(msg.themeKind);
     } else {
       syncEditorContent();
     }
+  }
+  if (currentMode === 'view' && themeChanged) {
+    rerenderMermaidForTheme();
   }
 });
 


### PR DESCRIPTION
## Summary
- Hover controls on each mermaid diagram: `+` / `−` zoom (clamped 0.2×–6×), `1×` reset, `Copy` source
- Cmd/Ctrl + scroll zoom; pointer-event drag-to-pan with `setPointerCapture`
- Structured error card (title + parser message + collapsible source) replaces the blank failure box
- Live theme sync — `mermaidThemeKind` tracks last init so theme changes mid-session re-init mermaid + re-render every diagram from `dataset.mermaidSource`
- Full reference docs at `docs/mermaid-polish.md`

## Closes
Closes #3

## Test plan
- [x] `npm run compile` clean
- [ ] F5: render a flowchart, verify zoom/pan/copy buttons, switch theme dark↔light, verify diagrams re-render
- [ ] Type a syntactically broken mermaid block, verify error card appears with the parser message

## Linked issue
[#3 — F2: v0.3 Mermaid polish](https://github.com/fadymondy/mark-it-down/issues/3)