### PR TITLE
chore(release): VSCode Marketplace publisher setup runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — v1.1 hardening: VSCode Marketplace publisher setup runbook (#34)
+
+- `package.json` extended with marketplace-friendly metadata: `bugs.url`, `categories` adds "Notebooks", `keywords` adds preview/publish/slideshow/github-pages, `galleryBanner` (`#0d1117` dark), `qna: marketplace`
+- `media/marketplace/` placeholder directory with a README documenting the 6 screenshots needed for the listing (filename convention, size budget, capture instructions)
+- `docs/releasing.md` gains a 7-step "Setting up the VSCode Marketplace publisher" section: publisher creation at marketplace.visualstudio.com → Azure DevOps PAT → repo secret → first manual `vsce publish` → Open VSX mirror recommendation → screenshot guidance → token rotation cadence
+- The release workflow's `vsce publish` step is already conditional on `VSCE_PAT` being set (from F14 #28) — gracefully no-ops until the user adds the secret
+- **User action required** to actually go live: create the publisher account + add `VSCE_PAT` secret + first manual publish per the runbook
+
 ### Added — v1.1 hardening: macOS code signing + notarization wired (#33)
 
 - `.github/workflows/release.yml` env block now references `MAC_CERTS`, `MAC_CERTS_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` secrets — populated only on macOS runners that have them, electron-builder gracefully falls back to unsigned builds when absent

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -117,6 +117,79 @@ If a released version is broken:
 2. Bump the version (e.g. `0.2.0` → `0.2.1`), fix the bug on a hotfix branch, repeat the release flow. Don't rewrite or delete the bad tag — semver says versions are immutable.
 3. Note the broken version in the CHANGELOG of the new release: "Fixes a regression in v0.2.0 that caused X."
 
+## Setting up the VSCode Marketplace publisher
+
+Required for the release workflow's auto-publish step to actually push the `.vsix` to the Marketplace. Without `VSCE_PAT` set, the workflow still attaches the `.vsix` to the GitHub release (users can sideload), but no Marketplace listing updates.
+
+You'll need:
+
+- A Microsoft account
+- ~15 minutes for first-time setup
+
+### 1. Create the publisher
+
+1. Go to https://marketplace.visualstudio.com/manage
+2. Sign in with your Microsoft account
+3. **Create publisher** → ID: `fadymondy` (must match `package.json#publisher`)
+4. Fill in display name, email, optional logo. Publisher IDs are immutable — pick carefully.
+
+### 2. Create an Azure DevOps PAT
+
+1. Go to https://dev.azure.com — sign in with the same Microsoft account
+2. (If prompted) create a default organization
+3. Top-right user icon → **Personal access tokens** → **New Token**
+4. Settings:
+   - **Name**: "vsce publish"
+   - **Organization**: All accessible organizations (required for vsce)
+   - **Expiration**: 1 year (set a calendar reminder)
+   - **Scopes**: **Custom defined** → check **Marketplace → Manage**
+5. Copy the token immediately — that's `VSCE_PAT`. It won't be shown again.
+
+### 3. Add the secret to the repo
+
+Repo → **Settings → Secrets and variables → Actions → New repository secret** → name `VSCE_PAT`, value the token from step 2.
+
+### 4. First publish (manual, one-time)
+
+The first publish has to be manual to claim the listing. From your local checkout:
+
+```bash
+npm install -g @vscode/vsce
+vsce login fadymondy            # paste the PAT
+npm run compile
+vsce package --no-dependencies  # produces mark-it-down-0.X.Y.vsix
+vsce publish --packagePath mark-it-down-*.vsix
+```
+
+After this succeeds, the listing appears at https://marketplace.visualstudio.com/items?itemName=fadymondy.mark-it-down within ~5 minutes.
+
+### 5. Open VSX (recommended)
+
+For non-Microsoft VSCode forks (Cursor, Code-OSS, Codeberg-Codium, etc.) the Marketplace is locked. Mirror to Open VSX so those users can install too:
+
+1. Sign in at https://open-vsx.org with your GitHub account
+2. Generate an access token (Profile → Tokens)
+3. Add as `OVSX_PAT` repo secret
+4. Add a step to the release workflow's vscode job: `npx ovsx publish *.vsix --pat $OVSX_PAT`
+
+(This isn't wired automatically yet — left for a follow-up; the Marketplace path works on its own.)
+
+### 6. Verify subsequent releases
+
+After the first publish + the secret is set, every `v*.*.*` tag push triggers `release.yml`'s vscode job. The job runs `vsce publish` automatically and the listing updates within minutes. Watch the Actions tab; the Marketplace step's logs show the upload.
+
+### 7. Add screenshots to the listing
+
+The Marketplace pulls images from the README's image references at install time. The screenshots live in [media/marketplace/](../media/marketplace/) — see that directory's README for what to capture and the recommended sizes. Reference them in the main README under a "Screenshots" heading; `vsce package` bundles them with the `.vsix`.
+
+### Token rotation
+
+Both `VSCE_PAT` and (when configured) `OVSX_PAT` expire — set a calendar reminder for ~11 months out. Rotation is steps 2 + 3 only.
+
+### When you're not ready yet
+
+The release workflow's Marketplace publish step has `if: ${{ env.VSCE_PAT != '' }}` — when the secret is absent, the step is skipped without failing. The `.vsix` still attaches to the GitHub release for sideload.
+
 ## Setting up macOS code signing
 
 Required for Electron auto-update to work on macOS. Without these, the release workflow still produces a `.dmg` that installs fine on first download, but `electron-updater` can't apply updates to it (Apple Gatekeeper rejects the differential update on unsigned apps). Linux + Windows updates work without any of this.

--- a/media/marketplace/README.md
+++ b/media/marketplace/README.md
@@ -1,0 +1,33 @@
+# Marketplace screenshots
+
+The VSCode Marketplace listing pulls images from this directory. Each one should be:
+
+- **Format**: PNG (preferred) or JPEG
+- **Width**: 1280px (Marketplace renders at 1200px max; allow some headroom)
+- **Theme**: dark or light, but be consistent within a single capture set
+- **Filename**: numeric prefix for ordering (`01-editor.png`, `02-notes-sidebar.png`, …)
+
+Capture these for the v1.0 listing:
+
+| File | What to show |
+|---|---|
+| `01-editor.png` | Mark It Down rendering a real markdown file with a heading + table + code block + mermaid diagram |
+| `02-notes-sidebar.png` | The Notes activity-bar view expanded with both Workspace + Global scopes and a couple of categories populated |
+| `03-pick-theme.png` | The `Mark It Down: Pick Theme` Quick Pick mid-selection, surfacing 3-5 of the bundled themes |
+| `04-warehouse-sync.png` | The status bar's "Notes synced" indicator + a brief view of the warehouse repo's notes/ directory on GitHub |
+| `05-slideshow.png` | A slideshow preview panel beside an editor showing the source markdown |
+| `06-publish.png` | The published GitHub Pages site rendering one of the user's notes |
+
+After capture, reference them in `package.json#galleryBanner` style won't work — Marketplace pulls the images from the README rendered at install time. Add inline references in the project README's "Screenshots" section that use the `media/marketplace/<file>.png` path; the `vsce` packaging step bundles them.
+
+## Recording the captures
+
+1. Open VSCode with the dev-host extension loaded (F5)
+2. Set the theme to `github-dark` for the dark captures (or `github-light` for the light captures)
+3. Open a generous markdown file (the `docs/` folder has lots of options)
+4. Use macOS `Cmd+Shift+5` to capture the editor area; trim chrome with Preview if needed
+5. Save to this folder with the right filename
+
+## Recommended size budget
+
+Total of 6 PNGs at 1280×800 ≈ 1.5MB; well under the Marketplace's 2MB per-image limit. Keep individual files under 500KB each — Marketplace warns above that.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "categories": [
     "Visualization",
+    "Notebooks",
     "Other"
   ],
   "keywords": [
@@ -17,20 +18,32 @@
     "editor",
     "mermaid",
     "notes",
-    "mcp"
+    "mcp",
+    "preview",
+    "publish",
+    "slideshow",
+    "github-pages"
   ],
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/fadymondy/mark-it-down.git"
   },
-  "homepage": "https://github.com/fadymondy/mark-it-down",
+  "bugs": {
+    "url": "https://github.com/fadymondy/mark-it-down/issues"
+  },
+  "homepage": "https://github.com/fadymondy/mark-it-down#readme",
   "author": {
     "name": "Fady Mondy",
     "email": "info@3x1.io",
     "url": "https://github.com/fadymondy"
   },
   "icon": "media/icon.png",
+  "galleryBanner": {
+    "color": "#0d1117",
+    "theme": "dark"
+  },
+  "qna": "marketplace",
   "main": "./out/extension.js",
   "build": {
     "appId": "io.markitdown.app",


### PR DESCRIPTION
## Summary
- `package.json` extended with marketplace-friendly metadata (galleryBanner, qna, bugs.url, more keywords + categories)
- New `media/marketplace/` placeholder dir with a README detailing the 6 screenshots needed
- `docs/releasing.md` gains a 7-step Marketplace publisher setup section
- Release workflow's vsce publish step (from #28) gracefully no-ops without VSCE_PAT — already wired

## Closes
Closes #34

## Test plan
- [x] `npm run compile` clean (package.json metadata changes don't affect build)
- [ ] User adds `VSCE_PAT` per docs/releasing.md, runs first manual `vsce publish`, verifies listing appears at marketplace.visualstudio.com/items?itemName=fadymondy.mark-it-down

## Linked issue
[#34 — VSCode Marketplace publisher account + first publish](https://github.com/fadymondy/mark-it-down/issues/34)