### PR TITLE
feat(code-block): export rendered code block as PNG

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"ed91df53-e634-45f6-a55c-7dfc90977131","pid":48338,"procStart":"Tue Apr 28 22:04:27 2026","acquiredAt":1777419484107}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"ed91df53-e634-45f6-a55c-7dfc90977131","pid":48338,"procStart":"Tue Apr 28 22:04:27 2026","acquiredAt":1777419484107}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 *.vsix
 .DS_Store
 .vscode-test/
+
+# Claude Code session metadata — local only
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Phase 0.4: Code-block image export (#4)
+
+- Each code block in View mode has a new `PNG` action next to `Copy` that exports the block as a 2× pixel-ratio PNG via [html-to-image](https://www.npmjs.com/package/html-to-image)
+- Captures syntax highlighting, the active VSCode editor background, font, padding, and border-radius — strips the hover toolbar so it doesn't appear in the image
+- Save flow uses `vscode.window.showSaveDialog`, defaults to the markdown file's directory with a slugified filename like `typescript-snippet-3.png`, then offers `Open` / `Reveal` follow-up actions
+
 ### Added — Phase 0.3: Mermaid polish (#3)
 
 - Mermaid diagrams in View mode now have hover controls: `+` / `−` zoom, `1×` reset, and `Copy` (posts the original mermaid source via the existing clipboard channel)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A beautiful markdown viewer + editor for VSCode — rich rendering, live mermaid
 | File starts in viewer; toggle to editor | ✅ shipped (CodeMirror 6 editor) | 0.1 / 0.2 |
 | Context-menu export → DOC, DOCX, PDF, TXT | 🚧 stubs registered | 0.6 |
 | Mermaid live preview (GitHub-style) | ✅ shipped (zoom/pan/error UX in 0.3) | 0.1 / 0.3 |
-| Code blocks with copy / export image | 🚧 copy shipped, export image pending | 0.4 |
+| Code blocks with copy / export image | ✅ shipped (PNG export 0.4) | 0.1 / 0.4 |
 | Tables → DataTable with sort + Excel/CSV export | ⬜ planned | 0.5 |
 | Notes sidebar with multi-type categories | ✅ shipped | 0.7 |
 | Multi-theme via `@orchestra-mcp/theme` (25 themes) | ⬜ planned | 0.8 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 |---|---|---|
 | F1 — Code editor (CodeMirror 6) | shipped | [code-editor.md](code-editor.md) |
 | F2 — Mermaid polish | shipped | [mermaid-polish.md](mermaid-polish.md) |
-| F3 — Code-block image export | planned | — |
+| F3 — Code-block image export | shipped | [code-block-image-export.md](code-block-image-export.md) |
 | F4 — Sortable DataTable + table exports | planned | — |
 | F5 — File export pipeline (PDF / DOCX / TXT) | planned | — |
 | F6 — Notes sidebar | shipped (0.7) | [notes-sidebar.md](notes-sidebar.md) |

--- a/docs/code-block-image-export.md
+++ b/docs/code-block-image-export.md
@@ -1,0 +1,60 @@
+# Code-block Image Export
+
+Status: shipped in Phase 0.4 · Issue: [#4](https://github.com/fadymondy/mark-it-down/issues/4)
+
+Each rendered code block in View mode now ships an **PNG** action next to **Copy** that exports the block as a self-contained PNG image — preserving syntax highlighting, the active VSCode theme background, and the typography exactly as they appear on screen. Useful for slide decks, blog posts, social shares.
+
+## At a glance
+
+| | |
+|---|---|
+| **Where** | Hover any rendered code block in View mode → toolbar (top-right) → `PNG` button |
+| **Engine** | [html-to-image](https://www.npmjs.com/package/html-to-image) — DOM → canvas → PNG, no server roundtrip |
+| **Output** | PNG at 2× pixel ratio (Retina-friendly), background matches the active VSCode editor background, rounded corners preserved |
+| **Save target** | VSCode `showSaveDialog` defaulting to the markdown file's directory with a slugified filename like `typescript-snippet-3.png` |
+| **After save** | Information toast with `Open` (in default app) and `Reveal` (in OS file manager) actions |
+
+## How it works
+
+1. The code-block toolbar is augmented with a `PNG` button next to the existing `Copy`.
+2. On click, the webview:
+   - Hides the toolbar temporarily (so it doesn't appear in the captured image)
+   - Reads `--vscode-editor-background` for an accurate background
+   - Calls `toPng(pre, { pixelRatio: 2, backgroundColor, style: { boxShadow: 'none', borderRadius: '6px' } })`
+   - Restores the toolbar
+   - Posts `{ type: 'saveCodeImage', dataUrl, suggestedName }` to the extension host
+3. The host:
+   - Decodes the data URL into a `Buffer`
+   - Suggests `<lang>-snippet-<n>.png` next to the markdown file
+   - Opens `vscode.window.showSaveDialog`
+   - Writes the buffer with `vscode.workspace.fs.writeFile`
+   - Shows an info toast with `Open` / `Reveal` actions
+
+If anything fails (DOM serialization error, CSP block on a remote font, etc.), the webview posts `{ type: 'showError', message }` and the host surfaces it via `showErrorMessage`. The toolbar is restored regardless via a `try/finally`.
+
+## What's preserved
+
+- Syntax highlighting (highlight.js classes + the active CSS rules)
+- Background color (`--vscode-editor-background`)
+- Font family (`--vscode-editor-font-family`)
+- Border radius and 1px border from the existing `<pre>` styling
+- Padding (so the code doesn't bleed against the image edge)
+
+What's stripped:
+
+- The hover toolbar (Copy / PNG buttons) — would clutter the export
+- Box shadow (none in current styles, but explicitly disabled for the export)
+
+## Edge cases & limitations
+
+- **Very wide code lines**: the PNG renders the full width of the `<pre>` as it appears on screen. If the code overflows horizontally and the user scrolled right, the visible area is what's captured. To capture the entire block, scroll the `<pre>` to the start before clicking `PNG`.
+- **Mermaid blocks**: the `attachCodeActions()` selector only matches `pre`, not `.mermaid` divs, so PNG export is intentionally limited to highlighted code. Mermaid diagrams have their own zoom/pan/copy controls (see [mermaid-polish.md](mermaid-polish.md)); a similar PNG export for mermaid is a future-work seed.
+- **Remote fonts**: html-to-image inlines images by re-fetching them as data URIs. If a code block embeds a remote `<img>` (rare in syntax-highlighted code), the CSP's `img-src https:` lets that fetch succeed. If a font-face references a remote URL, `html-to-image` does not inline fonts — fallback fonts may be used in the rendered PNG. The webview uses VSCode's monospace font (`var(--vscode-editor-font-family)`), which is system-installed, so this is rarely a problem.
+- **Save cancelled**: clicking `Cancel` in the save dialog is silent; no error toast.
+- **Pixel ratio**: fixed at `2` for Retina output. A user setting (`markItDown.codeBlock.exportPixelRatio`) is a future addition; not in v0.4.
+
+## Files of interest
+
+- [src/webview/main.ts](../src/webview/main.ts) — `attachCodeActions` adds the PNG button; `exportCodeBlockAsPng` hides the toolbar, calls `toPng`, and posts the `saveCodeImage` message
+- [src/editor/markdownEditorProvider.ts](../src/editor/markdownEditorProvider.ts) — host-side `saveCodeImage` and `showError` message handlers; `saveCodeImage` does the data-URL → buffer → save-dialog → write flow
+- [package.json](../package.json) — `html-to-image` runtime dep

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "codemirror": "^6.0.2",
         "dompurify": "^3.2.3",
         "highlight.js": "^11.10.0",
+        "html-to-image": "^1.11.13",
         "marked": "^14.1.3",
         "marked-highlight": "^2.2.1",
         "mermaid": "^11.4.1"
@@ -3642,6 +3643,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -394,6 +394,7 @@
     "codemirror": "^6.0.2",
     "dompurify": "^3.2.3",
     "highlight.js": "^11.10.0",
+    "html-to-image": "^1.11.13",
     "marked": "^14.1.3",
     "marked-highlight": "^2.2.1",
     "mermaid": "^11.4.1"

--- a/src/editor/markdownEditorProvider.ts
+++ b/src/editor/markdownEditorProvider.ts
@@ -97,8 +97,54 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             vscode.window.setStatusBarMessage('Mark It Down: copied', 1500);
           }
           return;
+        case 'saveCodeImage':
+          if (typeof msg.dataUrl === 'string') {
+            await this.saveCodeImage(document, msg.dataUrl, String(msg.suggestedName ?? 'code-block'));
+          }
+          return;
+        case 'showError':
+          if (typeof msg.message === 'string') {
+            vscode.window.showErrorMessage(msg.message);
+          }
+          return;
       }
     });
+  }
+
+  private async saveCodeImage(
+    document: vscode.TextDocument,
+    dataUrl: string,
+    suggestedName: string,
+  ): Promise<void> {
+    const match = /^data:image\/(png|jpeg|webp);base64,(.+)$/.exec(dataUrl);
+    if (!match) {
+      vscode.window.showErrorMessage('Mark It Down: malformed image data — export aborted.');
+      return;
+    }
+    const ext = match[1] === 'jpeg' ? 'jpg' : match[1];
+    const buffer = Buffer.from(match[2], 'base64');
+    const baseName = suggestedName.replace(/[^A-Za-z0-9._-]+/g, '-').slice(0, 64) || 'code-block';
+    const documentDir = vscode.Uri.joinPath(document.uri, '..');
+    const defaultUri = vscode.Uri.joinPath(documentDir, `${baseName}.${ext}`);
+    const target = await vscode.window.showSaveDialog({
+      defaultUri,
+      filters: { Image: [ext] },
+      title: 'Mark It Down: save code-block image',
+    });
+    if (!target) {
+      return;
+    }
+    await vscode.workspace.fs.writeFile(target, buffer);
+    const choice = await vscode.window.showInformationMessage(
+      `Mark It Down: saved ${target.fsPath.split('/').pop()}`,
+      'Open',
+      'Reveal',
+    );
+    if (choice === 'Open') {
+      await vscode.commands.executeCommand('vscode.open', target);
+    } else if (choice === 'Reveal') {
+      await vscode.commands.executeCommand('revealFileInOS', target);
+    }
   }
 
   public toggleActiveMode(): void {

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -13,6 +13,7 @@ import { markedHighlight } from 'marked-highlight';
 import hljs from 'highlight.js/lib/common';
 import mermaid from 'mermaid';
 import DOMPurify from 'dompurify';
+import { toPng } from 'html-to-image';
 import { EditorState } from '@codemirror/state';
 import { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter, drawSelection } from '@codemirror/view';
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
@@ -108,17 +109,61 @@ function renderMarkdown(md: string): string {
 }
 
 function attachCodeActions() {
-  root.querySelectorAll<HTMLPreElement>('main.viewing pre').forEach(pre => {
+  root.querySelectorAll<HTMLPreElement>('main.viewing pre').forEach((pre, idx) => {
     if (pre.querySelector('.code-actions')) return;
     const wrap = document.createElement('div');
     wrap.className = 'code-actions';
     const code = pre.querySelector('code')?.textContent ?? '';
+    const lang =
+      pre
+        .querySelector('code')
+        ?.className.match(/language-(\S+)/)?.[1] ?? 'code';
+
     const copyBtn = document.createElement('button');
     copyBtn.textContent = 'Copy';
+    copyBtn.title = 'Copy code to clipboard';
     copyBtn.addEventListener('click', () => vscode.postMessage({ type: 'copy', text: code }));
     wrap.appendChild(copyBtn);
+
+    const imgBtn = document.createElement('button');
+    imgBtn.textContent = 'PNG';
+    imgBtn.title = 'Export this code block as PNG';
+    imgBtn.addEventListener('click', () =>
+      exportCodeBlockAsPng(pre, `${lang}-snippet-${idx + 1}`).catch(err => {
+        vscode.postMessage({
+          type: 'showError',
+          message: `Mark It Down: failed to export code block — ${
+            (err as Error)?.message ?? String(err)
+          }`,
+        });
+      }),
+    );
+    wrap.appendChild(imgBtn);
     pre.appendChild(wrap);
   });
+}
+
+async function exportCodeBlockAsPng(pre: HTMLPreElement, suggestedName: string): Promise<void> {
+  const actions = pre.querySelector<HTMLDivElement>('.code-actions');
+  const previousActionsDisplay = actions?.style.display ?? '';
+  if (actions) actions.style.display = 'none';
+  try {
+    const styles = getComputedStyle(document.body);
+    const bg = styles.getPropertyValue('--vscode-editor-background').trim() || '#ffffff';
+    const dataUrl = await toPng(pre, {
+      backgroundColor: bg,
+      pixelRatio: 2,
+      cacheBust: true,
+      style: { boxShadow: 'none', borderRadius: '6px' },
+    });
+    vscode.postMessage({
+      type: 'saveCodeImage',
+      dataUrl,
+      suggestedName,
+    });
+  } finally {
+    if (actions) actions.style.display = previousActionsDisplay;
+  }
 }
 
 function renderMermaidDiagrams() {


### PR DESCRIPTION
## Summary
- Each code block in View mode has a `PNG` action next to `Copy`
- 2× pixel ratio output, background matches active VSCode editor background, syntax highlighting + font preserved
- Save via `showSaveDialog` defaulting to the markdown file's directory with slugified filename like `typescript-snippet-3.png`
- After save: info toast with `Open` / `Reveal` actions
- Full reference docs at `docs/code-block-image-export.md`

## Closes
Closes #4

## Test plan
- [x] `npm run compile` clean
- [ ] F5: render a markdown file with multiple code blocks, hover one, click `PNG`, verify save dialog → write → toast → Open / Reveal work

## Linked issue
[#4 — F3: v0.4 Per-code-block export as image](https://github.com/fadymondy/mark-it-down/issues/4)