### PR TITLE
chore(release): wire macOS code signing + notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,16 @@ jobs:
         run: npx electron-builder --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # macOS code signing — leave unset to produce unsigned/non-notarized builds.
-          # CSC_LINK: ${{ secrets.MAC_CERTS }}
-          # CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
-          # APPLE_ID: ${{ secrets.APPLE_ID }}
-          # APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # macOS code signing — populated only on macOS runners that have the secrets set.
+          # When the secrets are absent (e.g. on a fork or before the user sets them up),
+          # electron-builder falls back to producing an unsigned, non-notarized build that
+          # installs fine on first launch but cannot apply electron-updater updates.
+          # See docs/releasing.md#setting-up-macos-code-signing.
+          CSC_LINK: ${{ secrets.MAC_CERTS }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
   vscode:
     name: VSCode extension (.vsix)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — v1.1 hardening: macOS code signing + notarization wired (#33)
+
+- `.github/workflows/release.yml` env block now references `MAC_CERTS`, `MAC_CERTS_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` secrets — populated only on macOS runners that have them, electron-builder gracefully falls back to unsigned builds when absent
+- `docs/releasing.md` gains a complete "Setting up macOS code signing" section walking through cert creation in Xcode → `.p12` export → base64 → app-specific password → team ID → repo secrets, plus a verification + cert-rotation note
+- `docs/auto-update.md` Code Signing section updated to point at the new releasing.md flow
+- **User action required after merge** to actually enable signing: add the 5 GitHub repo secrets per the runbook. Until then, releases still ship unsigned macOS DMGs (functional but no auto-update on Mac).
+
 ### Added — v1.1 hardening: VSCode integration tests via @vscode/test-electron (#32)
 
 - New `tests/integration/` with the runner (`runTest.ts`), Mocha test-suite loader (`suite/index.ts`), and 5 happy-path tests covering: extension presence, activation without errors, every contributed command registered after activation, custom-editor `openWith` for a `.md` file resolves cleanly, configuration namespaces (`theme`, `startMode`, `mermaid.enabled`, `notes.categories`) all readable.

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -91,7 +91,9 @@ A `Help → Check for Updates…` menu item lets users force a check and surface
 
 ### Code signing
 
-For macOS auto-updates to work, the DMG **must be signed AND notarized**. An unsigned DMG installs fine on first download, but `electron-updater` refuses to apply updates to it (Apple's Gatekeeper rejects the differential update). Wire credentials into `.github/workflows/release.yml` via these env vars:
+For macOS auto-updates to work, the DMG **must be signed AND notarized**. An unsigned DMG installs fine on first download, but `electron-updater` refuses to apply updates to it (Apple's Gatekeeper rejects the differential update).
+
+The release workflow's env block already references the right secrets:
 
 ```yaml
 env:
@@ -102,7 +104,9 @@ env:
   APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 ```
 
-Without those, builds still succeed and Linux/Windows updates work fine. macOS users on unsigned builds will see "you're on the latest" indefinitely from `electron-updater`'s perspective.
+Add the 5 secrets in the repo's **Settings → Secrets and variables → Actions** following the step-by-step in [docs/releasing.md → Setting up macOS code signing](releasing.md#setting-up-macos-code-signing).
+
+Without those secrets, builds still succeed and Linux/Windows updates work fine. macOS users on unsigned builds will see "you're on the latest" indefinitely from `electron-updater`'s perspective.
 
 ## Release flow (shared)
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -117,6 +117,82 @@ If a released version is broken:
 2. Bump the version (e.g. `0.2.0` → `0.2.1`), fix the bug on a hotfix branch, repeat the release flow. Don't rewrite or delete the bad tag — semver says versions are immutable.
 3. Note the broken version in the CHANGELOG of the new release: "Fixes a regression in v0.2.0 that caused X."
 
+## Setting up macOS code signing
+
+Required for Electron auto-update to work on macOS. Without these, the release workflow still produces a `.dmg` that installs fine on first download, but `electron-updater` can't apply updates to it (Apple Gatekeeper rejects the differential update on unsigned apps). Linux + Windows updates work without any of this.
+
+You'll need:
+
+- An **Apple Developer Program** membership ($99/year)
+- A Mac with Xcode installed (to export the cert; the actual signing happens on the GitHub macOS runner)
+- ~30 minutes for the first-time setup
+
+### 1. Create a Developer ID Application certificate
+
+In Xcode:
+
+1. **Settings → Accounts** → sign in with your Apple ID
+2. Pick your team → **Manage Certificates…**
+3. Click `+` → **Developer ID Application** (NOT "Apple Development" — that one is for development builds only)
+4. The cert appears in your Mac's Keychain Access under **My Certificates**
+
+### 2. Export the cert as a `.p12`
+
+In Keychain Access:
+
+1. Find the new "Developer ID Application: Your Name (TEAMID)" entry under **My Certificates**
+2. Right-click → **Export** → save as `mark-it-down-signing.p12` somewhere temporary
+3. **Set a strong password** when prompted — this becomes `MAC_CERTS_PASSWORD`
+
+### 3. Base64-encode the `.p12`
+
+```bash
+base64 -i mark-it-down-signing.p12 | pbcopy
+```
+
+The encoded blob is now in your clipboard — that's `MAC_CERTS`.
+
+### 4. Generate an app-specific password for notarization
+
+At [appleid.apple.com](https://appleid.apple.com):
+
+1. **Sign-In and Security** → **App-Specific Passwords**
+2. Generate one for "Mark It Down releases"
+3. Copy the value — that's `APPLE_APP_SPECIFIC_PASSWORD`
+
+### 5. Find your Apple Team ID
+
+In the Xcode Accounts pane (or at [developer.apple.com](https://developer.apple.com/account)), grab the 10-character `TEAMID` (e.g. `ABCD123456`). That's `APPLE_TEAM_ID`.
+
+### 6. Add all 5 secrets to the repo
+
+Repo → **Settings → Secrets and variables → Actions → New repository secret**:
+
+| Secret name | Value |
+|---|---|
+| `MAC_CERTS` | The base64 blob from step 3 |
+| `MAC_CERTS_PASSWORD` | The .p12 password from step 2 |
+| `APPLE_ID` | The Apple ID email you signed in with |
+| `APPLE_APP_SPECIFIC_PASSWORD` | The app-specific password from step 4 |
+| `APPLE_TEAM_ID` | The 10-char team id from step 5 |
+
+### 7. Verify on the next release
+
+Cut a `v0.X.Y` tag. The `release.yml` `electron` job's macOS runner picks up the secrets via the env block, signs the DMG, and notarizes it. Smoke-test:
+
+1. Download the new DMG from the release
+2. Open it on a fresh Mac (or one that's never had Mark It Down installed)
+3. The first-launch dialog should say "Mark It Down is from an identified developer" — NOT "from an unidentified developer"
+4. From a previous version, the auto-updater should successfully prompt + install the new one
+
+### Cert rotation
+
+Developer ID Application certs are valid for ~5 years. Repeat steps 1–3 + 6 (`MAC_CERTS` + `MAC_CERTS_PASSWORD`) before the cert expires. The Apple ID + team ID don't change.
+
+### When you're not ready yet
+
+Leave the secrets unset. The workflow's env block still references them, but electron-builder gracefully degrades — the build still succeeds, just produces an unsigned DMG. The release won't crash.
+
 ## Common failures
 
 | Symptom | Cause | Fix |


### PR DESCRIPTION
## Summary
- Activates the env block in `release.yml` for `MAC_CERTS` / `MAC_CERTS_PASSWORD` / `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID`
- electron-builder gracefully degrades to unsigned builds when secrets are absent — no broken release pipeline
- `docs/releasing.md` gains a 7-step "Setting up macOS code signing" section (cert creation → export → base64 → app-specific password → team ID → repo secrets → verification + cert rotation)
- `docs/auto-update.md` Code Signing section points at the runbook
- **User action after merge:** add 5 repo secrets per the runbook to enable signed builds

## Closes
Closes #33

## Test plan
- [x] yaml-lint warnings on the 5 unset secrets are expected (resolve when secrets are added)
- [ ] Smoke (post-secret-setup): cut a tag, verify the macOS DMG passes Gatekeeper on a fresh Mac

## Linked issue
[#33 — macOS code signing + notarization for Electron auto-update](https://github.com/fadymondy/mark-it-down/issues/33)