### PR TITLE
feat(table): sortable headers + per-table CSV/TSV/Excel export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Phase 0.5: Sortable tables + per-table export (#5)
+
+- Markdown tables in View mode are now sortable — click any column header to cycle asc → desc → none (original markdown order)
+- Mixed-type-aware comparison: numeric strings (with `$`, `,`, `%` strip), then `localeCompare` with numeric-aware sensitivity for everything else
+- Per-table toolbar above each table with **CSV** / **TSV** / **Excel** export buttons
+- CSV/TSV serialization is RFC-4180 compliant (quote on separator/quote/newline, escape embedded `"` by doubling). Exports respect the **current** sort order in the DOM.
+- Excel export uses [SheetJS](https://www.npmjs.com/package/xlsx) (`aoa_to_sheet` → `XLSX.write({ type: 'base64' })`) — bundled webview grew 8.1MB → 8.7MB
+- Save flow: `vscode.window.showSaveDialog` → write via host → info toast with `Open` / `Reveal` actions
+
 ### Added — Phase 0.4: Code-block image export (#4)
 
 - Each code block in View mode has a new `PNG` action next to `Copy` that exports the block as a 2× pixel-ratio PNG via [html-to-image](https://www.npmjs.com/package/html-to-image)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A beautiful markdown viewer + editor for VSCode — rich rendering, live mermaid
 | Context-menu export → DOC, DOCX, PDF, TXT | 🚧 stubs registered | 0.6 |
 | Mermaid live preview (GitHub-style) | ✅ shipped (zoom/pan/error UX in 0.3) | 0.1 / 0.3 |
 | Code blocks with copy / export image | ✅ shipped (PNG export 0.4) | 0.1 / 0.4 |
-| Tables → DataTable with sort + Excel/CSV export | ⬜ planned | 0.5 |
+| Tables → DataTable with sort + Excel/CSV export | ✅ shipped | 0.5 |
 | Notes sidebar with multi-type categories | ✅ shipped | 0.7 |
 | Multi-theme via `@orchestra-mcp/theme` (25 themes) | ⬜ planned | 0.8 |
 | MCP server for Claude Desktop / Code | ⬜ planned | 0.9 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 | F1 — Code editor (CodeMirror 6) | shipped | [code-editor.md](code-editor.md) |
 | F2 — Mermaid polish | shipped | [mermaid-polish.md](mermaid-polish.md) |
 | F3 — Code-block image export | shipped | [code-block-image-export.md](code-block-image-export.md) |
-| F4 — Sortable DataTable + table exports | planned | — |
+| F4 — Sortable DataTable + table exports | shipped | [datatable.md](datatable.md) |
 | F5 — File export pipeline (PDF / DOCX / TXT) | planned | — |
 | F6 — Notes sidebar | shipped (0.7) | [notes-sidebar.md](notes-sidebar.md) |
 | F7 — 25-theme bridge | planned | — |

--- a/docs/datatable.md
+++ b/docs/datatable.md
@@ -1,0 +1,83 @@
+# Sortable Tables + Per-Table Export
+
+Status: shipped in Phase 0.5 · Issue: [#5](https://github.com/fadymondy/mark-it-down/issues/5)
+
+Markdown tables in View mode are now sortable (click any column header) and ship a per-table export toolbar with **CSV**, **TSV**, and **Excel (.xlsx)** outputs. No new framework dep — sort + serialization are hand-rolled; xlsx uses [SheetJS](https://www.npmjs.com/package/xlsx) for the binary workbook format.
+
+## At a glance
+
+| | |
+|---|---|
+| **Where** | Any markdown table in View mode |
+| **Sort** | Click a column header → asc → desc → none (original order) |
+| **Numeric vs string** | Both columns are detected per-cell; mixed columns fall back to localeCompare with numeric-aware sensitivity |
+| **Export formats** | CSV, TSV, Excel (.xlsx) — buttons in a toolbar above each table |
+| **Save** | `vscode.window.showSaveDialog` defaulting to the markdown file's directory; info toast with `Open` / `Reveal` follow-ups |
+
+## What ships
+
+### Sortable headers
+
+Every `<th>` gets a click handler that cycles its data-sort attribute through `none → asc → desc → none`. The first sort stamps `data-mid-original` on each row so the "none" state can restore the original markdown order.
+
+Comparison strategy:
+
+```
+parseFinite(value)  →  strips commas, $, %; tries Number()
+both numeric?       →  numeric subtract
+otherwise           →  localeCompare with { numeric: true, sensitivity: 'base' }
+```
+
+This handles "$1,200" vs "$300" correctly, sorts "2025-04-29" alphabetically (which is also chronologically correct for ISO dates), and falls back gracefully on free-form text.
+
+Indicator glyphs in the header:
+
+- ` ⇅` — unsorted (default)
+- ` ▲` — ascending
+- ` ▼` — descending
+
+Only one column can be active at a time — clicking a new header resets the previous indicator.
+
+### Per-table toolbar
+
+Above each table, a mini-toolbar:
+
+```
+Table 3                              [CSV] [TSV] [Excel]
+```
+
+The label numbers each table on the page (1-indexed) for use as the default save filename. Buttons are scoped per table — clicking `CSV` on Table 3 only exports Table 3's rows.
+
+### CSV / TSV serialization
+
+Hand-rolled in the webview:
+
+- Cells containing the separator, double-quote, or newline are quoted; embedded `"` is doubled per RFC 4180
+- Header row is included
+- Line terminator is `\n` (Excel + LibreOffice + sheets all accept this)
+- UTF-8 encoded by the host on write
+
+### Excel (.xlsx)
+
+Uses [SheetJS](https://www.npmjs.com/package/xlsx) (`xlsx` package) — the standard JS spreadsheet library. The xlsx format is a zip of XML files; hand-rolling it would be a substantial undertaking and a maintenance liability. SheetJS adds ~600KB to the webview bundle (8.1MB → 8.7MB) which is the trade-off. If bundle size becomes a concern in v1+, we can lazy-load the xlsx module on first export.
+
+### Sort state and export interaction
+
+Exports use the **current row order** in the DOM. So if you sort by "Cost (desc)" then export to CSV, the CSV reflects that order. To export the original markdown order, click the column header until it cycles back to `none` (or simply don't sort first).
+
+## Edge cases & limitations
+
+- **Tables without `<tbody>`**: marked emits `<tbody>` for every markdown table, so this is rare. The sort handler defends with `if (!tbody) return;` and exports skip such tables silently.
+- **Cells with embedded HTML**: `cell.textContent` strips tags for both sort and export. Bold/italic content sorts and exports as the unstyled text.
+- **Multiple `<thead>` rows**: only the first row is wired for sorting. Multi-header tables are uncommon in markdown anyway.
+- **Tables inside blockquotes / lists**: detected by `main.viewing table` selector, so the toolbar attaches consistently regardless of nesting.
+- **Mermaid diagrams that contain tables**: the `attachTableActions()` runs after `renderView()` and matches DOM tables under `main.viewing`. Mermaid SVG tables are inside `<svg>` and not matched — so they're not sortable, which is the intended behavior.
+- **Very large tables** (>1k rows): sort + export still work but a single click may block the main thread for a noticeable beat. Out of scope for v0.5; tracked as a future-work seed for chunked sort if reports come in.
+- **Per-cell formulas (xlsx)**: cells are written as plain values via `XLSX.utils.aoa_to_sheet`. No formula reconstruction — markdown can't express formulas anyway.
+
+## Files of interest
+
+- [src/webview/main.ts](../src/webview/main.ts) — `attachTableActions`, `wireSortableHeaders`, `sortTable`, `compareCells`, `parseFinite`, `tableToMatrix`, `exportTable`, `csvEscape`
+- [src/editor/markdownEditorProvider.ts](../src/editor/markdownEditorProvider.ts) — `saveTable` host-side handler (data URL / base64 / utf-8 → buffer → save dialog → write → toast)
+- [src/editor/webviewBuilder.ts](../src/editor/webviewBuilder.ts) — `.mid-table-wrap`, `.mid-table-toolbar`, `.mid-table-actions`, `.mid-sortable`, `.mid-sort-indicator` styles
+- [package.json](../package.json) — `xlsx` runtime dep

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "html-to-image": "^1.11.13",
         "marked": "^14.1.3",
         "marked-highlight": "^2.2.1",
-        "mermaid": "^11.4.1"
+        "mermaid": "^11.4.1",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@types/dompurify": "^3.2.0",
@@ -1835,6 +1836,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2128,6 +2138,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2250,6 +2273,15 @@
         "@codemirror/view": "^6.0.0"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2313,6 +2345,18 @@
       "license": "MIT",
       "dependencies": {
         "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/crelt": {
@@ -3364,6 +3408,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fs-constants": {
@@ -5395,6 +5448,18 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -5950,6 +6015,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5972,6 +6055,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml2js": {

--- a/package.json
+++ b/package.json
@@ -397,7 +397,8 @@
     "html-to-image": "^1.11.13",
     "marked": "^14.1.3",
     "marked-highlight": "^2.2.1",
-    "mermaid": "^11.4.1"
+    "mermaid": "^11.4.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/dompurify": "^3.2.0",

--- a/src/editor/markdownEditorProvider.ts
+++ b/src/editor/markdownEditorProvider.ts
@@ -102,6 +102,9 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             await this.saveCodeImage(document, msg.dataUrl, String(msg.suggestedName ?? 'code-block'));
           }
           return;
+        case 'saveTable':
+          await this.saveTable(document, msg);
+          return;
         case 'showError':
           if (typeof msg.message === 'string') {
             vscode.window.showErrorMessage(msg.message);
@@ -109,6 +112,46 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           return;
       }
     });
+  }
+
+  private async saveTable(
+    document: vscode.TextDocument,
+    msg: { format?: unknown; content?: unknown; contentBase64?: unknown; suggestedName?: unknown },
+  ): Promise<void> {
+    const format = msg.format === 'csv' || msg.format === 'tsv' || msg.format === 'xlsx' ? msg.format : null;
+    if (!format) return;
+    const baseName = String(msg.suggestedName ?? `table.${format}`).replace(/[^A-Za-z0-9._-]+/g, '-');
+    const documentDir = vscode.Uri.joinPath(document.uri, '..');
+    const defaultUri = vscode.Uri.joinPath(documentDir, baseName);
+    const filterLabel = format === 'xlsx' ? 'Excel workbook' : format.toUpperCase();
+    const target = await vscode.window.showSaveDialog({
+      defaultUri,
+      filters: { [filterLabel]: [format] },
+      title: `Mark It Down: save table as ${format.toUpperCase()}`,
+    });
+    if (!target) return;
+    let buffer: Uint8Array;
+    if (format === 'xlsx') {
+      if (typeof msg.contentBase64 !== 'string') {
+        vscode.window.showErrorMessage('Mark It Down: malformed xlsx payload — export aborted.');
+        return;
+      }
+      buffer = Buffer.from(msg.contentBase64, 'base64');
+    } else {
+      const content = typeof msg.content === 'string' ? msg.content : '';
+      buffer = Buffer.from(content, 'utf8');
+    }
+    await vscode.workspace.fs.writeFile(target, buffer);
+    const choice = await vscode.window.showInformationMessage(
+      `Mark It Down: saved ${target.fsPath.split('/').pop()}`,
+      'Open',
+      'Reveal',
+    );
+    if (choice === 'Open') {
+      await vscode.commands.executeCommand('vscode.open', target);
+    } else if (choice === 'Reveal') {
+      await vscode.commands.executeCommand('revealFileInOS', target);
+    }
   }
 
   private async saveCodeImage(

--- a/src/editor/webviewBuilder.ts
+++ b/src/editor/webviewBuilder.ts
@@ -141,15 +141,48 @@ export function buildWebviewHtml(
       background: var(--code-bg);
       border-radius: 0 6px 6px 0;
     }
+    main.viewing .mid-table-wrap {
+      margin: 1em 0;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      overflow: hidden;
+      background: var(--bg);
+    }
+    main.viewing .mid-table-toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 6px 10px;
+      background: var(--code-bg);
+      border-bottom: 1px solid var(--border);
+      font-size: 0.85em;
+    }
+    main.viewing .mid-table-label { color: var(--fg-muted); }
+    main.viewing .mid-table-actions { display: flex; gap: 4px; }
+    main.viewing .mid-table-actions button {
+      font-size: 11px;
+      padding: 2px 8px;
+      background: var(--bg);
+      color: var(--fg);
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      cursor: pointer;
+    }
+    main.viewing .mid-table-actions button:hover { background: rgba(127,127,127,0.10); }
     main.viewing table {
       border-collapse: collapse;
       width: 100%;
-      margin: 1em 0;
+      margin: 0;
       font-size: 0.95em;
     }
     main.viewing th, main.viewing td { padding: 8px 12px; border: 1px solid var(--border); text-align: left; }
     main.viewing th { background: var(--code-bg); font-weight: 600; }
     main.viewing tr:nth-child(even) td { background: var(--table-stripe); }
+    main.viewing th.mid-sortable { cursor: pointer; user-select: none; }
+    main.viewing th.mid-sortable:hover { background: rgba(127,127,127,0.12); }
+    main.viewing .mid-sort-indicator { font-size: 0.75em; opacity: 0.6; margin-left: 4px; }
+    main.viewing th[data-sort="asc"] .mid-sort-indicator,
+    main.viewing th[data-sort="desc"] .mid-sort-indicator { opacity: 1; }
     main.viewing img { max-width: 100%; border-radius: 4px; }
     main.viewing hr { border: 0; border-top: 1px solid var(--border); margin: 2em 0; }
     main.viewing ul, main.viewing ol { padding-left: 1.4em; }

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -14,6 +14,7 @@ import hljs from 'highlight.js/lib/common';
 import mermaid from 'mermaid';
 import DOMPurify from 'dompurify';
 import { toPng } from 'html-to-image';
+import * as XLSX from 'xlsx';
 import { EditorState } from '@codemirror/state';
 import { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter, drawSelection } from '@codemirror/view';
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
@@ -141,6 +142,164 @@ function attachCodeActions() {
     wrap.appendChild(imgBtn);
     pre.appendChild(wrap);
   });
+}
+
+function attachTableActions(): void {
+  const tables = root.querySelectorAll<HTMLTableElement>('main.viewing table');
+  tables.forEach((table, idx) => {
+    if (table.dataset.midEnhanced === '1') return;
+    const wrapper = document.createElement('div');
+    wrapper.className = 'mid-table-wrap';
+    table.parentNode?.insertBefore(wrapper, table);
+    wrapper.appendChild(table);
+    table.classList.add('mid-datatable');
+    table.dataset.midEnhanced = '1';
+
+    const toolbar = document.createElement('div');
+    toolbar.className = 'mid-table-toolbar';
+    toolbar.innerHTML = `
+      <span class="mid-table-label">Table ${idx + 1}</span>
+      <div class="mid-table-actions">
+        <button data-format="csv">CSV</button>
+        <button data-format="tsv">TSV</button>
+        <button data-format="xlsx">Excel</button>
+      </div>
+    `;
+    wrapper.insertBefore(toolbar, table);
+
+    toolbar.addEventListener('click', evt => {
+      const fmt = (evt.target as HTMLElement).dataset.format as 'csv' | 'tsv' | 'xlsx' | undefined;
+      if (!fmt) return;
+      try {
+        exportTable(table, fmt, `table-${idx + 1}`);
+      } catch (err) {
+        vscode.postMessage({
+          type: 'showError',
+          message: `Mark It Down: failed to export table — ${(err as Error)?.message ?? String(err)}`,
+        });
+      }
+    });
+
+    wireSortableHeaders(table);
+  });
+}
+
+function wireSortableHeaders(table: HTMLTableElement): void {
+  const headRow = table.tHead?.rows[0];
+  if (!headRow) return;
+  Array.from(headRow.cells).forEach((th, colIndex) => {
+    th.classList.add('mid-sortable');
+    th.dataset.sort = 'none';
+    const indicator = document.createElement('span');
+    indicator.className = 'mid-sort-indicator';
+    indicator.textContent = ' ⇅';
+    th.appendChild(indicator);
+    th.addEventListener('click', () => sortTable(table, colIndex, th));
+  });
+}
+
+function sortTable(table: HTMLTableElement, colIndex: number, th: HTMLTableCellElement): void {
+  const tbody = table.tBodies[0];
+  if (!tbody) return;
+  const rows = Array.from(tbody.rows);
+  const current = th.dataset.sort ?? 'none';
+  const next = current === 'none' ? 'asc' : current === 'asc' ? 'desc' : 'none';
+
+  // Reset indicators on all headers
+  table.tHead?.querySelectorAll<HTMLTableCellElement>('th').forEach(other => {
+    if (other === th) return;
+    other.dataset.sort = 'none';
+    const ind = other.querySelector('.mid-sort-indicator');
+    if (ind) ind.textContent = ' ⇅';
+  });
+  th.dataset.sort = next;
+  const ind = th.querySelector('.mid-sort-indicator');
+  if (ind) {
+    ind.textContent = next === 'asc' ? ' ▲' : next === 'desc' ? ' ▼' : ' ⇅';
+  }
+
+  if (next === 'none') {
+    const original = rows
+      .slice()
+      .sort((a, b) => Number(a.dataset.midOriginal ?? 0) - Number(b.dataset.midOriginal ?? 0));
+    original.forEach(r => tbody.appendChild(r));
+    return;
+  }
+  if (rows[0] && rows[0].dataset.midOriginal === undefined) {
+    rows.forEach((r, i) => (r.dataset.midOriginal = String(i)));
+  }
+  const factor = next === 'asc' ? 1 : -1;
+  rows.sort((a, b) => factor * compareCells(a.cells[colIndex], b.cells[colIndex]));
+  rows.forEach(r => tbody.appendChild(r));
+}
+
+function compareCells(a: HTMLTableCellElement | undefined, b: HTMLTableCellElement | undefined): number {
+  const av = (a?.textContent ?? '').trim();
+  const bv = (b?.textContent ?? '').trim();
+  const an = parseFinite(av);
+  const bn = parseFinite(bv);
+  if (an !== null && bn !== null) return an - bn;
+  return av.localeCompare(bv, undefined, { numeric: true, sensitivity: 'base' });
+}
+
+function parseFinite(s: string): number | null {
+  if (s.length === 0) return null;
+  const cleaned = s.replace(/[, ]/g, '').replace(/^\$/, '').replace(/%$/, '');
+  const n = Number(cleaned);
+  return Number.isFinite(n) ? n : null;
+}
+
+function tableToMatrix(table: HTMLTableElement): string[][] {
+  const out: string[][] = [];
+  const head = table.tHead?.rows[0];
+  if (head) {
+    out.push(
+      Array.from(head.cells).map(c => c.cloneNode(true) as HTMLElement)
+        .map(c => {
+          c.querySelector('.mid-sort-indicator')?.remove();
+          return (c.textContent ?? '').trim();
+        }),
+    );
+  }
+  Array.from(table.tBodies[0]?.rows ?? []).forEach(row => {
+    out.push(Array.from(row.cells).map(c => (c.textContent ?? '').trim()));
+  });
+  return out;
+}
+
+function exportTable(table: HTMLTableElement, format: 'csv' | 'tsv' | 'xlsx', baseName: string): void {
+  const matrix = tableToMatrix(table);
+  if (format === 'csv' || format === 'tsv') {
+    const sep = format === 'csv' ? ',' : '\t';
+    const text = matrix
+      .map(row => row.map(cell => csvEscape(cell, sep)).join(sep))
+      .join('\n');
+    vscode.postMessage({
+      type: 'saveTable',
+      format,
+      content: text,
+      suggestedName: `${baseName}.${format}`,
+    });
+    return;
+  }
+  // xlsx
+  const ws = XLSX.utils.aoa_to_sheet(matrix);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+  const buf = XLSX.write(wb, { type: 'base64', bookType: 'xlsx' });
+  vscode.postMessage({
+    type: 'saveTable',
+    format: 'xlsx',
+    contentBase64: buf,
+    suggestedName: `${baseName}.xlsx`,
+  });
+}
+
+function csvEscape(value: string, sep: string): string {
+  if (value.includes(sep) || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
 }
 
 async function exportCodeBlockAsPng(pre: HTMLPreElement, suggestedName: string): Promise<void> {
@@ -296,6 +455,7 @@ function renderView() {
   root.classList.add('viewing');
   root.innerHTML = renderMarkdown(currentText);
   attachCodeActions();
+  attachTableActions();
   renderMermaidDiagrams();
 
   // Intercept link clicks → open in OS browser


### PR DESCRIPTION
## Summary
- Markdown tables in View mode are sortable — click any column header (asc → desc → none cycle)
- Mixed numeric/string detection with `$`, `,`, `%` strip then `localeCompare(..., {numeric: true})`
- Per-table toolbar above each table with **CSV** / **TSV** / **Excel** buttons
- Exports respect the current DOM row order (sort first → export reflects that)
- Excel via SheetJS (`xlsx`); CSV/TSV hand-rolled RFC-4180
- Save flow: `showSaveDialog` → write → toast with `Open` / `Reveal`
- Full reference docs at `docs/datatable.md`

## Closes
Closes #5

## Test plan
- [x] `npm run compile` clean — webview 8.1MB → 8.7MB (xlsx)
- [ ] F5: render markdown with a table, click header to sort, click again to reverse, click third time to restore order; export CSV/TSV/Excel and verify file opens correctly

## Linked issue
[#5 — F4: v0.5 Sortable DataTable + per-table Excel/CSV/TSV export](https://github.com/fadymondy/mark-it-down/issues/5)