### PR TITLE
feat(slideshow): reveal.js slideshow preview + publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Phase 0.11: Slideshow export (#12)
+
+- Convert any markdown into a [reveal.js](https://revealjs.com) slideshow — `---` for horizontal slide breaks, `--` for vertical sub-slides, optional YAML frontmatter for `theme` / `transition` / `title` / `speakerNotes`
+- `Mark It Down: Slideshow: Preview Local` opens a webview panel beside the editor with reveal.js + mermaid + highlight.js loaded from JSDelivr at view time (CSP relaxed scoped to that panel only)
+- `Mark It Down: Slideshow: Publish` reuses the F10 publish pipeline — pushes a single self-contained HTML to `<publish-branch>/<publish-path>/slides/<basename>.html`, surfaces an info toast with Open / Copy URL actions
+- `Mark It Down: Slideshow: Copy Share URL` and `Slideshow: Export to PDF` (the PDF command currently surfaces a defer-notice pointing at reveal's built-in `?print-pdf` browser print mode)
+- 3 new settings: `markItDown.slideshow.theme` (12 reveal themes), `.transition` (6 styles), `.includeSpeakerNotes`
+- `Notes:` block at the end of any slide body becomes reveal speaker notes (`<aside class="notes">`)
+- Mermaid + code highlighting work in slides via the same render pipeline as the rest of Mark It Down
+
 ### Added — Phase 0.10: Publish to GitHub Pages (#11)
 
 - New `Mark It Down: Publish: Deploy Site` command publishes all global notes as a static site to the warehouse repo's `gh-pages` branch (configurable via `markItDown.publish.branch` and `.path`)

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 | F8 — MCP server | shipped | [mcp-server.md](mcp-server.md) |
 | F9 — Notes warehouse repo | shipped | [notes-warehouse.md](notes-warehouse.md) |
 | F10 — Publish any markdown to GitHub Pages | shipped | [publish.md](publish.md) |
-| F11 — Slideshow export | planned | — |
+| F11 — Slideshow export | shipped | [slideshow.md](slideshow.md) |
 | F12 — Standalone Electron app | planned | — |
 | F13 — Claude Code plugin | planned | — |
 

--- a/docs/slideshow.md
+++ b/docs/slideshow.md
@@ -1,0 +1,138 @@
+# Slideshow Export
+
+Status: shipped in Phase 0.11 · Issue: [#12](https://github.com/fadymondy/mark-it-down/issues/12) · Depends on: [#11 Publish to GitHub Pages](publish.md)
+
+Convert any markdown file into a [reveal.js](https://revealjs.com) slideshow — preview locally inside a VSCode webview, or publish to the warehouse repo's pages branch and share a public URL. Slide breaks come from the standard `---` markdown HR (which doubles as reveal.js's slide separator); vertical slides use `--`.
+
+## At a glance
+
+| | |
+|---|---|
+| **Engine** | reveal.js v5 (loaded from JSDelivr at view time — no bundle bloat) |
+| **Slide breaks** | `---` (horizontal), `--` (vertical / nested) |
+| **Frontmatter** | YAML-style at top of file: `theme`, `transition`, `title`, `speakerNotes` |
+| **Local preview** | `Mark It Down: Slideshow: Preview Local` opens a webview panel beside the editor |
+| **Publish** | `Mark It Down: Slideshow: Publish` reuses the F10 publish pipeline; pushes a single HTML to `<publish-branch>/<publish-path>/slides/<basename>.html` |
+| **Speaker notes** | `Notes:` line in a slide body — everything after becomes `<aside class="notes">` |
+
+## Authoring
+
+A minimal slide deck:
+
+````markdown
+---
+title: My talk
+theme: night
+transition: fade
+---
+
+# Welcome
+
+A subtitle line
+
+---
+
+## Section heading
+
+- bullet one
+- bullet two
+
+--
+
+## A vertical sub-slide
+
+This appears below the previous one when navigating with arrow-down.
+
+---
+
+## Code
+
+```ts
+console.log('hello');
+```
+
+Notes:
+This is a speaker note. It only shows in the speaker view (press `s` in reveal.js).
+````
+
+That's a 4-slide deck (one is a vertical sub-slide).
+
+## Local preview
+
+`Mark It Down: Slideshow: Preview Local` opens a webview panel beside the editor and renders the deck. Standard reveal.js controls apply — arrow keys, `f` for fullscreen, `s` for speaker view, `o` for the overview grid, `?` for the help cheatsheet.
+
+The preview panel uses a permissive CSP (loads reveal.js, mermaid, highlight.js CSS from JSDelivr at view time). The CSP relaxation is **scoped to the slideshow panel only** — the main custom editor's CSP stays strict.
+
+The preview is a one-shot render — edit the markdown and re-run the command to see updates. Live reload on save is a future-work seed.
+
+## Publish
+
+`Mark It Down: Slideshow: Publish`:
+
+1. Renders the active markdown with the configured theme/transition.
+2. Reuses the F10 publish pipeline's git-worktree-against-warehouse approach.
+3. Pushes the rendered HTML to `<publish-branch>/<publish-path>/slides/<basename>.html` (defaults: `gh-pages`, root, slugified file basename).
+4. Surfaces an info toast with `Open` and `Copy URL` actions.
+
+Requires both `markItDown.warehouse.repo` and `markItDown.publish.enabled` to be set — slideshow publish is a layered feature on top of F9 + F10.
+
+## Settings
+
+| Setting | Default | What it does |
+|---|---|---|
+| `markItDown.slideshow.theme` | `"black"` | Reveal.js theme. Built-ins: `black, white, league, beige, night, serif, simple, solarized, moon, dracula, sky, blood`. Frontmatter `theme:` overrides per-deck. |
+| `markItDown.slideshow.transition` | `"slide"` | `none / fade / slide / convex / concave / zoom`. Frontmatter `transition:` overrides per-deck. |
+| `markItDown.slideshow.includeSpeakerNotes` | `true` | Render lines after `Notes:` as reveal speaker notes. |
+
+## Frontmatter reference
+
+A YAML-ish block at the very top of the markdown file (between two `---` lines) sets per-deck options. Recognized keys:
+
+| Key | Type | Default |
+|---|---|---|
+| `title` | string | filename basename |
+| `theme` | string | settings value (`black`) |
+| `transition` | string | settings value (`slide`) |
+| `speakerNotes` | boolean | settings value (`true`) |
+
+Unknown keys are ignored.
+
+## Speaker notes
+
+Anywhere in a slide body, a line starting with `Notes:` flips everything after it into the slide's speaker notes. They show in reveal's speaker view (`s` key) — never in the main slide.
+
+```markdown
+## Slide title
+
+The visible body.
+
+Notes:
+- Mention the customer story
+- Don't forget to pause for the demo
+```
+
+## Mermaid + code highlighting in slides
+
+- **Mermaid**: any ` ```mermaid ` block becomes a `<div class="mermaid">` in the rendered slide; mermaid loads from CDN at view time and renders with the matching theme (dark for dark reveal themes, default otherwise).
+- **Code blocks**: highlight.js's `atom-one-dark` theme is loaded from CDN. The reveal.js highlight plugin can be added later for per-line stepping.
+
+## PDF export
+
+The `Slideshow: Export to PDF` command currently surfaces an info message pointing at reveal.js's built-in PDF print mode — append `?print-pdf` to the published URL and use the browser's "Save as PDF" Print dialog. Bundling a headless chromium for in-process PDF generation is out of scope (would push the .vsix size past 150MB). Tracked as future work.
+
+## Edge cases
+
+- **No `---` separators**: the whole file becomes one slide. Useful for single-slide quick previews.
+- **Frontmatter without closing `---`**: not detected; the leading `---` becomes a slide break and the would-be frontmatter renders as the first slide. Make sure the closing `---` is on its own line followed by `\n`.
+- **Markdown HR vs slide break ambiguity**: any `---` on its own line between two blank lines becomes a slide break. Inline HRs (e.g. inside a list) are not affected.
+- **Publish without warehouse / publish disabled**: surfaces a clear message with an Open Settings action.
+- **Cross-deck shared assets**: each slideshow ships with its own CDN references; nothing is shared between published slideshows. This means each one is fully self-contained.
+- **CSP**: the local preview uses a permissive CSP scoped to the slideshow panel. The main custom editor's strict CSP is unchanged.
+
+## Files of interest
+
+- [src/slideshow/slideshowGenerator.ts](../src/slideshow/slideshowGenerator.ts) — `buildSlideshow` parses frontmatter, splits slides, renders each via marked, wraps in reveal.js HTML; `template()` emits the full HTML page with reveal.js + mermaid + highlight.js loaded from JSDelivr
+- [src/slideshow/slideshowManager.ts](../src/slideshow/slideshowManager.ts) — `previewLocal` (webview panel), `publish` (warehouse worktree + write + commit + push), `copyShareUrl`, `exportPdf` (defer notice)
+- [src/slideshow/slideshowCommands.ts](../src/slideshow/slideshowCommands.ts) — 4 VSCode command registrations
+- [src/extension.ts](../src/extension.ts) — wires SlideshowManager + commands on activation
+- [package.json](../package.json) — 4 commands + 3 `markItDown.slideshow.*` settings

--- a/package.json
+++ b/package.json
@@ -202,6 +202,27 @@
         "title": "Publish: Open Site in Browser",
         "category": "Mark It Down",
         "icon": "$(globe)"
+      },
+      {
+        "command": "markItDown.slideshow.previewLocal",
+        "title": "Slideshow: Preview Local",
+        "category": "Mark It Down",
+        "icon": "$(play)"
+      },
+      {
+        "command": "markItDown.slideshow.publish",
+        "title": "Slideshow: Publish",
+        "category": "Mark It Down"
+      },
+      {
+        "command": "markItDown.slideshow.copyShareUrl",
+        "title": "Slideshow: Copy Share URL",
+        "category": "Mark It Down"
+      },
+      {
+        "command": "markItDown.slideshow.exportPdf",
+        "title": "Slideshow: Export to PDF",
+        "category": "Mark It Down"
       }
     ],
     "menus": {
@@ -454,6 +475,23 @@
           "type": "string",
           "default": "github-light",
           "description": "Theme baked into the published site (any markItDown.theme value except 'auto')."
+        },
+        "markItDown.slideshow.theme": {
+          "type": "string",
+          "default": "black",
+          "enum": ["black", "white", "league", "beige", "night", "serif", "simple", "solarized", "moon", "dracula", "sky", "blood"],
+          "description": "Reveal.js theme used by the slideshow preview and published slides."
+        },
+        "markItDown.slideshow.transition": {
+          "type": "string",
+          "default": "slide",
+          "enum": ["none", "fade", "slide", "convex", "concave", "zoom"],
+          "description": "Slide-to-slide transition style."
+        },
+        "markItDown.slideshow.includeSpeakerNotes": {
+          "type": "boolean",
+          "default": true,
+          "description": "Render lines after a `Notes:` block on each slide as Reveal speaker notes."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,8 @@ import { markdownToPdf } from './exporters/exportPdf';
 import { registerMcpInstallCommands } from './mcp/installCommand';
 import { PublishManager } from './publish/publishManager';
 import { registerPublishCommands } from './publish/publishCommands';
+import { SlideshowManager } from './slideshow/slideshowManager';
+import { registerSlideshowCommands } from './slideshow/slideshowCommands';
 
 export function activate(context: vscode.ExtensionContext) {
   const provider = new MarkdownEditorProvider(context);
@@ -32,6 +34,7 @@ export function activate(context: vscode.ExtensionContext) {
   const notesTree = new NotesTreeProvider(notesStore);
   const warehouse = new WarehouseManager(context, notesStore);
   const publish = new PublishManager(context, notesStore);
+  const slideshow = new SlideshowManager(context);
   context.subscriptions.push(
     notesStore,
     notesTree,
@@ -41,6 +44,7 @@ export function activate(context: vscode.ExtensionContext) {
     ...registerWarehouseCommands(warehouse),
     ...registerMcpInstallCommands(context),
     ...registerPublishCommands(publish),
+    ...registerSlideshowCommands(slideshow),
   );
   warehouse.start();
   void notesStore.writeMcpIndexSnapshot();

--- a/src/slideshow/slideshowCommands.ts
+++ b/src/slideshow/slideshowCommands.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+import { SlideshowManager } from './slideshowManager';
+
+export function registerSlideshowCommands(manager: SlideshowManager): vscode.Disposable[] {
+  return [
+    vscode.commands.registerCommand('markItDown.slideshow.previewLocal', () => manager.previewLocal()),
+    vscode.commands.registerCommand('markItDown.slideshow.publish', () => manager.publish()),
+    vscode.commands.registerCommand('markItDown.slideshow.copyShareUrl', () => manager.copyShareUrl()),
+    vscode.commands.registerCommand('markItDown.slideshow.exportPdf', () => manager.exportPdf()),
+  ];
+}

--- a/src/slideshow/slideshowGenerator.ts
+++ b/src/slideshow/slideshowGenerator.ts
@@ -1,0 +1,180 @@
+import { marked } from 'marked';
+import { markedHighlight } from 'marked-highlight';
+import hljs from 'highlight.js';
+
+marked.use(
+  markedHighlight({
+    langPrefix: 'hljs language-',
+    highlight(code, lang) {
+      const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+      return hljs.highlight(code, { language }).value;
+    },
+  }) as Parameters<typeof marked.use>[0],
+);
+
+export interface SlideshowFrontmatter {
+  title?: string;
+  theme?: string;
+  transition?: string;
+  speakerNotes?: boolean;
+}
+
+export interface SlideshowBuildInput {
+  markdown: string;
+  /** Title used in <title> if frontmatter doesn't provide one. */
+  fallbackTitle: string;
+}
+
+export interface SlideshowOptions {
+  /** Reveal.js theme — defaults to 'black'. */
+  theme: string;
+  /** none / fade / slide / convex / concave / zoom — defaults to 'slide'. */
+  transition: string;
+  /** Render speaker notes from `Notes:` blocks at the end of each slide body. */
+  speakerNotes: boolean;
+}
+
+export const DEFAULT_OPTIONS: SlideshowOptions = {
+  theme: 'black',
+  transition: 'slide',
+  speakerNotes: true,
+};
+
+export interface BuiltSlideshow {
+  title: string;
+  html: string;
+  slideCount: number;
+  options: SlideshowOptions;
+}
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n/;
+const SLIDE_BREAK_RE = /\n\s*---\s*\n/;
+const VERTICAL_BREAK_RE = /\n\s*--\s*\n/;
+const NOTES_RE = /\n\s*Notes:\s*\n([\s\S]+)$/i;
+
+export function buildSlideshow(input: SlideshowBuildInput, base: SlideshowOptions = DEFAULT_OPTIONS): BuiltSlideshow {
+  const { frontmatter, body } = parseFrontmatter(input.markdown);
+  const options: SlideshowOptions = {
+    theme: frontmatter.theme ?? base.theme,
+    transition: frontmatter.transition ?? base.transition,
+    speakerNotes: frontmatter.speakerNotes ?? base.speakerNotes,
+  };
+  const title = frontmatter.title ?? input.fallbackTitle;
+
+  const horizontals = body.split(SLIDE_BREAK_RE);
+  const slides = horizontals.map(h => {
+    const verticals = h.split(VERTICAL_BREAK_RE);
+    return verticals.map(renderSlideMarkdown);
+  });
+
+  const sections = slides
+    .map(group => {
+      if (group.length === 1) return `<section>${group[0]}</section>`;
+      return `<section>${group.map(s => `<section>${s}</section>`).join('')}</section>`;
+    })
+    .join('\n');
+
+  const total = slides.flat().length;
+
+  const html = template(title, options, sections);
+  return { title, html, slideCount: total, options };
+}
+
+function renderSlideMarkdown(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return '';
+  const notesMatch = trimmed.match(NOTES_RE);
+  let main = trimmed;
+  let notes = '';
+  if (notesMatch) {
+    main = trimmed.slice(0, notesMatch.index).trim();
+    notes = notesMatch[1].trim();
+  }
+  // Pre-process mermaid blocks
+  const mermaidBlocks: string[] = [];
+  const withMermaid = main.replace(/```mermaid\s*\n([\s\S]*?)\n```/g, (_m, code) => {
+    const i = mermaidBlocks.push(code) - 1;
+    return `\n\n<div class="mermaid" data-mid-index="${i}"></div>\n\n`;
+  });
+  let body = marked.parse(withMermaid, { async: false }) as string;
+  body = body.replace(/data-mid-index="(\d+)"><\/div>/g, (_m, i) => {
+    return `>${escapeHtml(mermaidBlocks[Number(i)] ?? '')}</div>`;
+  });
+  if (notes) {
+    body += `<aside class="notes">${escapeHtml(notes).replace(/\n/g, '<br/>')}</aside>`;
+  }
+  return body;
+}
+
+function parseFrontmatter(md: string): { frontmatter: SlideshowFrontmatter; body: string } {
+  const match = md.match(FRONTMATTER_RE);
+  if (!match) return { frontmatter: {}, body: md };
+  const raw = match[1];
+  const fm: SlideshowFrontmatter = {};
+  for (const line of raw.split(/\n/)) {
+    const m = line.match(/^([A-Za-z][A-Za-z0-9_]*)\s*:\s*(.*)$/);
+    if (!m) continue;
+    const key = m[1];
+    let value: string | boolean = m[2].trim().replace(/^"|"$/g, '').replace(/^'|'$/g, '');
+    if (value === 'true') value = true;
+    else if (value === 'false') value = false;
+    if (key === 'title' && typeof value === 'string') fm.title = value;
+    else if (key === 'theme' && typeof value === 'string') fm.theme = value;
+    else if (key === 'transition' && typeof value === 'string') fm.transition = value;
+    else if (key === 'speakerNotes' && typeof value === 'boolean') fm.speakerNotes = value;
+  }
+  return { frontmatter: fm, body: md.slice(match[0].length) };
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!));
+}
+
+function template(title: string, opts: SlideshowOptions, sections: string): string {
+  const themeUrl = `https://cdn.jsdelivr.net/npm/reveal.js@5/dist/theme/${escapeAttr(opts.theme)}.css`;
+  const revealCss = 'https://cdn.jsdelivr.net/npm/reveal.js@5/dist/reveal.css';
+  const revealJs = 'https://cdn.jsdelivr.net/npm/reveal.js@5/dist/reveal.js';
+  const notesPlugin = 'https://cdn.jsdelivr.net/npm/reveal.js@5/plugin/notes/notes.js';
+  const highlightCss = 'https://cdn.jsdelivr.net/npm/highlight.js@11/styles/atom-one-dark.min.css';
+  const mermaidJs = 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js';
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+<title>${escapeHtml(title)}</title>
+<link rel="stylesheet" href="${revealCss}" />
+<link rel="stylesheet" href="${themeUrl}" id="theme" />
+<link rel="stylesheet" href="${highlightCss}" />
+<style>
+  .reveal pre { box-shadow: none; }
+  .reveal .mermaid { background: rgba(255,255,255,0.04); border-radius: 8px; padding: 12px; }
+</style>
+</head>
+<body>
+<div class="reveal"><div class="slides">${sections}</div></div>
+<script src="${revealJs}"></script>
+<script src="${notesPlugin}"></script>
+<script src="${mermaidJs}"></script>
+<script>
+  Reveal.initialize({
+    hash: true,
+    transition: ${JSON.stringify(opts.transition)},
+    plugins: [RevealNotes],
+  });
+  if (window.mermaid) {
+    var isDark = ${JSON.stringify(isDarkTheme(opts.theme))};
+    mermaid.initialize({ startOnLoad: true, theme: isDark ? 'dark' : 'default', securityLevel: 'strict' });
+  }
+</script>
+</body>
+</html>`;
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/[^A-Za-z0-9_-]/g, '');
+}
+
+function isDarkTheme(name: string): boolean {
+  return ['black', 'night', 'blood', 'moon', 'dracula', 'league'].includes(name);
+}

--- a/src/slideshow/slideshowManager.ts
+++ b/src/slideshow/slideshowManager.ts
@@ -1,0 +1,242 @@
+import { spawn } from 'child_process';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { readConfig as readWarehouseConfig, repoSlug, repoUrl, WarehouseConfig } from '../warehouse/warehouseConfig';
+import { readPublishConfig } from '../publish/publishConfig';
+import { buildSlideshow, DEFAULT_OPTIONS, SlideshowOptions } from './slideshowGenerator';
+
+export class SlideshowManager {
+  constructor(private readonly context: vscode.ExtensionContext) {}
+
+  public async previewLocal(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showErrorMessage('Mark It Down: open a markdown file to preview as slideshow.');
+      return;
+    }
+    const built = buildSlideshow(
+      { markdown: editor.document.getText(), fallbackTitle: this.titleFor(editor.document.uri) },
+      this.optionsFromSettings(),
+    );
+    const panel = vscode.window.createWebviewPanel(
+      'markItDown.slideshow',
+      `Slideshow — ${built.title}`,
+      vscode.ViewColumn.Beside,
+      { enableScripts: true, retainContextWhenHidden: true },
+    );
+    // The slideshow HTML loads reveal/mermaid from CDNs. Allow https:// in img/style/script via a permissive CSP for the preview panel only.
+    panel.webview.html = built.html.replace(
+      '<head>',
+      `<head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self' https: 'unsafe-inline'; script-src 'self' https: 'unsafe-inline' 'unsafe-eval'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src https:;">`,
+    );
+    vscode.window.setStatusBarMessage(
+      `Mark It Down: previewing ${built.slideCount} slide(s) — theme=${built.options.theme}`,
+      4000,
+    );
+  }
+
+  public async publish(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showErrorMessage('Mark It Down: open a markdown file to publish as slideshow.');
+      return;
+    }
+    const wh = readWarehouseConfig();
+    const pub = readPublishConfig();
+    if (!wh.enabled) {
+      this.warnNoWarehouse();
+      return;
+    }
+    if (!pub.enabled) {
+      vscode.window.showWarningMessage(
+        'Mark It Down: enable markItDown.publish.enabled to publish — slideshow publish reuses the same pipeline.',
+      );
+      return;
+    }
+    const built = buildSlideshow(
+      { markdown: editor.document.getText(), fallbackTitle: this.titleFor(editor.document.uri) },
+      this.optionsFromSettings(),
+    );
+    const baseName = (editor.document.uri.path.split('/').pop() ?? 'slides').replace(/\.[^.]+$/, '');
+    const relPath = `slides/${slugify(baseName)}.html`;
+
+    try {
+      const sha = await this.pushHtml(wh, pub.branch, pub.subPath, relPath, built.html);
+      const url = this.publicUrl(wh, pub.branch, pub.subPath, relPath);
+      const action = await vscode.window.showInformationMessage(
+        `Mark It Down: slideshow published${sha ? ` (${sha.slice(0, 7)})` : ''} → ${url}`,
+        'Open',
+        'Copy URL',
+      );
+      if (action === 'Open') {
+        await vscode.env.openExternal(vscode.Uri.parse(url));
+      } else if (action === 'Copy URL') {
+        await vscode.env.clipboard.writeText(url);
+      }
+    } catch (err) {
+      vscode.window.showErrorMessage(`Mark It Down slideshow publish: ${(err as Error).message}`);
+    }
+  }
+
+  public async copyShareUrl(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showErrorMessage('Mark It Down: open a markdown file to copy a slideshow URL.');
+      return;
+    }
+    const wh = readWarehouseConfig();
+    const pub = readPublishConfig();
+    if (!wh.enabled) {
+      this.warnNoWarehouse();
+      return;
+    }
+    const baseName = (editor.document.uri.path.split('/').pop() ?? 'slides').replace(/\.[^.]+$/, '');
+    const url = this.publicUrl(wh, pub.branch, pub.subPath, `slides/${slugify(baseName)}.html`);
+    await vscode.env.clipboard.writeText(url);
+    vscode.window.setStatusBarMessage(`Mark It Down: copied ${url}`, 3000);
+  }
+
+  public async exportPdf(): Promise<void> {
+    const url = await vscode.window.showInformationMessage(
+      'Mark It Down: PDF export of slideshow is deferred to a future release. ' +
+        'For now, publish the slideshow and use your browser\'s reveal.js PDF print mode (append `?print-pdf`).',
+      'Show docs',
+    );
+    if (url === 'Show docs') {
+      await vscode.env.openExternal(vscode.Uri.parse('https://revealjs.com/pdf-export/'));
+    }
+  }
+
+  private optionsFromSettings(): SlideshowOptions {
+    const cfg = vscode.workspace.getConfiguration('markItDown.slideshow');
+    return {
+      theme: cfg.get<string>('theme') ?? DEFAULT_OPTIONS.theme,
+      transition: cfg.get<string>('transition') ?? DEFAULT_OPTIONS.transition,
+      speakerNotes: cfg.get<boolean>('includeSpeakerNotes') ?? DEFAULT_OPTIONS.speakerNotes,
+    };
+  }
+
+  private titleFor(uri: vscode.Uri): string {
+    return (uri.path.split('/').pop() ?? 'slides').replace(/\.[^.]+$/, '');
+  }
+
+  private warnNoWarehouse(): void {
+    void vscode.window
+      .showInformationMessage(
+        'Mark It Down: configure markItDown.warehouse.repo first — slideshow publish reuses the warehouse repo.',
+        'Open Settings',
+      )
+      .then(c => {
+        if (c === 'Open Settings') {
+          vscode.commands.executeCommand('workbench.action.openSettings', 'markItDown.warehouse.repo');
+        }
+      });
+  }
+
+  private async pushHtml(
+    wh: WarehouseConfig,
+    branch: string,
+    subPath: string,
+    relativePath: string,
+    html: string,
+  ): Promise<string | undefined> {
+    const cloneRoot = path.join(this.context.globalStorageUri.fsPath, 'warehouse', repoSlug(wh));
+    const worktreeRoot = path.join(this.context.globalStorageUri.fsPath, 'slideshow', repoSlug(wh));
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.dirname(worktreeRoot)));
+    if (!(await pathExists(cloneRoot))) {
+      await runGit(['clone', repoUrl(wh), cloneRoot], undefined);
+    } else {
+      await runGit(['fetch', '--prune', 'origin'], cloneRoot);
+    }
+    const branchExists = await branchExistsRemote(cloneRoot, branch);
+    try {
+      await runGit(['worktree', 'remove', '--force', worktreeRoot], cloneRoot);
+    } catch { /* not present */ }
+    if (branchExists) {
+      await runGit(['worktree', 'add', worktreeRoot, branch], cloneRoot);
+    } else {
+      await runGit(['worktree', 'add', '-B', branch, worktreeRoot, '--detach'], cloneRoot);
+      try {
+        await runGit(['rm', '-rf', '.'], worktreeRoot);
+      } catch { /* empty */ }
+    }
+    const subRoot = subPath ? path.join(worktreeRoot, subPath) : worktreeRoot;
+    const target = path.join(subRoot, relativePath);
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.dirname(target)));
+    await vscode.workspace.fs.writeFile(vscode.Uri.file(target), new TextEncoder().encode(html));
+
+    await runGit(['add', '-A'], worktreeRoot);
+    const status = await runGit(['status', '--porcelain'], worktreeRoot, { capture: true });
+    let sha: string | undefined;
+    if (status.trim().length > 0) {
+      await runGit(['commit', '-m', `slideshow: ${relativePath} — Mark It Down`], worktreeRoot, {
+        env: { GIT_AUTHOR_NAME: 'Mark It Down', GIT_AUTHOR_EMAIL: 'noreply@markitdown.dev' },
+      });
+      sha = (await runGit(['rev-parse', 'HEAD'], worktreeRoot, { capture: true })).trim();
+      await runGit(['push', 'origin', `HEAD:${branch}`], worktreeRoot);
+    }
+    try {
+      await runGit(['worktree', 'remove', '--force', worktreeRoot], cloneRoot);
+    } catch { /* ignore */ }
+    return sha;
+  }
+
+  private publicUrl(wh: WarehouseConfig, _branch: string, subPath: string, relativePath: string): string {
+    const [owner, repo] = wh.repo.split('/');
+    const base = `https://${owner}.github.io/${repo}`;
+    const sub = subPath ? `/${subPath}` : '';
+    return `${base}${sub}/${relativePath}`;
+  }
+}
+
+function slugify(input: string): string {
+  return (
+    input
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 64) || 'slides'
+  );
+}
+
+interface RunOpts {
+  capture?: boolean;
+  env?: NodeJS.ProcessEnv;
+}
+
+function runGit(args: string[], cwd: string | undefined, opts: RunOpts = {}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('git', args, {
+      cwd,
+      env: { ...process.env, ...(opts.env ?? {}) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', d => (stdout += d.toString()));
+    child.stderr.on('data', d => (stderr += d.toString()));
+    child.on('error', reject);
+    child.on('close', code => {
+      if (code === 0) resolve(opts.capture ? stdout : stderr || stdout);
+      else reject(new Error(`git ${args.join(' ')} exited ${code}: ${(stderr || stdout).trim()}`));
+    });
+  });
+}
+
+async function branchExistsRemote(cwd: string, branch: string): Promise<boolean> {
+  try {
+    const out = await runGit(['ls-remote', '--heads', 'origin', branch], cwd, { capture: true });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await vscode.workspace.fs.stat(vscode.Uri.file(p));
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- 4 slideshow commands (`previewLocal`, `publish`, `copyShareUrl`, `exportPdf` defer-notice)
- `---` slide breaks, `--` vertical sub-slides, YAML frontmatter for per-deck overrides
- Reveal.js + mermaid + highlight.js loaded from JSDelivr at view time (no bundle bloat)
- Local preview in a scoped-CSP webview panel; main editor's strict CSP unchanged
- Publish reuses F10's git-worktree-against-warehouse pipeline → `<publish-branch>/<publish-path>/slides/<basename>.html`
- 3 settings: `markItDown.slideshow.theme` (12 themes), `.transition` (6 styles), `.includeSpeakerNotes`
- PDF export deferred — defer-notice points at reveal's `?print-pdf` browser print mode
- Full reference docs at `docs/slideshow.md`

## Closes
Closes #12

## Test plan
- [x] `npm run compile` clean
- [ ] F5: open .md with `---` slide breaks, run Preview Local, navigate slides; configure warehouse + publish.enabled, run Publish, open the printed URL

## Linked issue
[#12 — F11: Slideshow export for any markdown, published via the connected repo](https://github.com/fadymondy/mark-it-down/issues/12)