### PR TITLE
feat(updates): auto-update for VSCode extension + Electron app via GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  electron:
+    name: Electron — ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build extension + electron
+        run: npm run compile && npm run compile:electron
+      - name: Build + publish Electron installers
+        run: npx electron-builder --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # macOS code signing — leave unset to produce unsigned/non-notarized builds.
+          # CSC_LINK: ${{ secrets.MAC_CERTS }}
+          # CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
+          # APPLE_ID: ${{ secrets.APPLE_ID }}
+          # APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+  vscode:
+    name: VSCode extension (.vsix)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci
+      - name: Build extension
+        run: npm run compile
+      - name: Package .vsix
+        run: npx vsce package --no-dependencies
+      - name: Attach .vsix to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VSIX=$(ls *.vsix | head -n 1)
+          gh release upload "$TAG" "$VSIX" --clobber
+      - name: Publish to VSCode Marketplace
+        if: ${{ env.VSCE_PAT != '' }}
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx vsce publish --packagePath *.vsix
+
+  release-notes:
+    name: Generate release notes from CHANGELOG
+    runs-on: ubuntu-latest
+    needs: [electron, vscode]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract section for this version
+        id: extract
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          NOTES=$(awk -v v="$VERSION" '
+            BEGIN { capture = 0 }
+            /^## \[/ {
+              if (capture) exit
+              if ($0 ~ "\\[" v "\\]") { capture = 1; next }
+            }
+            capture { print }
+          ' CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            NOTES="See CHANGELOG.md for details."
+          fi
+          {
+            echo "notes<<EOF"
+            echo "$NOTES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Update release body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release edit "$TAG" --notes "${{ steps.extract.outputs.notes }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Phase 0.14: Auto-update for both surfaces (#28)
+
+- **VSCode extension**: in-extension `UpdateChecker` polls `GET /repos/fadymondy/mark-it-down/releases/latest` once per launch + every 6h; surfaces a notification with `Open Release` / `View Changes` / `Later` actions when a newer version is published. Doesn't re-notify for the same version. Never auto-installs (security smell).
+- **VSCode extension — What's New**: on first launch after an update, a one-time toast surfaces with a `View What's New` action that opens the GitHub release page. First-ever install is silent.
+- **Manual check**: `Mark It Down: Check for Updates` from the command palette.
+- **Setting**: `markItDown.updates.checkOnLaunch` (default `true`).
+- **Electron app**: `electron-updater` wired with `provider: github`. App checks on launch, downloads in background, prompts the user to install on next quit OR restart now. `autoInstallOnAppQuit` defaults to `false` — explicit user opt-in for silent installs.
+- **Help → Check for Updates…** menu item in the Electron app.
+- **package.json#build.publish** block configures the GitHub provider for electron-updater.
+- **`.github/workflows/release.yml`**: tag-push pipeline (`v*.*.*`) builds Electron installers (mac/win/linux matrix) + `.vsix` (vsce package) + auto-publishes to Marketplace if `VSCE_PAT` is set; release body is extracted verbatim from the matching CHANGELOG `## [X.Y.Z]` section.
+- **Docs**: `docs/auto-update.md` (what users see) + `docs/releasing.md` (full release runbook with rollback recipe + common failures table).
+- **macOS auto-update caveat**: requires signed + notarized DMG. Wire `CSC_LINK` + Apple credentials into the release workflow's env block when ready; until then unsigned macOS builds install fine but can't apply updates.
+
 ### Added — Phase 0.13: Claude Code plugin (mark-it-down-claude) (#14)
 
 - New `plugins/mark-it-down-claude/` packages the bundled MCP server, 6 user-invocable skills, and 3 specialist sub-agents into a single Claude Code plugin

--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -1,8 +1,15 @@
 import { app, BrowserWindow, dialog, ipcMain, Menu, MenuItemConstructorOptions, nativeTheme, shell } from 'electron';
+import { autoUpdater } from 'electron-updater';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 
 const isDev = process.env.MID_DEV === '1' || !app.isPackaged;
+const updateState = {
+  available: false,
+  downloaded: false,
+  version: app.getVersion(),
+  notes: '',
+};
 
 let mainWindow: BrowserWindow | null = null;
 
@@ -44,6 +51,7 @@ app.whenReady().then(async () => {
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) void createWindow();
   });
+  setupAutoUpdate();
 });
 
 app.on('window-all-closed', () => {
@@ -97,11 +105,93 @@ ipcMain.handle('mid:open-external', async (_e, url: string) => {
   await shell.openExternal(url);
 });
 
+ipcMain.handle('mid:update-status', async () => updateState);
+ipcMain.handle('mid:update-check-now', async () => {
+  if (isDev) return { skipped: true, reason: 'dev mode — skip update check' };
+  try {
+    const result = await autoUpdater.checkForUpdates();
+    return { ok: true, version: result?.updateInfo?.version };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+});
+ipcMain.handle('mid:update-quit-and-install', async () => {
+  if (!updateState.downloaded) return false;
+  setImmediate(() => autoUpdater.quitAndInstall(true, true));
+  return true;
+});
+
 nativeTheme.on('updated', () => {
   if (mainWindow) {
     mainWindow.webContents.send('mid:theme-changed', nativeTheme.shouldUseDarkColors);
   }
 });
+
+function setupAutoUpdate(): void {
+  if (isDev) {
+    console.log('[mid] auto-update skipped (dev mode)');
+    return;
+  }
+  // electron-updater honors the `publish` block in package.json#build at build time
+  // and falls back to GitHub via repository.url at runtime.
+  autoUpdater.autoDownload = true;
+  autoUpdater.autoInstallOnAppQuit = false; // user has to opt in via menu
+  autoUpdater.on('update-available', info => {
+    updateState.available = true;
+    updateState.version = info.version;
+    updateState.notes = typeof info.releaseNotes === 'string' ? info.releaseNotes : '';
+    broadcastUpdateState();
+    void dialog.showMessageBox({
+      type: 'info',
+      buttons: ['Later'],
+      title: 'Mark It Down',
+      message: `Update available: v${info.version}`,
+      detail: 'Downloading in the background. We\'ll prompt you when it\'s ready to install.',
+      noLink: true,
+    });
+  });
+  autoUpdater.on('update-not-available', () => {
+    updateState.available = false;
+    broadcastUpdateState();
+  });
+  autoUpdater.on('update-downloaded', info => {
+    updateState.downloaded = true;
+    updateState.version = info.version;
+    updateState.notes = typeof info.releaseNotes === 'string' ? info.releaseNotes : '';
+    broadcastUpdateState();
+    void dialog
+      .showMessageBox({
+        type: 'info',
+        buttons: ['Install on next launch', 'Restart and install now'],
+        defaultId: 1,
+        cancelId: 0,
+        title: 'Mark It Down',
+        message: `Update v${info.version} ready to install`,
+        detail: 'Restart now to apply, or install automatically next time you launch.',
+        noLink: true,
+      })
+      .then(result => {
+        if (result.response === 1) {
+          autoUpdater.quitAndInstall(true, true);
+        } else {
+          autoUpdater.autoInstallOnAppQuit = true;
+        }
+      });
+  });
+  autoUpdater.on('error', err => {
+    console.warn('[mid] auto-update error:', err?.message ?? err);
+  });
+  // Kick off a check on launch (debounced to one per launch)
+  autoUpdater.checkForUpdatesAndNotify().catch(err => {
+    console.warn('[mid] checkForUpdatesAndNotify failed:', err?.message ?? err);
+  });
+}
+
+function broadcastUpdateState(): void {
+  if (mainWindow) {
+    mainWindow.webContents.send('mid:update-state', updateState);
+  }
+}
 
 function buildMenu(): Menu {
   const isMac = process.platform === 'darwin';
@@ -162,6 +252,39 @@ function buildMenu(): Menu {
         {
           label: 'Mark It Down on GitHub',
           click: () => shell.openExternal('https://github.com/fadymondy/mark-it-down'),
+        },
+        {
+          label: 'Check for Updates…',
+          click: async () => {
+            if (isDev) {
+              await dialog.showMessageBox({
+                type: 'info',
+                title: 'Mark It Down',
+                message: 'Update checks are disabled in dev mode.',
+                buttons: ['OK'],
+              });
+              return;
+            }
+            try {
+              const result = await autoUpdater.checkForUpdates();
+              if (!result?.updateInfo || result.updateInfo.version === app.getVersion()) {
+                await dialog.showMessageBox({
+                  type: 'info',
+                  title: 'Mark It Down',
+                  message: `You're on the latest version (v${app.getVersion()}).`,
+                  buttons: ['OK'],
+                });
+              }
+            } catch (err) {
+              await dialog.showMessageBox({
+                type: 'error',
+                title: 'Mark It Down',
+                message: 'Update check failed',
+                detail: (err as Error).message,
+                buttons: ['OK'],
+              });
+            }
+          },
         },
       ],
     },

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,4 +20,10 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 | F12 — Standalone Electron app | shipped (first-cut) | [electron-app.md](electron-app.md) |
 | F13 — Claude Code plugin | shipped | [claude-plugin.md](claude-plugin.md) |
 
+## Post-v1.0
+
+| Feature | Status | Doc |
+|---|---|---|
+| F14 — Auto-update for both surfaces | shipped | [auto-update.md](auto-update.md) + [releasing.md](releasing.md) |
+
 Each feature gets its own page when it ships. New pages should follow the [notes-sidebar.md](notes-sidebar.md) shape: at-a-glance table, settings, workflows, edge cases, and a "what it unblocks" section.

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -1,0 +1,151 @@
+# Auto-Update
+
+Status: shipped in Phase 0.14 · Issue: [#28](https://github.com/fadymondy/mark-it-down/issues/28)
+
+Both shipping surfaces — the VSCode extension and the standalone Electron app — now stay current via GitHub Releases. One source of truth, no extra hosting.
+
+## At a glance
+
+| Surface | Channel | What runs |
+|---|---|---|
+| **VSCode extension (Marketplace)** | `vscode.marketplace` | VSCode's native auto-update — silent, on by default |
+| **VSCode extension (.vsix)** | `GET /repos/fadymondy/mark-it-down/releases/latest` | In-extension poller checks once per launch + every 6h; surfaces a notification with `Open Release` / `View Changes` actions |
+| **Electron app** | `electron-updater` (GitHub provider) | App checks on launch, downloads in background, prompts user to install on next quit (or restart now) |
+
+## VSCode side
+
+Two paths users can be on:
+
+### Marketplace install
+
+The extension is published to the VSCode Marketplace as `fadymondy.mark-it-down`. VSCode polls the Marketplace and pulls updates automatically — nothing extension-side to do. Whatever VSCode's update settings say is what happens.
+
+### Self-installed `.vsix`
+
+For users who downloaded the `.vsix` from a GitHub Release (or sideloaded from a build), there's no Marketplace channel. The extension polls GitHub itself:
+
+```
+on activate
+  → if markItDown.updates.checkOnLaunch (default true)
+    → fetch GET https://api.github.com/repos/fadymondy/mark-it-down/releases/latest
+    → if release.tag_name > package.json#version
+      → notification: "v0.X.Y is available — Open Release / View Changes / Later"
+    → schedule re-check every 6h while VSCode runs
+```
+
+Behavior notes:
+
+- **Never auto-installs.** Pulling executable code from a remote without a user gesture is a security smell. The notification is the action.
+- **Doesn't re-notify** for the same version unless the user clicks `Later` then quits + relaunches. Tracked via `globalState[markItDown.updates.lastSeenVersion]`.
+- **`View Changes`** opens an untitled markdown buffer with the release body so the user can read offline / save / share.
+- **Manual check**: `Mark It Down: Check for Updates` from the command palette runs the same check on demand and surfaces "you're on the latest" if there's nothing new (the auto-poll stays silent in that case).
+- **What's New on first launch after update**: when the installed version differs from `globalState[markItDown.updates.installedVersion]`, the extension shows a one-time "Mark It Down updated to v0.X.Y" toast with a `View What's New` action that opens the GitHub release page. First-ever install is silent (no `last` value to compare against).
+
+Settings:
+
+| Setting | Default | What it does |
+|---|---|---|
+| `markItDown.updates.checkOnLaunch` | `true` | Poll GitHub on launch + every 6h. Set to `false` to disable; `Check for Updates` command still works manually. |
+
+## Electron side
+
+Wired via `electron-updater` (the official update channel for `electron-builder`). The `package.json#build.publish` block:
+
+```jsonc
+{
+  "publish": [
+    {
+      "provider": "github",
+      "owner": "fadymondy",
+      "repo": "mark-it-down",
+      "releaseType": "release"
+    }
+  ]
+}
+```
+
+`electron-builder` writes a `latest-mac.yml` / `latest.yml` / `latest-linux.yml` next to each installer at release time, and `electron-updater` fetches whichever matches the running platform.
+
+### Lifecycle in the Electron app
+
+```
+app launches
+  → if production build (NOT MID_DEV)
+    → autoUpdater.checkForUpdatesAndNotify()
+      → on 'update-available':   download begins; dialog: "Update available v0.X.Y — downloading"
+      → on 'update-downloaded':  dialog: "Update v0.X.Y ready — Install on next launch | Restart and install now"
+      → on 'error':              warn to stderr; no user dialog (stays out of the way)
+```
+
+User chooses on the post-download dialog:
+
+- **Restart and install now** — `quitAndInstall(true, true)` runs the installer immediately
+- **Install on next launch** — `autoInstallOnAppQuit = true` is set, the install runs the next time the user quits
+
+Settings (defaults):
+
+- `autoDownload = true` — downloads happen in the background, no consent dialog before the bytes start
+- `autoInstallOnAppQuit = false` — explicit user opt-in required for silent installs (this is the conservative choice)
+
+A `Help → Check for Updates…` menu item lets users force a check and surfaces "You're on the latest" if nothing's available.
+
+### Code signing
+
+For macOS auto-updates to work, the DMG **must be signed AND notarized**. An unsigned DMG installs fine on first download, but `electron-updater` refuses to apply updates to it (Apple's Gatekeeper rejects the differential update). Wire credentials into `.github/workflows/release.yml` via these env vars:
+
+```yaml
+env:
+  CSC_LINK: ${{ secrets.MAC_CERTS }}
+  CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
+  APPLE_ID: ${{ secrets.APPLE_ID }}
+  APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+  APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+```
+
+Without those, builds still succeed and Linux/Windows updates work fine. macOS users on unsigned builds will see "you're on the latest" indefinitely from `electron-updater`'s perspective.
+
+## Release flow (shared)
+
+A push of a tag matching `v*.*.*` triggers `.github/workflows/release.yml`:
+
+```
+v0.2.0 git push --tags
+   ↓
+electron job (mac/win/linux matrix) → electron-builder --publish always
+   - builds installers + latest-*.yml metadata
+   - uploads to the GitHub release for that tag
+vscode job (single ubuntu) → vsce package
+   - builds .vsix, attaches to the release
+   - if VSCE_PAT secret is set: vsce publish to the Marketplace
+release-notes job
+   - extracts the matching ## [X.Y.Z] section from CHANGELOG.md
+   - sets it as the release body
+```
+
+So one tag push produces:
+
+- `Mark.It.Down-0.2.0-arm64.dmg`, `Mark.It.Down-0.2.0-x64.dmg` (macOS)
+- `Mark.It.Down.Setup.0.2.0.exe` (Windows)
+- `Mark.It.Down-0.2.0.AppImage`, `mark-it-down_0.2.0_amd64.deb` (Linux)
+- `latest-mac.yml`, `latest.yml`, `latest-linux.yml` (electron-updater metadata)
+- `mark-it-down-0.2.0.vsix` (the VSCode extension)
+- A release body sourced verbatim from `CHANGELOG.md`'s `## [0.2.0]` section
+
+See [docs/releasing.md](releasing.md) for the manual checklist that wraps a release.
+
+## Edge cases
+
+- **Pre-release tags** (e.g. `v0.3.0-rc.1`) — the GitHub `releases/latest` endpoint skips releases marked `prerelease: true`, so the in-extension poller won't notify on them. `electron-updater` honors the same default. To roll a pre-release channel, mark the GitHub release as "Pre-release"; users opted in via `autoUpdater.channel = 'beta'` (not wired in v0.14) would receive it.
+- **Network failures** — both checkers swallow errors silently. The user only sees a failure when they manually invoked `Check for Updates`.
+- **Rate limiting** — unauthenticated GitHub API calls cap at 60/hour per IP. The 6-hour poll interval keeps us well under that even with multiple VSCode windows open.
+- **Same version, different build** — semver comparison is exact (`0.1.0 == 0.1.0` → no notification). If you re-tag the same version, users won't be re-pinged — bump the patch number.
+- **Extension installed to extra-mode VSCode forks** (Cursor, Code-OSS, etc.) — they don't all hit the Marketplace, so the in-extension poller is the active path there too.
+
+## Files of interest
+
+- [src/updates/updateChecker.ts](../src/updates/updateChecker.ts) — VSCode-side `UpdateChecker` (poll + notify + What's New)
+- [src/extension.ts](../src/extension.ts) — wires `UpdateChecker` + `markItDown.updates.checkNow` command on activation
+- [apps/electron/main.ts](../apps/electron/main.ts) — `setupAutoUpdate` wiring `electron-updater` event handlers + `Check for Updates…` menu item
+- [.github/workflows/release.yml](../.github/workflows/release.yml) — tag-push release pipeline (matrix electron build + vsce package + release notes from CHANGELOG)
+- [docs/releasing.md](releasing.md) — release runbook
+- [package.json](../package.json) — `build.publish` block (electron-updater) + `markItDown.updates.checkOnLaunch` setting + `markItDown.updates.checkNow` command

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,135 @@
+# Releasing Mark It Down
+
+The release runbook for shipping a new version. One tag push triggers parallel builds for the Electron app (mac/win/linux) and the VSCode extension (`.vsix` + Marketplace), plus pulls the release notes verbatim from CHANGELOG.md.
+
+## When to release
+
+- A meaningful set of features or fixes has landed on `main` since the last tag
+- All in-flight feature branches are merged or explicitly excluded from this version
+- CHANGELOG.md has a complete `## [Unreleased]` section ready to be promoted
+
+## Pre-flight checklist
+
+- [ ] All v0.X feature branches are merged to `main`
+- [ ] Local `main` is up to date with `origin/main` and clean (`git status` clean)
+- [ ] `npm run compile && npm run compile:electron` is green
+- [ ] You're on macOS (the release workflow's mac runner does the actual signing — but a local sanity launch is good)
+- [ ] If shipping the VSCode extension to the Marketplace, confirm `VSCE_PAT` secret is set on the repo. If shipping signed macOS Electron builds, confirm `MAC_CERTS` / `APPLE_*` secrets are set.
+
+## Steps
+
+### 1. Decide the version number
+
+Use [SemVer](https://semver.org). For Mark It Down's pre-1.0 cycle:
+
+- **Patch** (`0.1.0` → `0.1.1`) — bug fixes, doc-only changes, minor UX polish
+- **Minor** (`0.1.x` → `0.2.0`) — new features, additive settings, additive commands
+- **Major** (`0.x` → `1.0.0`) — when v1.0 is fully ready, breaking changes
+
+### 2. Update `package.json` version
+
+```bash
+npm version <patch|minor|major> --no-git-tag-version
+```
+
+This bumps `package.json#version` without committing or tagging — we'll do that manually after the CHANGELOG update.
+
+### 3. Promote `[Unreleased]` in CHANGELOG.md
+
+Open `CHANGELOG.md`. Replace `## [Unreleased]` with `## [X.Y.Z] — YYYY-MM-DD`. Re-add a fresh `## [Unreleased]` block at the top so the next round of work has somewhere to live.
+
+```markdown
+# Changelog
+
+## [Unreleased]
+
+## [0.2.0] — 2026-05-15
+
+### Added — Phase 0.14: Auto-update for both surfaces (#28)
+…
+```
+
+The release-notes job in CI extracts the `## [X.Y.Z]` section by exact match and uses it as the GitHub Release body — make sure the section header is well-formed.
+
+### 4. Commit
+
+```bash
+git checkout -b chore/release-vX.Y.Z
+git add package.json package-lock.json CHANGELOG.md
+git commit -m "chore(release): vX.Y.Z"
+git push -u origin chore/release-vX.Y.Z
+gh pr create --title "chore(release): vX.Y.Z" --body "Release prep for vX.Y.Z. CHANGELOG promoted; version bumped."
+```
+
+Open the PR, wait for CI, merge to `main`. The release tag is **not** created on the PR branch — it goes on `main` after merge.
+
+### 5. Tag and push
+
+After the release-prep PR merges:
+
+```bash
+git checkout main
+git pull origin main
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The tag push fires `.github/workflows/release.yml`. From here CI does the work.
+
+### 6. CI does its thing
+
+Three parallel jobs:
+
+| Job | Where | What |
+|---|---|---|
+| `electron` | matrix: macos-latest / windows-latest / ubuntu-latest | `npm ci` → `npm run compile && npm run compile:electron` → `npx electron-builder --publish always`. Each runner builds + uploads its installers + the `latest-*.yml` metadata file to the new GitHub release. |
+| `vscode` | ubuntu-latest | `npm ci` → `npm run compile` → `npx vsce package --no-dependencies` → `gh release upload` the `.vsix`. If `VSCE_PAT` secret is set: also `npx vsce publish --packagePath *.vsix` to the Marketplace. |
+| `release-notes` | ubuntu-latest, depends on the two above | Extracts the matching `## [X.Y.Z]` section from CHANGELOG.md → `gh release edit --notes "$NOTES"`. |
+
+Watch in the Actions tab of the repo. All three should go green.
+
+### 7. Verify the release
+
+After CI completes:
+
+- [ ] [GitHub Releases](https://github.com/fadymondy/mark-it-down/releases/latest) page shows v0.X.Y with all expected assets
+- [ ] The release body matches the `## [0.X.Y]` section from CHANGELOG.md
+- [ ] All three `latest-*.yml` files are attached (mac, win, linux) — these are what `electron-updater` reads
+- [ ] The `.vsix` is attached and the file size looks reasonable
+- [ ] If Marketplace publish ran: the [Marketplace listing](https://marketplace.visualstudio.com/items?itemName=fadymondy.mark-it-down) shows the new version
+
+### 8. Smoke-test the update on at least one client
+
+- **VSCode**: download the previous `.vsix` from a prior release, install it, then in that VSCode window open the command palette → `Mark It Down: Check for Updates`. You should get the "v0.X.Y is available" notification.
+- **Electron app on macOS**: install the previous `.dmg` from a prior release, launch it. Within seconds it should auto-check, see the new release, and offer to download.
+
+If either smoke test fails, open an issue immediately and consider yanking the release.
+
+### 9. Announce
+
+Drop a note wherever the user community lives — the README's "Status" section, a Discussion, a tweet, etc. Link the GitHub release.
+
+## Rollback
+
+If a released version is broken:
+
+1. **Mark the GitHub release as Pre-release** in the release UI — the in-extension poller and `electron-updater` will both stop offering it.
+2. Bump the version (e.g. `0.2.0` → `0.2.1`), fix the bug on a hotfix branch, repeat the release flow. Don't rewrite or delete the bad tag — semver says versions are immutable.
+3. Note the broken version in the CHANGELOG of the new release: "Fixes a regression in v0.2.0 that caused X."
+
+## Common failures
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `electron-builder` fails on macOS with "ELECTRON_BUILDER_YML_PATH" | electron-builder can't find config | The config lives in `package.json#build` — should auto-detect; check working dir |
+| `electron-builder` succeeds but uploads nothing | `--publish always` not passed OR `GH_TOKEN` env not set | The workflow sets both; verify |
+| `vsce publish` fails with auth | `VSCE_PAT` secret missing or expired | Refresh the PAT at https://dev.azure.com/<your-org>/_usersSettings/tokens; update the repo secret |
+| macOS DMG installs but won't auto-update | Unsigned / unnotarized build | Wire `CSC_LINK` + Apple credentials into the workflow env block |
+| Release-notes job posts "See CHANGELOG.md for details" | The `## [X.Y.Z]` section header didn't match what awk expected | Check exact format: `## [0.2.0] — 2026-05-15` (em dash + space + date) |
+
+## Files of interest
+
+- [.github/workflows/release.yml](../.github/workflows/release.yml) — the release pipeline
+- [package.json#build.publish](../package.json) — electron-updater provider config
+- [docs/auto-update.md](auto-update.md) — what users see on the receiving end
+- [CHANGELOG.md](../CHANGELOG.md) — source of release notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "codemirror": "^6.0.2",
         "docx": "^9.6.1",
         "dompurify": "^3.2.3",
+        "electron-updater": "^6.8.3",
         "highlight.js": "^11.10.0",
         "html-to-image": "^1.11.13",
         "marked": "^14.1.3",
@@ -2897,7 +2898,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assert-plus": {
@@ -3206,7 +3206,6 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -4913,6 +4912,36 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
@@ -5873,7 +5902,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/hachure-fill": {
@@ -6450,7 +6478,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6510,7 +6537,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -6688,7 +6714,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/leven": {
@@ -6752,6 +6777,12 @@
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -6764,6 +6795,13 @@
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
@@ -8458,7 +8496,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9252,6 +9289,12 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
@@ -9557,7 +9600,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -49,15 +49,51 @@
     },
     "mac": {
       "category": "public.app-category.productivity",
-      "target": [{ "target": "dmg", "arch": ["arm64", "x64"] }]
+      "target": [
+        {
+          "target": "dmg",
+          "arch": [
+            "arm64",
+            "x64"
+          ]
+        }
+      ]
     },
     "win": {
-      "target": [{ "target": "nsis", "arch": ["x64"] }]
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        }
+      ]
     },
     "linux": {
-      "target": [{ "target": "AppImage", "arch": ["x64"] }, { "target": "deb", "arch": ["x64"] }],
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "deb",
+          "arch": [
+            "x64"
+          ]
+        }
+      ],
       "category": "Office"
-    }
+    },
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "fadymondy",
+        "repo": "mark-it-down",
+        "releaseType": "release"
+      }
+    ]
   },
   "activationEvents": [],
   "contributes": {
@@ -250,6 +286,12 @@
         "command": "markItDown.slideshow.exportPdf",
         "title": "Slideshow: Export to PDF",
         "category": "Mark It Down"
+      },
+      {
+        "command": "markItDown.updates.checkNow",
+        "title": "Check for Updates",
+        "category": "Mark It Down",
+        "icon": "$(cloud-download)"
       }
     ],
     "menus": {
@@ -539,6 +581,11 @@
           "type": "boolean",
           "default": true,
           "description": "Render lines after a `Notes:` block on each slide as Reveal speaker notes."
+        },
+        "markItDown.updates.checkOnLaunch": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Check for newer Mark It Down releases on GitHub once per launch (and every 6 hours after). Only used by users on a self-installed `.vsix`; Marketplace installs use VSCode's native update mechanism."
         }
       }
     }
@@ -555,7 +602,7 @@
     "package": "vsce package",
     "publish": "vsce publish",
     "dev:vscode": "echo 'Press F5 in VSCode to launch the Extension Development Host.'",
-    "dev:electron": "npm run compile && npm run compile:electron && MID_DEV=1 electron out/electron/main.js",
+    "dev:electron": "npm run compile && npm run compile:electron && env -u ELECTRON_RUN_AS_NODE -u ELECTRON_NO_ATTACH_CONSOLE MID_DEV=1 electron out/electron/main.js",
     "dist:electron": "npm run compile && npm run compile:electron && electron-builder --mac --win --linux",
     "lint": "eslint src --ext ts"
   },
@@ -571,6 +618,7 @@
     "codemirror": "^6.0.2",
     "docx": "^9.6.1",
     "dompurify": "^3.2.3",
+    "electron-updater": "^6.8.3",
     "highlight.js": "^11.10.0",
     "html-to-image": "^1.11.13",
     "marked": "^14.1.3",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import { PublishManager } from './publish/publishManager';
 import { registerPublishCommands } from './publish/publishCommands';
 import { SlideshowManager } from './slideshow/slideshowManager';
 import { registerSlideshowCommands } from './slideshow/slideshowCommands';
+import { UpdateChecker } from './updates/updateChecker';
 
 export function activate(context: vscode.ExtensionContext) {
   const provider = new MarkdownEditorProvider(context);
@@ -35,17 +36,21 @@ export function activate(context: vscode.ExtensionContext) {
   const warehouse = new WarehouseManager(context, notesStore);
   const publish = new PublishManager(context, notesStore);
   const slideshow = new SlideshowManager(context);
+  const updates = new UpdateChecker(context);
   context.subscriptions.push(
     notesStore,
     notesTree,
     warehouse,
+    updates,
     vscode.window.registerTreeDataProvider('markItDown.notes', notesTree),
     ...registerNotesCommands(context, notesStore),
     ...registerWarehouseCommands(warehouse),
     ...registerMcpInstallCommands(context),
     ...registerPublishCommands(publish),
     ...registerSlideshowCommands(slideshow),
+    vscode.commands.registerCommand('markItDown.updates.checkNow', () => updates.checkNow()),
   );
+  updates.start();
   warehouse.start();
   void notesStore.writeMcpIndexSnapshot();
   context.subscriptions.push(

--- a/src/updates/updateChecker.ts
+++ b/src/updates/updateChecker.ts
@@ -1,0 +1,187 @@
+import * as https from 'https';
+import * as vscode from 'vscode';
+
+const REPO_OWNER = 'fadymondy';
+const REPO_NAME = 'mark-it-down';
+const RELEASE_API = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest`;
+const STATE_KEYS = {
+  lastCheckedAt: 'markItDown.updates.lastCheckedAt',
+  lastSeenVersion: 'markItDown.updates.lastSeenVersion',
+  installedVersion: 'markItDown.updates.installedVersion',
+};
+const DEFAULT_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+export interface UpdateInfo {
+  version: string;
+  htmlUrl: string;
+  bodyMarkdown: string;
+  publishedAt: string;
+}
+
+export class UpdateChecker {
+  private timer: NodeJS.Timeout | undefined;
+
+  constructor(private readonly context: vscode.ExtensionContext) {}
+
+  public start(): void {
+    void this.maybeShowWhatsNew();
+    if (!this.checkOnLaunchEnabled()) return;
+    void this.runCheck({ trigger: 'launch' });
+    this.timer = setInterval(() => {
+      void this.runCheck({ trigger: 'interval' });
+    }, DEFAULT_INTERVAL_MS);
+  }
+
+  public dispose(): void {
+    if (this.timer) clearInterval(this.timer);
+  }
+
+  public async checkNow(): Promise<void> {
+    await this.runCheck({ trigger: 'manual' });
+  }
+
+  private checkOnLaunchEnabled(): boolean {
+    return vscode.workspace.getConfiguration('markItDown.updates').get<boolean>('checkOnLaunch') ?? true;
+  }
+
+  private async runCheck(opts: { trigger: 'launch' | 'interval' | 'manual' }): Promise<void> {
+    const installed = this.installedVersion();
+    let release: UpdateInfo | undefined;
+    try {
+      release = await fetchLatestRelease();
+    } catch (err) {
+      if (opts.trigger === 'manual') {
+        vscode.window.showErrorMessage(`Mark It Down: update check failed — ${(err as Error).message}`);
+      }
+      return;
+    }
+    await this.context.globalState.update(STATE_KEYS.lastCheckedAt, Date.now());
+    if (!release) return;
+
+    if (compareSemver(release.version, installed) <= 0) {
+      if (opts.trigger === 'manual') {
+        vscode.window.showInformationMessage(`Mark It Down: you're on the latest version (v${installed}).`);
+      }
+      return;
+    }
+    const lastSeen = this.context.globalState.get<string>(STATE_KEYS.lastSeenVersion) ?? '';
+    if (opts.trigger !== 'manual' && lastSeen === release.version) {
+      // Already notified the user about this version; don't re-notify silently.
+      return;
+    }
+    await this.context.globalState.update(STATE_KEYS.lastSeenVersion, release.version);
+    const action = await vscode.window.showInformationMessage(
+      `Mark It Down: v${release.version} is available (you're on v${installed}).`,
+      'Open Release',
+      'View Changes',
+      'Later',
+    );
+    if (action === 'Open Release') {
+      await vscode.env.openExternal(vscode.Uri.parse(release.htmlUrl));
+    } else if (action === 'View Changes') {
+      await this.openReleaseNotes(release);
+    }
+  }
+
+  private async openReleaseNotes(release: UpdateInfo): Promise<void> {
+    const doc = await vscode.workspace.openTextDocument({
+      language: 'markdown',
+      content: `# Mark It Down v${release.version}\n\nReleased ${release.publishedAt}\n\n${release.bodyMarkdown}\n\n---\n\n[Open release on GitHub](${release.htmlUrl})\n`,
+    });
+    await vscode.window.showTextDocument(doc, { preview: true });
+  }
+
+  private installedVersion(): string {
+    return this.context.extension?.packageJSON?.version ?? '0.0.0';
+  }
+
+  private async maybeShowWhatsNew(): Promise<void> {
+    const current = this.installedVersion();
+    const last = this.context.globalState.get<string>(STATE_KEYS.installedVersion);
+    if (last === current) return;
+    await this.context.globalState.update(STATE_KEYS.installedVersion, current);
+    if (!last) return; // first install — no "what's new" toast
+    const action = await vscode.window.showInformationMessage(
+      `Mark It Down updated to v${current}.`,
+      'View What\'s New',
+      'Dismiss',
+    );
+    if (action === 'View What\'s New') {
+      const url = `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/tag/v${current}`;
+      await vscode.env.openExternal(vscode.Uri.parse(url));
+    }
+  }
+}
+
+function fetchLatestRelease(): Promise<UpdateInfo | undefined> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      RELEASE_API,
+      {
+        method: 'GET',
+        headers: {
+          'User-Agent': 'mark-it-down-vscode-extension',
+          Accept: 'application/vnd.github+json',
+        },
+        timeout: 10_000,
+      },
+      res => {
+        let body = '';
+        res.on('data', chunk => (body += chunk.toString()));
+        res.on('end', () => {
+          if (res.statusCode === 404) {
+            // No releases published yet — silently no-op.
+            resolve(undefined);
+            return;
+          }
+          if (res.statusCode && res.statusCode >= 400) {
+            reject(new Error(`GitHub API ${res.statusCode}: ${body.slice(0, 200)}`));
+            return;
+          }
+          try {
+            const json = JSON.parse(body) as {
+              tag_name?: string;
+              name?: string;
+              html_url?: string;
+              body?: string;
+              published_at?: string;
+              draft?: boolean;
+              prerelease?: boolean;
+            };
+            if (!json || json.draft || json.prerelease || !json.tag_name) {
+              resolve(undefined);
+              return;
+            }
+            const version = json.tag_name.replace(/^v/, '');
+            resolve({
+              version,
+              htmlUrl: json.html_url ?? `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/tag/${json.tag_name}`,
+              bodyMarkdown: json.body ?? '',
+              publishedAt: json.published_at ?? '',
+            });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.on('timeout', () => req.destroy(new Error('request timed out')));
+    req.end();
+  });
+}
+
+function compareSemver(a: string, b: string): number {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+function parseSemver(v: string): [number, number, number] {
+  const cleaned = v.replace(/^v/, '').split('-')[0];
+  const parts = cleaned.split('.').map(p => Number.parseInt(p, 10));
+  return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
+}


### PR DESCRIPTION
## Summary
- **VSCode extension**: in-extension `UpdateChecker` polls GitHub Releases (once per launch + every 6h); notification w/ Open Release / View Changes / Later actions; never auto-installs (security smell). What's New toast on first launch after an installed-version bump.
- **Electron app**: `electron-updater` wired with the GitHub provider. autoDownload on, autoInstallOnAppQuit off (explicit user opt-in). Help → Check for Updates… menu item.
- **Release pipeline**: tag push (`v*.*.*`) triggers `.github/workflows/release.yml` — matrix Electron build (mac/win/linux) + .vsix package + auto-Marketplace publish (if `VSCE_PAT` set) + release notes extracted from the matching `## [X.Y.Z]` CHANGELOG section.
- **Settings**: `markItDown.updates.checkOnLaunch` (default true) + `markItDown.updates.checkNow` command.
- **Docs**: `docs/auto-update.md` (user-facing) + `docs/releasing.md` (release runbook with rollback recipe + common failures table).

## Closes
Closes #28

## Test plan
- [x] `npm run compile && npm run compile:electron` clean
- [ ] Smoke (post-merge): cut a `v0.1.1` tag, verify CI builds installers + .vsix + electron-updater metadata + release-notes job populates the body from CHANGELOG
- [ ] Smoke (post-merge): install previous .vsix, run `Check for Updates`, verify notification appears

## Linked issue
[#28 — Auto-update for VSCode extension + Electron app via GitHub Releases](https://github.com/fadymondy/mark-it-down/issues/28)