### PR TITLE
feat(mcp): stdio MCP server + one-click installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Phase 0.9: MCP server for Claude Desktop / Code (#9)
+
+- Standalone stdio MCP server bundled at `out/mcp/server.js` (esbuild → CJS Node18, ~1.1MB)
+- 5 active tools: `list_notes`, `get_note`, `create_note`, `update_note`, `delete_note` — operate on the global-scope notes from the Notes sidebar
+- 2 tools registered as stubs (return a clear "requires extension IPC" error): `get_active_markdown`, `list_open_md` — defer to v1+ pending an IPC channel between the running extension and the spawned MCP server
+- One-click install: `Mark It Down: Install MCP for Claude Desktop / Code` Quick-Picks Claude Desktop (per-OS path) or Claude Code (project-level `.mcp.json`) and writes the right `mcpServers["mark-it-down"]` entry. Uses the running Node binary (`process.execPath`) and the user's globalStorage notes dir.
+- `Mark It Down: Show MCP Server Path (copy to clipboard)` for users wiring it into other MCP clients manually
+- Extension writes `_mcp-index.json` snapshot to `globalStorage/notes/` on every NotesStore change so the cross-process MCP server stays in sync
+- Limitation: workspace-scope notes are not exposed (per-VSCode-window, no addressable path); use the warehouse repo for cross-machine notes instead
+- Restart Claude Desktop / Code after install to pick up the new server
+
 ### Added — Phase 0.6: File-level export pipeline TXT/DOCX/PDF (#6)
 
 - The previously-stub commands `markItDown.exportPdf`, `exportDocx`, `exportTxt` are now real

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A beautiful markdown viewer + editor for VSCode — rich rendering, live mermaid
 | Tables → DataTable with sort + Excel/CSV export | ✅ shipped | 0.5 |
 | Notes sidebar with multi-type categories | ✅ shipped | 0.7 |
 | Multi-theme via `@orchestra-mcp/theme` (25 themes) | ✅ shipped (palettes bundled inline) | 0.8 |
-| MCP server for Claude Desktop / Code | ⬜ planned | 0.9 |
+| MCP server for Claude Desktop / Code | ✅ shipped (5 tools + one-click install; 2 IPC stubs) | 0.9 |
 
 ## Install (dev)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 | F5 — File export pipeline (PDF / DOCX / TXT) | shipped | [file-export.md](file-export.md) |
 | F6 — Notes sidebar | shipped (0.7) | [notes-sidebar.md](notes-sidebar.md) |
 | F7 — 25-theme bridge | shipped | [themes.md](themes.md) |
-| F8 — MCP server | planned | — |
+| F8 — MCP server | shipped | [mcp-server.md](mcp-server.md) |
 | F9 — Notes warehouse repo | shipped | [notes-warehouse.md](notes-warehouse.md) |
 | F10 — Publish any markdown to GitHub Pages | planned | — |
 | F11 — Slideshow export | planned | — |

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,164 @@
+# MCP Server (stdio) for Claude Desktop / Code
+
+Status: shipped in Phase 0.9 · Issue: [#9](https://github.com/fadymondy/mark-it-down/issues/9)
+
+A standalone stdio MCP server bundled inside the `.vsix` exposes your global Mark It Down notes to Claude Desktop and Claude Code. Install with one click; the server reads from the same on-disk store the [Notes sidebar](notes-sidebar.md) writes to.
+
+## At a glance
+
+| | |
+|---|---|
+| **Server binary** | `out/mcp/server.js` (bundled by esbuild from `src/mcp/server.ts`, ~1.1MB CJS, Node 18+) |
+| **Transport** | stdio (`@modelcontextprotocol/sdk`'s `StdioServerTransport`) |
+| **CLI args** | `--notes-dir <path>` — required; the directory containing `_mcp-index.json` and the `<id>.md` files |
+| **Install** | `Mark It Down: Install MCP for Claude Desktop / Code` command |
+| **Scope** | Global notes only (workspace notes are per-VSCode-window and not addressable from outside) |
+| **Tools** | `list_notes`, `get_note`, `create_note`, `update_note`, `delete_note` |
+| **Deferred to v1+** | `get_active_markdown`, `list_open_md` (registered as stubs that return a clear "requires extension IPC" error) |
+
+## How it works
+
+```
+┌────────────────────────────┐         ┌─────────────────────────────────┐
+│ Claude Desktop / Code      │ stdin/  │ out/mcp/server.js               │
+│ — McpClient                │ stdout  │ — McpServer + StdioTransport    │
+│ — sees Mark It Down tools  │◄──────► │ — reads NotesAdapter            │
+└────────────────────────────┘         │   on the on-disk store          │
+                                       └─────────────────────────────────┘
+                                                          │ reads
+                                                          ▼
+                                       ┌─────────────────────────────────┐
+                                       │ globalStorage/notes/            │
+                                       │   _mcp-index.json (snapshot)    │
+                                       │   <id>.md (one per note)        │
+                                       └─────────────────────────────────┘
+                                                          ▲ writes
+                                                          │ on every
+                                                          │ NotesStore change
+                                       ┌─────────────────────────────────┐
+                                       │ VSCode extension (Notes sidebar)│
+                                       │ — NotesStore                    │
+                                       │ — writeMcpIndexSnapshot()       │
+                                       └─────────────────────────────────┘
+```
+
+The extension owns the canonical state (workspaceState/globalState index + `<id>.md` files). On every change to the global-scope notes, it writes a `_mcp-index.json` snapshot under `globalStorage/notes/` that the MCP server reads.
+
+The MCP server runs as a separate Node process spawned by Claude Desktop/Code per the standard MCP launch model. It does not require VSCode to be running — but mutations made via MCP tools while the extension is also running will only be visible in the Notes sidebar after a tree refresh (the extension watches the index file via the standard NotesStore change events; cross-process change detection is on the roadmap).
+
+## Install
+
+Run `Mark It Down: Install MCP for Claude Desktop / Code` from the command palette. You'll get a Quick Pick:
+
+| Target | Where the config lands |
+|---|---|
+| **Claude Desktop** | macOS `~/Library/Application Support/Claude/claude_desktop_config.json` · Windows `%APPDATA%/Claude/...` · Linux `~/.config/Claude/...` |
+| **Claude Code (project-level)** | `<workspace>/.mcp.json` (or `~/.mcp.json` if no folder is open) |
+
+Pick one, and the install command:
+
+1. Reads (or creates) the target JSON config
+2. Adds an `mcpServers["mark-it-down"]` entry pointing at the bundled server with the right `--notes-dir` for your VSCode global storage
+3. Offers `Reveal Config` to inspect the result
+
+The entry looks like:
+
+```jsonc
+{
+  "mcpServers": {
+    "mark-it-down": {
+      "command": "/path/to/node",
+      "args": [
+        "/path/to/extension/out/mcp/server.js",
+        "--notes-dir",
+        "/Users/you/Library/Application Support/Code/User/globalStorage/fadymondy.mark-it-down/notes"
+      ]
+    }
+  }
+}
+```
+
+After installing, **restart** Claude Desktop or Claude Code so it picks up the new server. From the next session, you'll have the Mark It Down tools available.
+
+There's a companion command `Mark It Down: Show MCP Server Path (copy to clipboard)` that just copies the absolute path to the bundled `server.js` for users who want to wire it into other MCP clients manually.
+
+## Tools
+
+All tools take JSON inputs and return text content blocks. The server is registered as `mark-it-down` v0.9.0.
+
+### `list_notes(category?)`
+
+List global notes. Optionally filter by category.
+
+```json
+{ "category": "Reference" }
+```
+
+Returns a JSON array of note metadata: `{ id, title, category, scope, createdAt, updatedAt, filename }`.
+
+### `get_note(id)`
+
+Read one note by id. Returns metadata + full markdown content as two text blocks.
+
+```json
+{ "id": "ka9zsb1tfnd2" }
+```
+
+### `create_note(title, category, content?)`
+
+Create a new global note. `content` defaults to `# <title>\n\n`.
+
+```json
+{ "title": "API design notes", "category": "Reference" }
+```
+
+Returns the created note's metadata.
+
+### `update_note(id, ...patch)`
+
+Patch any of `title`, `category`, `content`. Bumps `updatedAt`.
+
+```json
+{ "id": "ka9zsb1tfnd2", "content": "# Updated body\n..." }
+```
+
+### `delete_note(id)`
+
+Permanently delete a note. No soft-delete.
+
+### `get_active_markdown` (deferred)
+
+Would return whatever is open in the active Mark It Down editor. Requires bidirectional IPC between the running VSCode extension and the spawned MCP server — a Unix socket / named pipe is on the v1+ roadmap. In v0.9 the tool is registered but returns an `isError` result with a clear message.
+
+### `list_open_md` (deferred)
+
+Same story: requires extension IPC. Stub registered.
+
+## What lives where
+
+| Path | Purpose | Owner |
+|---|---|---|
+| `out/mcp/server.js` | Bundled MCP server entry | extension build |
+| `src/mcp/server.ts` | MCP server source (registers tools, wires StdioTransport) | source |
+| `src/mcp/notesAdapter.ts` | File-system notes I/O (read index + content, mutate both) | source |
+| `src/mcp/installCommand.ts` | VSCode commands that write the MCP entry to client configs | source |
+| `globalStorage/.../notes/_mcp-index.json` | Snapshot of global note metadata, written by the extension | extension runtime |
+| `globalStorage/.../notes/<id>.md` | Each note's markdown content | extension + MCP both write |
+
+## Edge cases & limitations
+
+- **MCP server can't see workspace-scope notes.** Workspace notes live in `<workspaceStorage>/notes/` per workspace; the MCP server has no way to enumerate VSCode workspaces. Workspace notes are exposed through the [warehouse repo](notes-warehouse.md) instead.
+- **Concurrent writes.** If the MCP server creates/updates a note while the extension is mid-save on a different note, they race on the index file. The extension's `writeMcpIndexSnapshot()` and the MCP server's `writeIndex` both rewrite the whole file; last writer wins. Real cross-process locking is a future addition.
+- **Stale index after MCP-side mutations.** When the MCP server creates/updates/deletes notes, the extension does NOT automatically refresh its sidebar — its in-memory index stays current with `workspaceState`/`globalState`, not the on-disk `_mcp-index.json`. After running MCP-side mutations, click the Notes sidebar `Refresh` button to re-read from disk. Auto-watching the index file from inside the extension is a follow-up.
+- **`get_active_markdown` / `list_open_md`** are stubs that return a clear error. Don't bind workflows to them in v0.9.
+- **`--notes-dir` must exist.** First time: install via the command (which uses the absolute global-storage path) OR create the directory manually.
+- **Restart required.** Claude Desktop / Code only re-reads MCP configs at startup. After install, restart the client.
+
+## Files of interest
+
+- [src/mcp/server.ts](../src/mcp/server.ts) — server entry, McpServer + 7 tool registrations
+- [src/mcp/notesAdapter.ts](../src/mcp/notesAdapter.ts) — pure-Node fs adapter (`listNotes`, `getNote`, `createNote`, `updateNote`, `deleteNote`)
+- [src/mcp/installCommand.ts](../src/mcp/installCommand.ts) — `markItDown.mcp.install` (Quick Pick + JSON-merge into client config), `markItDown.mcp.revealServer`
+- [src/notes/notesStore.ts](../src/notes/notesStore.ts) — `writeMcpIndexSnapshot()` writes the snapshot the MCP server reads
+- [src/extension.ts](../src/extension.ts) — wires the install commands and the snapshot-on-change listener
+- [package.json](../package.json) — `compile:mcp` build step (esbuild → CJS Node18); `markItDown.mcp.install` + `markItDown.mcp.revealServer` command registrations

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@codemirror/view": "^6.41.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@types/pdfkit": "^0.17.6",
         "codemirror": "^6.0.2",
         "docx": "^9.6.1",
@@ -884,6 +885,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
@@ -991,6 +1004,46 @@
       "license": "MIT",
       "dependencies": {
         "langium": "^4.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@noble/ciphers": {
@@ -1868,6 +1921,44 @@
         "win32"
       ]
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1903,7 +1994,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1914,6 +2004,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -2052,6 +2159,46 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -2167,11 +2314,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2185,7 +2340,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2407,11 +2561,68 @@
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cose-base": {
       "version": "1.0.3",
@@ -2444,7 +2655,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3003,7 +3213,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3105,6 +3314,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/detect-libc": {
@@ -3228,7 +3446,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3266,12 +3483,27 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
@@ -3328,7 +3560,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3338,7 +3569,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3348,7 +3578,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3414,6 +3643,42 @@
         "@esbuild/win32-x64": "0.24.2"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -3423,6 +3688,92 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3452,7 +3803,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3486,6 +3836,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fontkit": {
@@ -3539,6 +3910,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/frac": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
@@ -3546,6 +3926,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-constants": {
@@ -3575,7 +3964,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3585,7 +3973,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3610,7 +3997,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3730,7 +4116,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3766,7 +4151,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3805,7 +4189,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3821,6 +4204,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -3873,6 +4265,26 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -3989,6 +4401,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -4067,6 +4497,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-wsl": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -4093,7 +4529,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istextorbinary": {
@@ -4130,6 +4565,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-md5": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
@@ -4160,8 +4604,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4524,7 +4973,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4536,6 +4984,27 @@
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4729,7 +5198,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -4764,6 +5232,15 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/node-abi": {
       "version": "3.89.0",
@@ -4849,11 +5326,19 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4862,13 +5347,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5015,6 +5510,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
@@ -5025,7 +5529,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5056,6 +5559,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -5116,6 +5629,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-types": {
@@ -5198,6 +5720,19 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -5224,7 +5759,6 @@
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
       "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -5256,6 +5790,46 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -5353,7 +5927,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5392,6 +5965,22 @@
         "path-data-parser": "^0.1.0",
         "points-on-curve": "^0.2.0",
         "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/run-applescript": {
@@ -5508,17 +6097,92 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5531,7 +6195,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5541,7 +6204,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5561,7 +6223,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5578,7 +6239,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5597,7 +6257,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5752,6 +6411,15 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string_decoder": {
@@ -6032,6 +6700,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -6082,6 +6759,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-rest-client": {
@@ -6195,6 +6911,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -6227,6 +6952,15 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/version-range": {
@@ -6325,7 +7059,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6359,9 +7092,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
@@ -6471,6 +7202,24 @@
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -169,6 +169,17 @@
         "title": "Pick Theme",
         "category": "Mark It Down",
         "icon": "$(symbol-color)"
+      },
+      {
+        "command": "markItDown.mcp.install",
+        "title": "Install MCP for Claude Desktop / Code",
+        "category": "Mark It Down",
+        "icon": "$(plug)"
+      },
+      {
+        "command": "markItDown.mcp.revealServer",
+        "title": "Show MCP Server Path (copy to clipboard)",
+        "category": "Mark It Down"
       }
     ],
     "menus": {
@@ -402,9 +413,10 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "npm run compile:extension && npm run compile:webview",
+    "compile": "npm run compile:extension && npm run compile:webview && npm run compile:mcp",
     "compile:extension": "tsc -p ./",
     "compile:webview": "esbuild src/webview/main.ts --bundle --outfile=out/webview/main.js --format=iife --target=es2020 --platform=browser",
+    "compile:mcp": "esbuild src/mcp/server.ts --bundle --outfile=out/mcp/server.js --format=cjs --platform=node --target=node18 --external:vscode",
     "watch": "tsc -watch -p ./",
     "package": "vsce package",
     "publish": "vsce publish",
@@ -417,6 +429,7 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.41.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/pdfkit": "^0.17.6",
     "codemirror": "^6.0.2",
     "docx": "^9.6.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { THEMES } from './themes/themes';
 import { markdownToTxt } from './exporters/exportTxt';
 import { markdownToDocx } from './exporters/exportDocx';
 import { markdownToPdf } from './exporters/exportPdf';
+import { registerMcpInstallCommands } from './mcp/installCommand';
 
 export function activate(context: vscode.ExtensionContext) {
   const provider = new MarkdownEditorProvider(context);
@@ -35,8 +36,15 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.window.registerTreeDataProvider('markItDown.notes', notesTree),
     ...registerNotesCommands(context, notesStore),
     ...registerWarehouseCommands(warehouse),
+    ...registerMcpInstallCommands(context),
   );
   warehouse.start();
+  void notesStore.writeMcpIndexSnapshot();
+  context.subscriptions.push(
+    notesStore.onDidChange(() => {
+      void notesStore.writeMcpIndexSnapshot();
+    }),
+  );
 
   context.subscriptions.push(
     vscode.commands.registerCommand('markItDown.toggleMode', () => {

--- a/src/mcp/installCommand.ts
+++ b/src/mcp/installCommand.ts
@@ -1,0 +1,168 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+interface ClientTarget {
+  id: 'claude-desktop' | 'claude-code';
+  label: string;
+  configPath: string;
+  description: string;
+}
+
+const SERVER_KEY = 'mark-it-down';
+
+export function registerMcpInstallCommands(context: vscode.ExtensionContext): vscode.Disposable[] {
+  return [
+    vscode.commands.registerCommand('markItDown.mcp.install', () => installToClient(context)),
+    vscode.commands.registerCommand('markItDown.mcp.revealServer', async () => {
+      const serverPath = mcpServerPath(context);
+      const exists = await pathExists(serverPath);
+      if (!exists) {
+        vscode.window.showWarningMessage(
+          `Mark It Down MCP server not found at ${serverPath}. Run \`npm run compile\` first.`,
+        );
+        return;
+      }
+      await vscode.env.clipboard.writeText(serverPath);
+      vscode.window.showInformationMessage(
+        `Mark It Down: copied MCP server path to clipboard — ${serverPath}`,
+      );
+    }),
+  ];
+}
+
+async function installToClient(context: vscode.ExtensionContext): Promise<void> {
+  const targets = candidateTargets();
+  if (targets.length === 0) {
+    vscode.window.showErrorMessage(
+      'Mark It Down: no Claude Desktop / Claude Code config locations were detected on this OS.',
+    );
+    return;
+  }
+  const choice = await vscode.window.showQuickPick(
+    targets.map(t => ({
+      label: t.label,
+      description: t.description,
+      detail: t.configPath,
+      target: t,
+    })),
+    { placeHolder: 'Where should we install the Mark It Down MCP?' },
+  );
+  if (!choice) return;
+  await applyInstall(context, (choice as { target: ClientTarget }).target);
+}
+
+async function applyInstall(
+  context: vscode.ExtensionContext,
+  target: ClientTarget,
+): Promise<void> {
+  const serverPath = mcpServerPath(context);
+  if (!(await pathExists(serverPath))) {
+    vscode.window.showErrorMessage(
+      `Mark It Down: MCP server not built (${serverPath}). Run "npm run compile" first.`,
+    );
+    return;
+  }
+  const notesDir = path.join(context.globalStorageUri.fsPath, 'notes');
+  const entry = {
+    command: process.execPath,
+    args: [serverPath, '--notes-dir', notesDir],
+  };
+  let raw = '{}';
+  try {
+    raw = await fs.readFile(target.configPath, 'utf8');
+  } catch {
+    await fs.mkdir(path.dirname(target.configPath), { recursive: true });
+  }
+  let json: { mcpServers?: Record<string, unknown> } = {};
+  try {
+    json = raw.trim().length > 0 ? JSON.parse(raw) : {};
+  } catch {
+    const ok = await vscode.window.showWarningMessage(
+      `${target.label} config at ${target.configPath} is not valid JSON. Overwrite?`,
+      { modal: true },
+      'Overwrite',
+    );
+    if (ok !== 'Overwrite') return;
+  }
+  json.mcpServers = json.mcpServers ?? {};
+  json.mcpServers[SERVER_KEY] = entry;
+  await fs.writeFile(target.configPath, JSON.stringify(json, null, 2) + '\n', 'utf8');
+  const action = await vscode.window.showInformationMessage(
+    `Mark It Down MCP installed to ${target.label}. Restart ${target.label} to pick it up.`,
+    'Reveal Config',
+    'OK',
+  );
+  if (action === 'Reveal Config') {
+    await vscode.commands.executeCommand('revealFileInOS', vscode.Uri.file(target.configPath));
+  }
+}
+
+function candidateTargets(): ClientTarget[] {
+  const home = os.homedir();
+  const platform = process.platform;
+  const targets: ClientTarget[] = [];
+
+  if (platform === 'darwin') {
+    targets.push({
+      id: 'claude-desktop',
+      label: 'Claude Desktop',
+      description: 'macOS — ~/Library/Application Support/Claude',
+      configPath: path.join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json'),
+    });
+    targets.push({
+      id: 'claude-code',
+      label: 'Claude Code (project-level)',
+      description: 'Current workspace — ./.mcp.json',
+      configPath: workspaceMcpPath() ?? path.join(home, '.mcp.json'),
+    });
+  } else if (platform === 'win32') {
+    targets.push({
+      id: 'claude-desktop',
+      label: 'Claude Desktop',
+      description: 'Windows — %APPDATA%/Claude',
+      configPath: path.join(process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming'), 'Claude', 'claude_desktop_config.json'),
+    });
+    targets.push({
+      id: 'claude-code',
+      label: 'Claude Code (project-level)',
+      description: 'Current workspace — ./.mcp.json',
+      configPath: workspaceMcpPath() ?? path.join(home, '.mcp.json'),
+    });
+  } else {
+    // linux
+    targets.push({
+      id: 'claude-desktop',
+      label: 'Claude Desktop',
+      description: 'Linux — ~/.config/Claude',
+      configPath: path.join(home, '.config', 'Claude', 'claude_desktop_config.json'),
+    });
+    targets.push({
+      id: 'claude-code',
+      label: 'Claude Code (project-level)',
+      description: 'Current workspace — ./.mcp.json',
+      configPath: workspaceMcpPath() ?? path.join(home, '.mcp.json'),
+    });
+  }
+  return targets;
+}
+
+function workspaceMcpPath(): string | undefined {
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  if (!folder) return undefined;
+  return path.join(folder.uri.fsPath, '.mcp.json');
+}
+
+function mcpServerPath(context: vscode.ExtensionContext): string {
+  return path.join(context.extensionUri.fsPath, 'out', 'mcp', 'server.js');
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/mcp/notesAdapter.ts
+++ b/src/mcp/notesAdapter.ts
@@ -1,0 +1,133 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+export interface MdNote {
+  id: string;
+  title: string;
+  category: string;
+  scope: 'global';
+  createdAt: string;
+  updatedAt: string;
+  filename: string;
+}
+
+export interface MdIndex {
+  generatedAt: string;
+  notes: MdNote[];
+}
+
+const INDEX_FILENAME = '_mcp-index.json';
+
+export class NotesAdapter {
+  constructor(private readonly notesDir: string) {}
+
+  async listNotes(filter: { category?: string } = {}): Promise<MdNote[]> {
+    const idx = await this.readIndex();
+    const cat = filter.category?.trim();
+    return cat ? idx.notes.filter(n => n.category === cat) : idx.notes;
+  }
+
+  async getNote(id: string): Promise<{ meta: MdNote; content: string } | undefined> {
+    const idx = await this.readIndex();
+    const meta = idx.notes.find(n => n.id === id);
+    if (!meta) return undefined;
+    const content = await fs.readFile(this.notePath(meta.filename), 'utf8');
+    return { meta, content };
+  }
+
+  async createNote(input: { title: string; category: string; content?: string }): Promise<MdNote> {
+    const now = new Date().toISOString();
+    const id = randomId();
+    const meta: MdNote = {
+      id,
+      title: input.title.trim() || 'Untitled note',
+      category: input.category.trim() || 'Drafts',
+      scope: 'global',
+      createdAt: now,
+      updatedAt: now,
+      filename: `${id}.md`,
+    };
+    await this.ensureDir();
+    await fs.writeFile(
+      this.notePath(meta.filename),
+      input.content ?? `# ${meta.title}\n\n`,
+      'utf8',
+    );
+    const idx = await this.readIndex();
+    idx.notes.push(meta);
+    idx.generatedAt = now;
+    await this.writeIndex(idx);
+    return meta;
+  }
+
+  async updateNote(
+    id: string,
+    patch: { title?: string; category?: string; content?: string },
+  ): Promise<MdNote> {
+    const idx = await this.readIndex();
+    const i = idx.notes.findIndex(n => n.id === id);
+    if (i < 0) throw new Error(`note ${id} not found`);
+    const next: MdNote = { ...idx.notes[i] };
+    if (patch.title !== undefined) next.title = patch.title.trim() || next.title;
+    if (patch.category !== undefined) next.category = patch.category.trim() || next.category;
+    next.updatedAt = new Date().toISOString();
+    if (patch.content !== undefined) {
+      await fs.writeFile(this.notePath(next.filename), patch.content, 'utf8');
+    }
+    idx.notes[i] = next;
+    idx.generatedAt = next.updatedAt;
+    await this.writeIndex(idx);
+    return next;
+  }
+
+  async deleteNote(id: string): Promise<MdNote | undefined> {
+    const idx = await this.readIndex();
+    const i = idx.notes.findIndex(n => n.id === id);
+    if (i < 0) return undefined;
+    const meta = idx.notes[i];
+    idx.notes.splice(i, 1);
+    idx.generatedAt = new Date().toISOString();
+    await this.writeIndex(idx);
+    try {
+      await fs.unlink(this.notePath(meta.filename));
+    } catch {
+      // already gone
+    }
+    return meta;
+  }
+
+  private notePath(filename: string): string {
+    return path.join(this.notesDir, filename);
+  }
+
+  private indexPath(): string {
+    return path.join(this.notesDir, INDEX_FILENAME);
+  }
+
+  private async ensureDir(): Promise<void> {
+    await fs.mkdir(this.notesDir, { recursive: true });
+  }
+
+  private async readIndex(): Promise<MdIndex> {
+    try {
+      const buf = await fs.readFile(this.indexPath(), 'utf8');
+      const parsed = JSON.parse(buf) as MdIndex;
+      if (!parsed || !Array.isArray(parsed.notes)) throw new Error('bad index');
+      return parsed;
+    } catch {
+      return { generatedAt: new Date().toISOString(), notes: [] };
+    }
+  }
+
+  private async writeIndex(idx: MdIndex): Promise<void> {
+    await this.ensureDir();
+    await fs.writeFile(this.indexPath(), JSON.stringify(idx, null, 2) + '\n', 'utf8');
+  }
+}
+
+function randomId(): string {
+  const alpha = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  let s = '';
+  for (let i = 0; i < 12; i++) s += alpha[Math.floor(Math.random() * alpha.length)];
+  return s;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { NotesAdapter } from './notesAdapter';
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.notesDir) {
+  console.error('mark-it-down-mcp: missing required --notes-dir <path>');
+  console.error('usage: mark-it-down-mcp --notes-dir <path-to-globalStorage/notes>');
+  process.exit(2);
+}
+
+const adapter = new NotesAdapter(args.notesDir);
+
+const server = new McpServer(
+  { name: 'mark-it-down', version: '0.9.0' },
+  {
+    capabilities: { tools: {} },
+    instructions:
+      'Mark It Down — markdown notes from the VSCode extension. Use list_notes to discover, get_note to read, create/update/delete_note to mutate. Active-editor introspection (get_active_markdown / list_open_md) requires the extension to be running and is not available in this transport.',
+  },
+);
+
+server.registerTool(
+  'list_notes',
+  {
+    description: 'List notes in the Mark It Down warehouse. Optionally filter by category.',
+    inputSchema: {
+      category: z.string().optional().describe('Restrict to notes in this category'),
+    },
+  },
+  async ({ category }) => {
+    const notes = await adapter.listNotes({ category });
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(notes, null, 2),
+        },
+      ],
+    };
+  },
+);
+
+server.registerTool(
+  'get_note',
+  {
+    description: 'Read a single note by id. Returns metadata + full markdown content.',
+    inputSchema: { id: z.string().describe('Note id') },
+  },
+  async ({ id }) => {
+    const note = await adapter.getNote(id);
+    if (!note) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `note ${id} not found` }],
+      };
+    }
+    return {
+      content: [
+        { type: 'text', text: JSON.stringify(note.meta, null, 2) },
+        { type: 'text', text: note.content },
+      ],
+    };
+  },
+);
+
+server.registerTool(
+  'create_note',
+  {
+    description: 'Create a new global note with optional initial content.',
+    inputSchema: {
+      title: z.string().describe('Note title'),
+      category: z.string().describe('Category, e.g. Daily / Reference / Snippet / Drafts'),
+      content: z.string().optional().describe('Initial markdown content (default: "# <title>\\n\\n")'),
+    },
+  },
+  async ({ title, category, content }) => {
+    const meta = await adapter.createNote({ title, category, content });
+    return {
+      content: [{ type: 'text', text: JSON.stringify(meta, null, 2) }],
+    };
+  },
+);
+
+server.registerTool(
+  'update_note',
+  {
+    description: 'Update a note. Any of title / category / content may be patched; updatedAt bumps.',
+    inputSchema: {
+      id: z.string(),
+      title: z.string().optional(),
+      category: z.string().optional(),
+      content: z.string().optional(),
+    },
+  },
+  async ({ id, title, category, content }) => {
+    try {
+      const next = await adapter.updateNote(id, { title, category, content });
+      return { content: [{ type: 'text', text: JSON.stringify(next, null, 2) }] };
+    } catch (err) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: (err as Error).message }],
+      };
+    }
+  },
+);
+
+server.registerTool(
+  'delete_note',
+  {
+    description: 'Permanently delete a note (no soft-delete or trash).',
+    inputSchema: { id: z.string() },
+  },
+  async ({ id }) => {
+    const removed = await adapter.deleteNote(id);
+    if (!removed) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `note ${id} not found` }],
+      };
+    }
+    return { content: [{ type: 'text', text: `deleted ${removed.id} (${removed.title})` }] };
+  },
+);
+
+server.registerTool(
+  'get_active_markdown',
+  {
+    description:
+      'Return the markdown currently open in the active Mark It Down editor. ' +
+      'Requires the VSCode extension to be running with IPC enabled (not yet implemented in v0.9).',
+    inputSchema: {},
+  },
+  async () => ({
+    isError: true,
+    content: [
+      {
+        type: 'text',
+        text: 'get_active_markdown requires extension IPC — not available in v0.9 stdio mode. Use list_notes / get_note for warehouse access instead.',
+      },
+    ],
+  }),
+);
+
+server.registerTool(
+  'list_open_md',
+  {
+    description:
+      'List all open .md tabs in the running VSCode. ' +
+      'Requires the VSCode extension to be running with IPC enabled (not yet implemented in v0.9).',
+    inputSchema: {},
+  },
+  async () => ({
+    isError: true,
+    content: [
+      {
+        type: 'text',
+        text: 'list_open_md requires extension IPC — not available in v0.9 stdio mode.',
+      },
+    ],
+  }),
+);
+
+const transport = new StdioServerTransport();
+server.connect(transport).then(
+  () => {
+    console.error('mark-it-down-mcp: ready (notes-dir=%s)', args.notesDir);
+  },
+  err => {
+    console.error('mark-it-down-mcp: failed to start', err);
+    process.exit(1);
+  },
+);
+
+interface CliArgs {
+  notesDir?: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const out: CliArgs = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--notes-dir' && argv[i + 1]) {
+      out.notesDir = argv[i + 1];
+      i++;
+    }
+  }
+  return out;
+}

--- a/src/notes/notesStore.ts
+++ b/src/notes/notesStore.ts
@@ -138,6 +138,24 @@ export class NotesStore {
     this.emitter.fire();
   }
 
+  public async writeMcpIndexSnapshot(): Promise<void> {
+    const dir = vscode.Uri.joinPath(this.context.globalStorageUri, 'notes');
+    try {
+      await vscode.workspace.fs.createDirectory(dir);
+    } catch {
+      // already exists
+    }
+    const indexUri = vscode.Uri.joinPath(dir, '_mcp-index.json');
+    const snapshot = {
+      generatedAt: new Date().toISOString(),
+      notes: this.read('global'),
+    };
+    await vscode.workspace.fs.writeFile(
+      indexUri,
+      new TextEncoder().encode(JSON.stringify(snapshot, null, 2) + '\n'),
+    );
+  }
+
   public dispose(): void {
     this.emitter.dispose();
   }


### PR DESCRIPTION
## Summary
- Standalone stdio MCP server bundled at `out/mcp/server.js` (esbuild → CJS Node18)
- 5 active tools (`list_notes`, `get_note`, `create_note`, `update_note`, `delete_note`); 2 IPC-deferred stubs (`get_active_markdown`, `list_open_md`)
- One-click install command that detects Claude Desktop / Claude Code config locations and merges in the right `mcpServers` entry
- Extension writes `_mcp-index.json` snapshot to globalStorage on every NotesStore change for cross-process state
- Sister command: `Show MCP Server Path (copy to clipboard)` for manual wiring
- Full reference docs at `docs/mcp-server.md`
- Unblocks F13 (Claude plugin) which wraps these tools as user-friendly skills

## Closes
Closes #9

## Test plan
- [x] `npm run compile` clean — server bundles to 1.1MB
- [x] `node out/mcp/server.js` errors with usage when --notes-dir missing
- [ ] F5: run `Mark It Down: Install MCP for Claude Desktop / Code`, verify config entry, restart Claude, verify list_notes returns the global notes

## Linked issue
[#9 — F8: v0.9 MCP server (stdio) for Claude Desktop / Code](https://github.com/fadymondy/mark-it-down/issues/9)