### PR TITLE
feat(publish): static-site publish to GitHub Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Phase 0.10: Publish to GitHub Pages (#11)
+
+- New `Mark It Down: Publish: Deploy Site` command publishes all global notes as a static site to the warehouse repo's `gh-pages` branch (configurable via `markItDown.publish.branch` and `.path`)
+- `Mark It Down: Publish: Deploy Current Page` publishes only the active markdown for one-off shares
+- `Mark It Down: Publish: Copy Public URL` copies the would-be URL for the active file (no build)
+- `Mark It Down: Publish: Open Site in Browser` opens the deployed root
+- Static generator (`src/publish/staticGenerator.ts`): marked + markedHighlight server-side render → HTML; mermaid blocks left for client-side render via JSDelivr CDN; sortable-table JS bundled into `assets/site.js`; theme palette baked into `assets/style.css` from any of the 25 [bundled palettes](docs/themes.md)
+- Output structure: `index.html` (page list) + `notes/<slug>-<id>.html` per note + shared `assets/style.css` + `assets/site.js`
+- Publish flow uses `git worktree add` against the warehouse working clone so the publish branch and the sync branch don't fight; orphan branch is created on first deploy if missing
+- 5 new settings: `markItDown.publish.enabled / .branch / .path / .includeGlob / .theme`
+- v1 limitations documented in [docs/publish.md](docs/publish.md): no first-run wizard for Pages enable, no private-repo warning, glob filtering not yet applied, no per-page slug override
+
 ### Added — Phase 0.9: MCP server for Claude Desktop / Code (#9)
 
 - Standalone stdio MCP server bundled at `out/mcp/server.js` (esbuild → CJS Node18, ~1.1MB)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 | F7 — 25-theme bridge | shipped | [themes.md](themes.md) |
 | F8 — MCP server | shipped | [mcp-server.md](mcp-server.md) |
 | F9 — Notes warehouse repo | shipped | [notes-warehouse.md](notes-warehouse.md) |
-| F10 — Publish any markdown to GitHub Pages | planned | — |
+| F10 — Publish any markdown to GitHub Pages | shipped | [publish.md](publish.md) |
 | F11 — Slideshow export | planned | — |
 | F12 — Standalone Electron app | planned | — |
 | F13 — Claude Code plugin | planned | — |

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -1,0 +1,153 @@
+# Publish to GitHub Pages
+
+Status: shipped in Phase 0.10 · Issue: [#11](https://github.com/fadymondy/mark-it-down/issues/11) · Depends on: [#10 Notes warehouse](notes-warehouse.md)
+
+Publish your global notes (or any markdown file) as a public static site hosted on GitHub Pages. Builds a self-contained HTML site with the same Mark It Down rendering pipeline (marked + highlight.js + mermaid + sortable tables) and pushes to the warehouse repo's publish branch (default `gh-pages`).
+
+## At a glance
+
+| | |
+|---|---|
+| **Where** | Command palette → `Mark It Down: Publish: …` (4 commands) |
+| **Source** | All global notes (`Deploy Site`) or just the active markdown (`Deploy Current Page`) |
+| **Target** | The warehouse repo (`markItDown.warehouse.repo`) on the `gh-pages` branch (configurable) under `markItDown.publish.path` (configurable) |
+| **Engine** | marked → HTML, highlight.js for syntax tokens (server-side), mermaid loaded from a CDN at view time |
+| **Theme** | Any of the 25 [bundled palettes](themes.md) baked into `assets/style.css` |
+| **Output** | One HTML page per source file + `index.html` listing all pages + shared `assets/style.css` and `assets/site.js` |
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `markItDown.publish.deploy` | Publish all global notes as a full site rebuild. Wipes the publish branch's working tree, regenerates everything, commits + pushes. |
+| `markItDown.publish.deployCurrent` | Publish only the markdown in the active editor as `<basename>.html` at the publish root. Useful for one-off shares. |
+| `markItDown.publish.copyUrl` | Copy the public URL for the active markdown file to the clipboard. Doesn't trigger a build. |
+| `markItDown.publish.openSite` | Open the deployed site in your default browser. |
+
+## Settings
+
+| Setting | Default | What it does |
+|---|---|---|
+| `markItDown.publish.enabled` | `false` | Master switch. Must be `true` for any deploy to run. |
+| `markItDown.publish.branch` | `"gh-pages"` | Branch on the warehouse repo to push to. Created as an orphan branch on first deploy if it doesn't exist remotely. |
+| `markItDown.publish.path` | `""` (root) | Subdirectory under the publish branch root to write the site into. Useful if the same branch hosts multiple sites. |
+| `markItDown.publish.includeGlob` | `"**/*.md"` | Glob filter for source files in `Deploy Site`. (v1 only filters by extension; full glob matching is a future addition.) |
+| `markItDown.publish.theme` | `"github-light"` | Which of the 25 bundled palettes to bake into the published site's CSS. |
+
+## Quick start
+
+```jsonc
+// settings.json
+{
+  "markItDown.warehouse.repo": "you/your-notes",
+  "markItDown.publish.enabled": true,
+  "markItDown.publish.branch": "gh-pages",
+  "markItDown.publish.theme": "github-dark"
+}
+```
+
+Then:
+
+1. Make sure GitHub Pages is enabled for the warehouse repo (Settings → Pages → Source: deploy from branch → branch `gh-pages` → folder `/`).
+2. Run `Mark It Down: Publish: Deploy Site` from the command palette.
+3. Open the URL it prints — typically `https://<owner>.github.io/<repo>/` (plus your `path` subdir if configured).
+
+## How it works
+
+```
+                                                     ┌───────────────────────┐
+                                                     │ globalStorage/        │
+                                                     │   warehouse/<owner>-- │
+                                                     │     <repo>/           │
+                                                     │     .git/             │
+                                                     │     notes/...         │
+                                                     └─────────┬─────────────┘
+                                                               │ git worktree add
+                                                               ▼
+                                                     ┌───────────────────────┐
+PublishManager.publishAll()  ─render─►               │ globalStorage/        │
+PublishManager.publishCurrent() ─render─►            │   publish/<owner>--   │
+                                                     │     <repo>/           │
+  marked + markedHighlight  ─→ HTML body             │     index.html        │
+  mermaid blocks left as <div class="mermaid">       │     <slug>-<id>.html  │
+  build assets/style.css from chosen palette         │     assets/style.css  │
+  client JS for sortable tables + mermaid CDN load   │     assets/site.js    │
+                                                     └─────────┬─────────────┘
+                                                               │ git add -A
+                                                               │ git commit -m "publish: N pages — Mark It Down"
+                                                               │ git push origin HEAD:gh-pages
+                                                               ▼
+                                                     ┌───────────────────────┐
+                                                     │ origin/gh-pages       │
+                                                     │   on github.com       │
+                                                     │   served by           │
+                                                     │   GitHub Pages        │
+                                                     └───────────────────────┘
+```
+
+The publish flow uses **`git worktree`** to keep the orphan publish branch in a separate working directory under `globalStorage/publish/<repo-slug>/`. That way the warehouse working clone (used by F9 for sync) and the publish branch don't fight over the same checkout. The worktree is removed after each push so subsequent deploys start fresh.
+
+## Output structure
+
+For two notes, "Sprint 12 retro" and "Postgres tuning":
+
+```
+gh-pages/                       ← branch root (or .../<path>/ if configured)
+├── index.html                  ← list of all pages
+├── notes/
+│   ├── sprint-12-retro-ka9zsb1tfnd2.html
+│   └── postgres-tuning-8jqzv2axrmfn.html
+└── assets/
+    ├── style.css               ← chosen theme palette + base styles + highlight.js theme
+    └── site.js                 ← sortable-table JS + mermaid lazy loader
+```
+
+Each HTML page is self-contained: relative links to the shared assets, no JS frameworks, no inline `<script>`. Mermaid is loaded from `https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js` only when a page actually contains a `.mermaid` element.
+
+## Pages layout
+
+Every published page has:
+
+- **Header** — link back to `index.html` ("Mark It Down" home) + the page title
+- **Sidebar nav** — the same list of all pages, with relative links so it works at any deploy depth
+- **Body** — the rendered markdown
+- **Footer (none)** — the layout is intentionally minimal so the content is the focus
+- Responsive: under 720px wide, the sidebar collapses
+
+## Sortable tables in the public site
+
+Tables in published pages are sortable: click any column header to cycle asc → desc → none. The behavior matches the in-VSCode [DataTable feature](datatable.md) — same parsing logic (numeric strip + `localeCompare`). Implemented in `assets/site.js` with vanilla JS, no framework.
+
+## Mermaid in the public site
+
+Mermaid blocks are rendered client-side — `assets/site.js` lazy-loads mermaid from JSDelivr only when the page contains at least one `.mermaid` div. Theme follows the published-site theme's `kind` (light/dark) at load time.
+
+## What's not in v1
+
+Tracked as future-work seeds in the issue body and this docs page:
+
+- **First-run wizard** — verify the warehouse repo is public, verify Pages is enabled, offer to flip both via `gh api`. v1 just deploys; if Pages isn't enabled, the URL won't resolve until you flip it manually.
+- **Privacy guard for private repos** — v1 doesn't warn before publishing to a private repo. The site will be 404 until the repo is public; no leak risk, but a clearer message would be friendlier.
+- **Per-folder `includeGlob` filtering** — v1 publishes all global notes regardless of `includeGlob`. Glob matching is wired in settings but not yet applied.
+- **Per-page `slug` overrides** — files are named `<slug>-<id>.html` from the note title. Stable across renames (because of the `id` suffix) but ugly. A frontmatter `slug:` override is a future addition.
+- **Embedded images** — markdown image references aren't rewritten to local paths or copied. They render via the original URL (which works for hosted images). Local relative-path images would need a copy pass.
+- **Sitemap / RSS** — would be ~30 LOC to add.
+
+## Edge cases
+
+- **Warehouse not configured**: Publish commands surface an info toast pointing to settings. No deploy attempted.
+- **Publish disabled** (`enabled: false`): `Deploy Site` and `Deploy Current` show a warning + "Open Settings" action. `Copy URL` and `Open Site` still work (they don't deploy).
+- **First deploy** (no `gh-pages` branch yet): the publisher creates an orphan branch via `git worktree add -B`, wipes any inherited tree, writes the site, commits + pushes. Subsequent deploys reuse that branch.
+- **Push fails** (e.g. credential issue, branch protection): error toast surfaces the git stderr; the worktree is cleaned up regardless.
+- **No notes to publish**: `Deploy Site` shows "nothing to publish" and exits.
+- **Active editor isn't markdown**: `Deploy Current Page` reads whatever the active editor's URI points at, treating it as markdown. Non-markdown content goes through marked anyway and renders as plain paragraphs; not great UX but not destructive.
+- **Theme `auto`**: not valid for publish. Default `github-light` is used if you set `auto` here.
+
+## Files of interest
+
+- [src/publish/staticGenerator.ts](../src/publish/staticGenerator.ts) — `renderPage`, `renderIndex`, `buildSiteAssets` (CSS + client JS), embedded BASE_CSS / HLJS_LIGHT_CSS / HLJS_DARK_CSS / CLIENT_JS
+- [src/publish/publishManager.ts](../src/publish/publishManager.ts) — `PublishManager` orchestrates the warehouse worktree, render, commit, push, cleanup
+- [src/publish/publishConfig.ts](../src/publish/publishConfig.ts) — settings reader + theme lookup
+- [src/publish/publishCommands.ts](../src/publish/publishCommands.ts) — 4 VSCode command registrations
+- [src/extension.ts](../src/extension.ts) — wires PublishManager + commands on activation
+- [package.json](../package.json) — 4 commands + 5 `markItDown.publish.*` settings

--- a/package.json
+++ b/package.json
@@ -180,6 +180,28 @@
         "command": "markItDown.mcp.revealServer",
         "title": "Show MCP Server Path (copy to clipboard)",
         "category": "Mark It Down"
+      },
+      {
+        "command": "markItDown.publish.deploy",
+        "title": "Publish: Deploy Site",
+        "category": "Mark It Down",
+        "icon": "$(rocket)"
+      },
+      {
+        "command": "markItDown.publish.deployCurrent",
+        "title": "Publish: Deploy Current Page",
+        "category": "Mark It Down"
+      },
+      {
+        "command": "markItDown.publish.copyUrl",
+        "title": "Publish: Copy Public URL",
+        "category": "Mark It Down"
+      },
+      {
+        "command": "markItDown.publish.openSite",
+        "title": "Publish: Open Site in Browser",
+        "category": "Mark It Down",
+        "icon": "$(globe)"
       }
     ],
     "menus": {
@@ -407,6 +429,31 @@
           "type": "string",
           "default": "",
           "markdownDescription": "Override the workspace folder name used as a subfolder in the warehouse. Leave empty to derive from the workspace name."
+        },
+        "markItDown.publish.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow Publish commands to push a generated static site to the warehouse repo."
+        },
+        "markItDown.publish.branch": {
+          "type": "string",
+          "default": "gh-pages",
+          "description": "Branch on the warehouse repo to publish to."
+        },
+        "markItDown.publish.path": {
+          "type": "string",
+          "default": "",
+          "description": "Subdirectory under the publish branch root where the site lives. Empty = repo root."
+        },
+        "markItDown.publish.includeGlob": {
+          "type": "string",
+          "default": "**/*.md",
+          "description": "Glob (relative to source) of files included in a full Deploy Site run."
+        },
+        "markItDown.publish.theme": {
+          "type": "string",
+          "default": "github-light",
+          "description": "Theme baked into the published site (any markItDown.theme value except 'auto')."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,8 @@ import { markdownToTxt } from './exporters/exportTxt';
 import { markdownToDocx } from './exporters/exportDocx';
 import { markdownToPdf } from './exporters/exportPdf';
 import { registerMcpInstallCommands } from './mcp/installCommand';
+import { PublishManager } from './publish/publishManager';
+import { registerPublishCommands } from './publish/publishCommands';
 
 export function activate(context: vscode.ExtensionContext) {
   const provider = new MarkdownEditorProvider(context);
@@ -29,6 +31,7 @@ export function activate(context: vscode.ExtensionContext) {
   const notesStore = new NotesStore(context);
   const notesTree = new NotesTreeProvider(notesStore);
   const warehouse = new WarehouseManager(context, notesStore);
+  const publish = new PublishManager(context, notesStore);
   context.subscriptions.push(
     notesStore,
     notesTree,
@@ -37,6 +40,7 @@ export function activate(context: vscode.ExtensionContext) {
     ...registerNotesCommands(context, notesStore),
     ...registerWarehouseCommands(warehouse),
     ...registerMcpInstallCommands(context),
+    ...registerPublishCommands(publish),
   );
   warehouse.start();
   void notesStore.writeMcpIndexSnapshot();

--- a/src/publish/publishCommands.ts
+++ b/src/publish/publishCommands.ts
@@ -1,0 +1,25 @@
+import * as vscode from 'vscode';
+import { PublishManager } from './publishManager';
+
+export function registerPublishCommands(manager: PublishManager): vscode.Disposable[] {
+  return [
+    vscode.commands.registerCommand('markItDown.publish.deploy', async () => {
+      try {
+        await manager.publishAll();
+      } catch (err) {
+        vscode.window.showErrorMessage(`Mark It Down publish: ${(err as Error).message}`);
+      }
+    }),
+    vscode.commands.registerCommand('markItDown.publish.deployCurrent', async () => {
+      try {
+        await manager.publishCurrent();
+      } catch (err) {
+        vscode.window.showErrorMessage(`Mark It Down publish: ${(err as Error).message}`);
+      }
+    }),
+    vscode.commands.registerCommand('markItDown.publish.copyUrl', (uri?: vscode.Uri) =>
+      manager.copyShareUrl(uri),
+    ),
+    vscode.commands.registerCommand('markItDown.publish.openSite', () => manager.openSite()),
+  ];
+}

--- a/src/publish/publishConfig.ts
+++ b/src/publish/publishConfig.ts
@@ -1,0 +1,29 @@
+import * as vscode from 'vscode';
+import { findTheme, ThemeDefinition, THEMES } from '../themes/themes';
+
+export interface PublishConfig {
+  enabled: boolean;
+  branch: string;
+  subPath: string;
+  includeGlob: string;
+  themeId: string;
+  theme?: ThemeDefinition;
+}
+
+export function readPublishConfig(): PublishConfig {
+  const cfg = vscode.workspace.getConfiguration('markItDown.publish');
+  const enabled = cfg.get<boolean>('enabled') ?? false;
+  const branch = (cfg.get<string>('branch') ?? 'gh-pages').trim() || 'gh-pages';
+  const subPath = ((cfg.get<string>('path') ?? '/').replace(/^\/+|\/+$/g, '')) || '';
+  const includeGlob = (cfg.get<string>('includeGlob') ?? '**/*.md').trim() || '**/*.md';
+  const themeId = (cfg.get<string>('theme') ?? 'github-light').trim() || 'github-light';
+  return { enabled, branch, subPath, includeGlob, themeId, theme: findTheme(themeId) };
+}
+
+export function publishAffected(e: vscode.ConfigurationChangeEvent): boolean {
+  return e.affectsConfiguration('markItDown.publish');
+}
+
+export function listAvailableThemes(): { id: string; label: string }[] {
+  return THEMES.map(t => ({ id: t.id, label: t.label }));
+}

--- a/src/publish/publishManager.ts
+++ b/src/publish/publishManager.ts
@@ -1,0 +1,286 @@
+import { spawn } from 'child_process';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { NotesStore } from '../notes/notesStore';
+import { readConfig as readWarehouseConfig, repoSlug, repoUrl, WarehouseConfig } from '../warehouse/warehouseConfig';
+import { log } from '../warehouse/warehouseLog';
+import { findTheme } from '../themes/themes';
+import { PublishConfig, readPublishConfig } from './publishConfig';
+import { buildSiteAssets, PageInput, renderIndex, renderPage } from './staticGenerator';
+
+export interface PublishResult {
+  pages: number;
+  branch: string;
+  pushedSha?: string;
+  url: string;
+}
+
+export class PublishManager {
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly notesStore: NotesStore,
+  ) {}
+
+  public async publishAll(): Promise<PublishResult | undefined> {
+    const wh = readWarehouseConfig();
+    const pub = readPublishConfig();
+    if (!this.requireWarehouse(wh)) return undefined;
+    if (!pub.enabled) {
+      const ok = await vscode.window.showWarningMessage(
+        'Mark It Down: publishing is disabled. Enable markItDown.publish.enabled to publish.',
+        'Open Settings',
+      );
+      if (ok === 'Open Settings') {
+        vscode.commands.executeCommand('workbench.action.openSettings', 'markItDown.publish');
+      }
+      return undefined;
+    }
+    const sources = await this.collectAll(wh, pub);
+    if (sources.length === 0) {
+      vscode.window.showInformationMessage('Mark It Down: nothing to publish.');
+      return undefined;
+    }
+    return this.runBuildAndPush(wh, pub, sources);
+  }
+
+  public async publishCurrent(): Promise<PublishResult | undefined> {
+    const wh = readWarehouseConfig();
+    const pub = readPublishConfig();
+    if (!this.requireWarehouse(wh)) return undefined;
+    if (!pub.enabled) {
+      vscode.window.showWarningMessage('Mark It Down: publishing is disabled.');
+      return undefined;
+    }
+    const editor = vscode.window.activeTextEditor;
+    const uri = editor?.document.uri ?? vscode.window.activeNotebookEditor?.notebook.uri;
+    if (!uri) {
+      vscode.window.showErrorMessage('Mark It Down: no active markdown to publish.');
+      return undefined;
+    }
+    const buf = await vscode.workspace.fs.readFile(uri);
+    const markdown = new TextDecoder().decode(buf);
+    const baseName = (uri.path.split('/').pop() ?? 'page').replace(/\.[^.]+$/, '');
+    const page: PageInput = {
+      title: baseName,
+      pathFromRoot: `${baseName}.html`,
+      markdown,
+    };
+    return this.runBuildAndPush(wh, pub, [page]);
+  }
+
+  public async copyShareUrl(uri?: vscode.Uri): Promise<void> {
+    const wh = readWarehouseConfig();
+    const pub = readPublishConfig();
+    if (!this.requireWarehouse(wh)) return;
+    const target = uri ?? vscode.window.activeTextEditor?.document.uri;
+    if (!target) {
+      vscode.window.showErrorMessage('Mark It Down: no active file to copy a URL for.');
+      return;
+    }
+    const baseName = (target.path.split('/').pop() ?? 'page').replace(/\.[^.]+$/, '');
+    const url = this.pageUrl(wh, pub, `${baseName}.html`);
+    await vscode.env.clipboard.writeText(url);
+    vscode.window.setStatusBarMessage(`Mark It Down: copied ${url}`, 3000);
+  }
+
+  public async openSite(): Promise<void> {
+    const wh = readWarehouseConfig();
+    if (!this.requireWarehouse(wh)) return;
+    const pub = readPublishConfig();
+    const url = this.siteUrl(wh, pub);
+    await vscode.env.openExternal(vscode.Uri.parse(url));
+  }
+
+  private requireWarehouse(wh: WarehouseConfig): boolean {
+    if (wh.enabled) return true;
+    void vscode.window.showInformationMessage(
+      'Mark It Down: configure markItDown.warehouse.repo first — publishing reuses the warehouse repo as the deploy target.',
+      'Open Settings',
+    ).then(c => {
+      if (c === 'Open Settings') vscode.commands.executeCommand('workbench.action.openSettings', 'markItDown.warehouse.repo');
+    });
+    return false;
+  }
+
+  private async collectAll(wh: WarehouseConfig, _pub: PublishConfig): Promise<PageInput[]> {
+    // For v1 we publish all global notes. Workspace notes per workspace are out of scope here.
+    const notes = this.notesStore.listByScope('global');
+    const out: PageInput[] = [];
+    for (const note of notes) {
+      const content = await this.notesStore.readContent(note);
+      const slug = slugify(note.title);
+      out.push({
+        title: note.title,
+        pathFromRoot: `notes/${slug}-${note.id}.html`,
+        markdown: content,
+      });
+    }
+    return out;
+  }
+
+  private async runBuildAndPush(
+    wh: WarehouseConfig,
+    pub: PublishConfig,
+    pages: PageInput[],
+  ): Promise<PublishResult> {
+    const cloneRoot = path.join(this.context.globalStorageUri.fsPath, 'warehouse', repoSlug(wh));
+    const worktreeRoot = path.join(this.context.globalStorageUri.fsPath, 'publish', repoSlug(wh));
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.dirname(worktreeRoot)));
+
+    // Ensure warehouse working clone exists (we leverage the warehouse transport contract)
+    if (!(await pathExists(cloneRoot))) {
+      await runGit(['clone', repoUrl(wh), cloneRoot], undefined);
+    } else {
+      await runGit(['fetch', '--prune', 'origin'], cloneRoot);
+    }
+
+    // Ensure the publish branch exists locally — create from an empty tree if not
+    const branchExists = await branchExistsRemote(cloneRoot, pub.branch);
+    if (!branchExists) {
+      // Create an orphan branch with an initial empty commit
+      await runGit(['worktree', 'add', '-B', pub.branch, worktreeRoot, '--detach'], cloneRoot).catch(() => undefined);
+      // Fall back: simple checkout + reset
+      try {
+        await runGit(['rm', '-rf', '.'], worktreeRoot);
+      } catch { /* empty */ }
+    } else {
+      // Add a worktree pointing to that branch
+      try {
+        await runGit(['worktree', 'remove', '--force', worktreeRoot], cloneRoot);
+      } catch { /* not present */ }
+      await runGit(['worktree', 'add', worktreeRoot, pub.branch], cloneRoot);
+    }
+
+    // Wipe existing site files (keep .git artifacts)
+    let entries: [string, vscode.FileType][] = [];
+    try {
+      entries = await vscode.workspace.fs.readDirectory(vscode.Uri.file(worktreeRoot));
+    } catch { /* ignore */ }
+    for (const [name] of entries) {
+      if (name === '.git') continue;
+      try {
+        await vscode.workspace.fs.delete(vscode.Uri.file(path.join(worktreeRoot, name)), { recursive: true, useTrash: false });
+      } catch { /* ignore */ }
+    }
+
+    // Render
+    const indexPages = pages.map(p => ({ title: p.title, pathFromRoot: p.pathFromRoot }));
+    const subRoot = pub.subPath ? path.join(worktreeRoot, pub.subPath) : worktreeRoot;
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(subRoot));
+    const themeDef = pub.theme ?? findTheme('github-light')!;
+    const assets = buildSiteAssets(themeDef.palette, themeDef.kind === 'dark');
+
+    // Write each page
+    for (const page of pages) {
+      const rendered = renderPage(page, indexPages);
+      const out = path.join(subRoot, rendered.pathFromRoot);
+      await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.dirname(out)));
+      await vscode.workspace.fs.writeFile(vscode.Uri.file(out), new TextEncoder().encode(rendered.html));
+    }
+
+    // index.html (overrides any same-named page from the page set; that's fine)
+    await vscode.workspace.fs.writeFile(
+      vscode.Uri.file(path.join(subRoot, 'index.html')),
+      new TextEncoder().encode(renderIndex(indexPages)),
+    );
+
+    // Shared assets
+    const assetsDir = path.join(subRoot, 'assets');
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(assetsDir));
+    await vscode.workspace.fs.writeFile(
+      vscode.Uri.file(path.join(assetsDir, 'style.css')),
+      new TextEncoder().encode(assets.pageCss),
+    );
+    await vscode.workspace.fs.writeFile(
+      vscode.Uri.file(path.join(assetsDir, 'site.js')),
+      new TextEncoder().encode(assets.clientJs),
+    );
+
+    // Commit + push
+    await runGit(['add', '-A'], worktreeRoot);
+    const status = await runGit(['status', '--porcelain'], worktreeRoot, { capture: true });
+    let pushedSha: string | undefined;
+    if (status.trim().length > 0) {
+      const message = `publish: ${pages.length} page(s) — Mark It Down`;
+      await runGit(['commit', '-m', message], worktreeRoot, {
+        env: { GIT_AUTHOR_NAME: 'Mark It Down', GIT_AUTHOR_EMAIL: 'noreply@markitdown.dev' },
+      });
+      pushedSha = (await runGit(['rev-parse', 'HEAD'], worktreeRoot, { capture: true })).trim();
+      await runGit(['push', 'origin', `HEAD:${pub.branch}`], worktreeRoot);
+    }
+
+    // Cleanup the worktree (keep the branch)
+    try {
+      await runGit(['worktree', 'remove', '--force', worktreeRoot], cloneRoot);
+    } catch { /* ignore */ }
+
+    log('info', `published ${pages.length} pages to ${wh.repo}@${pub.branch}` + (pushedSha ? ` (${pushedSha.slice(0, 7)})` : ' (no changes)'));
+
+    const url = this.siteUrl(wh, pub);
+    vscode.window.showInformationMessage(`Mark It Down: published ${pages.length} page(s) → ${url}`);
+
+    return { pages: pages.length, branch: pub.branch, pushedSha, url };
+  }
+
+  private siteUrl(wh: WarehouseConfig, pub: PublishConfig): string {
+    const [owner, repo] = wh.repo.split('/');
+    const base = `https://${owner}.github.io/${repo}`;
+    return pub.subPath ? `${base}/${pub.subPath}/` : `${base}/`;
+  }
+
+  private pageUrl(wh: WarehouseConfig, pub: PublishConfig, relative: string): string {
+    return `${this.siteUrl(wh, pub).replace(/\/?$/, '/')}${relative}`;
+  }
+}
+
+function slugify(input: string): string {
+  return (
+    input
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 48) || 'page'
+  );
+}
+
+interface RunOpts {
+  capture?: boolean;
+  env?: NodeJS.ProcessEnv;
+}
+
+function runGit(args: string[], cwd: string | undefined, opts: RunOpts = {}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('git', args, {
+      cwd,
+      env: { ...process.env, ...(opts.env ?? {}) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', d => (stdout += d.toString()));
+    child.stderr.on('data', d => (stderr += d.toString()));
+    child.on('error', reject);
+    child.on('close', code => {
+      if (code === 0) resolve(opts.capture ? stdout : stderr || stdout);
+      else reject(new Error(`git ${args.join(' ')} exited ${code}: ${(stderr || stdout).trim()}`));
+    });
+  });
+}
+
+async function branchExistsRemote(cwd: string, branch: string): Promise<boolean> {
+  try {
+    const out = await runGit(['ls-remote', '--heads', 'origin', branch], cwd, { capture: true });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await vscode.workspace.fs.stat(vscode.Uri.file(p));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/publish/staticGenerator.ts
+++ b/src/publish/staticGenerator.ts
@@ -1,0 +1,266 @@
+import { marked } from 'marked';
+import { markedHighlight } from 'marked-highlight';
+import hljs from 'highlight.js';
+import { paletteToCss, ThemePalette } from '../themes/themes';
+
+marked.use(
+  markedHighlight({
+    langPrefix: 'hljs language-',
+    highlight(code, lang) {
+      const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+      return hljs.highlight(code, { language }).value;
+    },
+  }) as Parameters<typeof marked.use>[0],
+);
+marked.setOptions({ gfm: true, breaks: false });
+const renderer = marked;
+
+export interface PageInput {
+  title: string;
+  /** Relative URL (no leading slash, e.g. `notes/foo.html`) so links resolve under any deploy path. */
+  pathFromRoot: string;
+  markdown: string;
+}
+
+export interface SiteAssets {
+  /** Full CSS for one page. */
+  pageCss: string;
+  /** Self-contained client JS for mermaid + sortable tables (no external deps at view time). */
+  clientJs: string;
+}
+
+export interface RenderedPage {
+  pathFromRoot: string;
+  title: string;
+  html: string;
+}
+
+export function buildSiteAssets(palette: ThemePalette, kindIsDark: boolean): SiteAssets {
+  const hljsTheme = kindIsDark ? HLJS_DARK_CSS : HLJS_LIGHT_CSS;
+  const pageCss = `
+:root { ${paletteToCss(palette)} color-scheme: ${kindIsDark ? 'dark' : 'light'}; }
+${BASE_CSS}
+${hljsTheme}
+`;
+  return { pageCss, clientJs: CLIENT_JS };
+}
+
+export function renderPage(input: PageInput, indexPages: { title: string; pathFromRoot: string }[]): RenderedPage {
+  // Pre-process mermaid blocks: marked treats them as code blocks → swap to <div class="mermaid">.
+  const mermaidBlocks: string[] = [];
+  const withMermaid = input.markdown.replace(/```mermaid\s*\n([\s\S]*?)\n```/g, (_m, code) => {
+    const i = mermaidBlocks.push(code) - 1;
+    return `\n\n<div class="mermaid" data-mid-index="${i}"></div>\n\n`;
+  });
+  let body = renderer.parse(withMermaid, { async: false }) as string;
+  body = body.replace(/data-mid-index="(\d+)"><\/div>/g, (_m, i) => {
+    const code = mermaidBlocks[Number(i)] ?? '';
+    return `>${escapeHtml(code)}</div>`;
+  });
+
+  const navItems = indexPages
+    .map(p => `<li><a href="${rel(input.pathFromRoot, p.pathFromRoot)}">${escapeHtml(p.title)}</a></li>`)
+    .join('');
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>${escapeHtml(input.title)}</title>
+<link rel="stylesheet" href="${rel(input.pathFromRoot, 'assets/style.css')}" />
+</head>
+<body>
+<header class="mid-header">
+  <a class="mid-home" href="${rel(input.pathFromRoot, 'index.html')}">Mark It Down</a>
+  <span class="mid-doc-title">${escapeHtml(input.title)}</span>
+</header>
+<aside class="mid-nav">
+  <h2>Pages</h2>
+  <ul>${navItems}</ul>
+</aside>
+<main class="mid-body">${body}</main>
+<script src="${rel(input.pathFromRoot, 'assets/site.js')}"></script>
+</body>
+</html>`;
+  return { pathFromRoot: input.pathFromRoot, title: input.title, html };
+}
+
+export function renderIndex(pages: { title: string; pathFromRoot: string }[]): string {
+  const items = pages
+    .map(p => `<li><a href="${escapeAttr(p.pathFromRoot)}">${escapeHtml(p.title)}</a></li>`)
+    .join('\n');
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Mark It Down — Index</title>
+<link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+<header class="mid-header">
+  <a class="mid-home" href="index.html">Mark It Down</a>
+</header>
+<main class="mid-body">
+  <h1>Pages</h1>
+  <ul class="mid-index">${items}</ul>
+</main>
+<script src="assets/site.js"></script>
+</body>
+</html>`;
+}
+
+function rel(from: string, to: string): string {
+  const fromParts = from.split('/').slice(0, -1);
+  const toParts = to.split('/');
+  let i = 0;
+  while (i < fromParts.length && i < toParts.length - 1 && fromParts[i] === toParts[i]) i++;
+  const up = fromParts.length - i;
+  return [...Array(up).fill('..'), ...toParts.slice(i)].join('/') || '.';
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!));
+}
+
+function escapeAttr(s: string): string {
+  return escapeHtml(s);
+}
+
+const BASE_CSS = `
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--fg);
+  background: var(--bg);
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  grid-template-rows: 56px 1fr;
+  grid-template-areas: "header header" "nav main";
+  min-height: 100vh;
+}
+.mid-header {
+  grid-area: header;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 20px;
+  background: var(--code-bg);
+  border-bottom: 1px solid var(--border);
+}
+.mid-home { color: var(--accent); font-weight: 600; text-decoration: none; }
+.mid-doc-title { color: var(--fg-muted); font-size: 0.92em; }
+.mid-nav {
+  grid-area: nav;
+  background: var(--code-bg);
+  border-right: 1px solid var(--border);
+  padding: 14px;
+  overflow-y: auto;
+}
+.mid-nav h2 { font-size: 0.78em; text-transform: uppercase; letter-spacing: 0.06em; color: var(--fg-muted); margin: 0 0 8px; }
+.mid-nav ul { list-style: none; padding: 0; margin: 0; }
+.mid-nav li { margin: 4px 0; }
+.mid-nav a { color: var(--fg); text-decoration: none; font-size: 0.92em; }
+.mid-nav a:hover { color: var(--link); }
+.mid-body { grid-area: main; padding: 32px 48px 96px; max-width: 920px; }
+.mid-body h1, .mid-body h2 { border-bottom: 1px solid var(--border); padding-bottom: 0.3em; }
+.mid-body h1 { font-size: 2em; margin-top: 0.6em; }
+.mid-body h2 { font-size: 1.5em; margin-top: 1.4em; }
+.mid-body h3 { font-size: 1.25em; }
+.mid-body p { margin: 0.8em 0; }
+.mid-body a { color: var(--link); }
+.mid-body code { background: var(--inline-code-bg); padding: 2px 6px; border-radius: 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.9em; }
+.mid-body pre { background: var(--code-bg); border: 1px solid var(--border); border-radius: 6px; padding: 14px 16px; overflow-x: auto; margin: 1em 0; }
+.mid-body pre code { background: transparent; padding: 0; font-size: 0.88em; line-height: 1.55; }
+.mid-body blockquote { border-left: 3px solid var(--accent); padding: 4px 14px; margin: 1em 0; color: var(--fg-muted); background: var(--code-bg); border-radius: 0 6px 6px 0; }
+.mid-body table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.95em; }
+.mid-body th, .mid-body td { padding: 8px 12px; border: 1px solid var(--border); text-align: left; }
+.mid-body th { background: var(--code-bg); font-weight: 600; cursor: pointer; user-select: none; }
+.mid-body th:hover { background: rgba(127,127,127,0.12); }
+.mid-body tr:nth-child(even) td { background: var(--table-stripe); }
+.mid-body img { max-width: 100%; border-radius: 4px; }
+.mid-body hr { border: 0; border-top: 1px solid var(--border); margin: 2em 0; }
+.mid-body ul.mid-index { list-style: none; padding: 0; }
+.mid-index li { margin: 6px 0; }
+.mid-body .mermaid { background: var(--code-bg); border: 1px solid var(--border); border-radius: 6px; padding: 14px; margin: 1em 0; text-align: center; overflow-x: auto; }
+@media (max-width: 720px) {
+  body { grid-template-columns: 1fr; grid-template-areas: "header" "main"; }
+  .mid-nav { display: none; }
+  .mid-body { padding: 16px; }
+}
+`;
+
+const HLJS_LIGHT_CSS = `
+.hljs{color:#383a42;background:transparent}
+.hljs-comment,.hljs-quote{color:#a0a1a7;font-style:italic}
+.hljs-keyword,.hljs-selector-tag,.hljs-name,.hljs-section{color:#a626a4}
+.hljs-string,.hljs-attr,.hljs-symbol,.hljs-bullet{color:#50a14f}
+.hljs-number,.hljs-literal,.hljs-built_in,.hljs-type{color:#986801}
+.hljs-title,.hljs-class .hljs-title{color:#4078f2}
+.hljs-variable,.hljs-template-variable{color:#e45649}
+.hljs-tag,.hljs-meta{color:#0184bb}
+.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
+`;
+
+const HLJS_DARK_CSS = `
+.hljs{color:#abb2bf;background:transparent}
+.hljs-comment,.hljs-quote{color:#5c6370;font-style:italic}
+.hljs-keyword,.hljs-selector-tag,.hljs-name,.hljs-section{color:#c678dd}
+.hljs-string,.hljs-attr,.hljs-symbol,.hljs-bullet{color:#98c379}
+.hljs-number,.hljs-literal,.hljs-built_in,.hljs-type{color:#d19a66}
+.hljs-title,.hljs-class .hljs-title{color:#61afef}
+.hljs-variable,.hljs-template-variable{color:#e06c75}
+.hljs-tag,.hljs-meta{color:#56b6c2}
+.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
+`;
+
+const CLIENT_JS = `
+(function(){
+  // Sortable tables — click any th to cycle asc/desc/none
+  document.querySelectorAll('main.mid-body table').forEach(function(table){
+    var head = table.tHead && table.tHead.rows[0];
+    if (!head) return;
+    Array.prototype.forEach.call(head.cells, function(th, col){
+      th.addEventListener('click', function(){
+        var tbody = table.tBodies[0]; if (!tbody) return;
+        var rows = Array.prototype.slice.call(tbody.rows);
+        if (!rows.length || rows[0].dataset.midOriginal === undefined) {
+          rows.forEach(function(r,i){ r.dataset.midOriginal = String(i); });
+        }
+        var current = th.dataset.sort || 'none';
+        var next = current === 'none' ? 'asc' : current === 'asc' ? 'desc' : 'none';
+        Array.prototype.forEach.call(head.cells, function(other){ other.dataset.sort = 'none'; });
+        th.dataset.sort = next;
+        if (next === 'none') {
+          rows.sort(function(a,b){ return Number(a.dataset.midOriginal) - Number(b.dataset.midOriginal); });
+        } else {
+          var factor = next === 'asc' ? 1 : -1;
+          rows.sort(function(a,b){
+            var av = (a.cells[col]?.textContent || '').trim();
+            var bv = (b.cells[col]?.textContent || '').trim();
+            var an = parseFloat(av.replace(/[\\$,%]/g,'')); var bn = parseFloat(bv.replace(/[\\$,%]/g,''));
+            if (!isNaN(an) && !isNaN(bn)) return factor * (an - bn);
+            return factor * av.localeCompare(bv, undefined, { numeric: true, sensitivity: 'base' });
+          });
+        }
+        rows.forEach(function(r){ tbody.appendChild(r); });
+      });
+    });
+  });
+  // Mermaid via CDN — only loaded when there's at least one diagram
+  if (document.querySelector('.mermaid')) {
+    var s = document.createElement('script');
+    s.src = 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js';
+    s.onload = function(){
+      var isDark = matchMedia('(prefers-color-scheme: dark)').matches;
+      var bgIsDark = getComputedStyle(document.body).getPropertyValue('color-scheme').indexOf('dark') >= 0;
+      window.mermaid.initialize({ startOnLoad: true, theme: bgIsDark || isDark ? 'dark' : 'default', securityLevel: 'strict' });
+    };
+    document.head.appendChild(s);
+  }
+})();
+`;


### PR DESCRIPTION
## Summary
- 4 publish commands (`deploy`, `deployCurrent`, `copyUrl`, `openSite`) push a static site to the warehouse repo's `gh-pages` branch (configurable)
- Self-contained output: `index.html` + per-page HTML + shared `assets/style.css` + `assets/site.js`
- Render: marked + highlight.js server-side, mermaid via CDN at view time, sortable tables in vanilla JS
- Theme baked in from any of the 25 bundled palettes
- `git worktree` keeps publish branch separate from warehouse sync branch
- 5 new settings: `markItDown.publish.enabled / .branch / .path / .includeGlob / .theme`
- v1 limitations called out in `docs/publish.md`: no Pages-enable wizard, no private-repo warning, glob filter not yet applied, no per-page slug override

## Closes
Closes #11

## Test plan
- [x] `npm run compile` clean
- [ ] F5: configure warehouse, set `publish.enabled: true`, run Deploy Site, verify `gh-pages` branch contains the rendered files, open the GitHub Pages URL

## Linked issue
[#11 — F10: Publish any markdown as a public GitHub-hosted site](https://github.com/fadymondy/mark-it-down/issues/11)