### PR TITLE
feat(warehouse): side-by-side conflict-resolution UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — v1.2 polish: side-by-side conflict-resolution UI for warehouse (#39)
+
+- New `ConflictRegistry` collects diverged notes during sync (was previously just a log warning)
+- New `ConflictPanel` webview shows local vs remote side-by-side per note with `Keep local` / `Replace with remote` / `Skip` actions; live-refreshes as the registry changes
+- Status bar's `conflict` state now opens the panel on click (other states still open the log channel)
+- New command: `Mark It Down: Warehouse: Resolve Conflicts`
+- `Replace with remote` calls `NotesStore.importNote` with the remote content + remote `updatedAt`
+- Strict CSP scoped to the panel webview; per-button `aria-label`s; dark/light theme follows VSCode `--vscode-*` variables
+- F9 (#10) docs future-work seed for "side-by-side conflict UI" — resolved
+
 ### Added — v1.2 polish: accessibility audit + remediations (#38)
 
 - Mode toggle buttons (View / Edit): `aria-pressed` toggled in sync with `.active` class; `aria-label` overrides emoji-only labels; toolbar wrapper gains `aria-label="Mark It Down view mode"`

--- a/package.json
+++ b/package.json
@@ -241,6 +241,12 @@
         "icon": "$(output)"
       },
       {
+        "command": "markItDown.warehouse.openConflicts",
+        "title": "Warehouse: Resolve Conflicts",
+        "category": "Mark It Down",
+        "icon": "$(warning)"
+      },
+      {
         "command": "markItDown.pickTheme",
         "title": "Pick Theme",
         "category": "Mark It Down",

--- a/src/warehouse/conflictPanel.ts
+++ b/src/warehouse/conflictPanel.ts
@@ -1,0 +1,244 @@
+import * as vscode from 'vscode';
+import { ConflictRecord, ConflictRegistry } from './conflictRegistry';
+import { NotesStore } from '../notes/notesStore';
+import { log } from './warehouseLog';
+
+const VIEW_TYPE = 'markItDown.warehouse.conflicts';
+
+export class ConflictPanel implements vscode.Disposable {
+  private panel: vscode.WebviewPanel | undefined;
+  private readonly subs: vscode.Disposable[] = [];
+
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly registry: ConflictRegistry,
+    private readonly store: NotesStore,
+  ) {
+    this.subs.push(
+      registry.onDidChange(() => {
+        if (this.panel) this.refresh();
+      }),
+    );
+  }
+
+  public reveal(): void {
+    if (this.panel) {
+      this.panel.reveal(vscode.ViewColumn.Active);
+      this.refresh();
+      return;
+    }
+    this.panel = vscode.window.createWebviewPanel(
+      VIEW_TYPE,
+      'Mark It Down — Warehouse Conflicts',
+      vscode.ViewColumn.Active,
+      { enableScripts: true, retainContextWhenHidden: true },
+    );
+    this.panel.onDidDispose(() => {
+      this.panel = undefined;
+    });
+    this.panel.webview.onDidReceiveMessage(msg => this.handleMessage(msg));
+    this.refresh();
+  }
+
+  public dispose(): void {
+    this.panel?.dispose();
+    this.subs.forEach(s => s.dispose());
+  }
+
+  private refresh(): void {
+    if (!this.panel) return;
+    const records = this.registry.list();
+    this.panel.webview.html = this.renderHtml(records);
+    this.panel.title =
+      records.length > 0
+        ? `Mark It Down — Conflicts (${records.length})`
+        : 'Mark It Down — Conflicts';
+  }
+
+  private async handleMessage(msg: { type?: string; id?: string; choice?: string }): Promise<void> {
+    if (!msg?.type || !msg.id) return;
+    const record = this.registry.get(msg.id);
+    if (!record) return;
+    try {
+      switch (msg.type) {
+        case 'keepLocal':
+          this.registry.resolve(msg.id);
+          log('info', `conflict ${record.noteId} resolved by keeping local copy`);
+          vscode.window.setStatusBarMessage(
+            `Mark It Down: kept local copy of "${record.title}"`,
+            3000,
+          );
+          break;
+        case 'keepRemote':
+          await this.store.importNote(
+            { ...record.local, updatedAt: record.remote.updatedAt },
+            record.remoteContent,
+          );
+          this.registry.resolve(msg.id);
+          log('info', `conflict ${record.noteId} resolved by accepting remote copy`);
+          vscode.window.setStatusBarMessage(
+            `Mark It Down: replaced "${record.title}" with remote copy`,
+            3000,
+          );
+          break;
+        case 'skip':
+          this.registry.resolve(msg.id);
+          log('info', `conflict ${record.noteId} skipped (will re-surface on next sync if still diverged)`);
+          break;
+        default:
+          return;
+      }
+      this.refresh();
+    } catch (err) {
+      vscode.window.showErrorMessage(`Mark It Down: conflict resolution failed — ${(err as Error).message}`);
+    }
+  }
+
+  private renderHtml(records: ConflictRecord[]): string {
+    const csp = `default-src 'none'; style-src 'unsafe-inline'; script-src ${this.panel!.webview.cspSource} 'unsafe-inline';`;
+    const body =
+      records.length === 0
+        ? `<p class="empty">No conflicts. Run a Sync Now to populate.</p>`
+        : records.map(record => this.renderConflict(record)).join('\n');
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta http-equiv="Content-Security-Policy" content="${csp}" />
+<title>Mark It Down — Warehouse Conflicts</title>
+<style>
+  body {
+    font-family: var(--vscode-font-family, system-ui, sans-serif);
+    color: var(--vscode-foreground);
+    background: var(--vscode-editor-background);
+    padding: 16px 20px;
+    line-height: 1.55;
+  }
+  header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 12px; }
+  header h1 { margin: 0; font-size: 1.25em; }
+  .count { color: var(--vscode-descriptionForeground); font-size: 0.92em; }
+  .empty { color: var(--vscode-descriptionForeground); font-style: italic; }
+  .conflict {
+    border: 1px solid var(--vscode-panel-border);
+    border-radius: 6px;
+    margin-bottom: 18px;
+    overflow: hidden;
+  }
+  .conflict-head {
+    padding: 10px 14px;
+    background: var(--vscode-textBlockQuote-background);
+    border-bottom: 1px solid var(--vscode-panel-border);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .conflict-head strong { font-weight: 600; }
+  .conflict-head .meta { color: var(--vscode-descriptionForeground); font-size: 0.88em; }
+  .panes { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--vscode-panel-border); }
+  .pane { background: var(--vscode-editor-background); padding: 12px 14px; }
+  .pane h2 { font-size: 0.78em; text-transform: uppercase; letter-spacing: 0.06em; color: var(--vscode-descriptionForeground); margin: 0 0 8px; }
+  .pane h2 .ts { float: right; font-weight: normal; text-transform: none; letter-spacing: 0; }
+  .pane pre {
+    background: var(--vscode-textBlockQuote-background);
+    border: 1px solid var(--vscode-panel-border);
+    border-radius: 4px;
+    padding: 10px;
+    overflow: auto;
+    font-family: var(--vscode-editor-font-family, ui-monospace, monospace);
+    font-size: 0.88em;
+    line-height: 1.45;
+    margin: 0;
+    max-height: 320px;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .actions {
+    display: flex;
+    gap: 8px;
+    padding: 10px 14px;
+    border-top: 1px solid var(--vscode-panel-border);
+    background: var(--vscode-textBlockQuote-background);
+  }
+  .actions button {
+    padding: 6px 14px;
+    font-size: 12px;
+    background: var(--vscode-button-secondaryBackground, transparent);
+    color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
+    border: 1px solid var(--vscode-panel-border);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .actions button.primary {
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+    border-color: transparent;
+  }
+  .actions button:hover { filter: brightness(1.1); }
+  .actions button:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 1px; }
+  @media (max-width: 720px) { .panes { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+<header>
+  <h1>Warehouse conflicts</h1>
+  <span class="count">${records.length} note${records.length === 1 ? '' : 's'} diverged</span>
+</header>
+${body}
+<script>
+  const vscode = acquireVsCodeApi();
+  document.querySelectorAll('button[data-action]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      vscode.postMessage({ type: btn.dataset.action, id: btn.dataset.id });
+    });
+  });
+</script>
+</body>
+</html>`;
+  }
+
+  private renderConflict(record: ConflictRecord): string {
+    const localTs = formatTs(record.local.updatedAt);
+    const remoteTs = formatTs(record.remote.updatedAt);
+    return `
+<div class="conflict">
+  <div class="conflict-head">
+    <div>
+      <strong>${escapeHtml(record.title)}</strong>
+      <span class="meta">${escapeHtml(record.scope)} · ${escapeHtml(record.category)}</span>
+    </div>
+    <span class="meta">id: ${escapeHtml(record.noteId)}</span>
+  </div>
+  <div class="panes">
+    <div class="pane">
+      <h2>Local <span class="ts">${escapeHtml(localTs)}</span></h2>
+      <pre>${escapeHtml(record.localContent)}</pre>
+    </div>
+    <div class="pane">
+      <h2>Remote <span class="ts">${escapeHtml(remoteTs)}</span></h2>
+      <pre>${escapeHtml(record.remoteContent)}</pre>
+    </div>
+  </div>
+  <div class="actions">
+    <button class="primary" data-action="keepLocal" data-id="${escapeHtml(record.noteId)}">Keep local</button>
+    <button data-action="keepRemote" data-id="${escapeHtml(record.noteId)}">Replace with remote</button>
+    <button data-action="skip" data-id="${escapeHtml(record.noteId)}">Skip</button>
+  </div>
+</div>`;
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!));
+}
+
+function formatTs(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
+}
+
+export function registerConflictPanelCommand(panel: ConflictPanel): vscode.Disposable {
+  return vscode.commands.registerCommand('markItDown.warehouse.openConflicts', () => panel.reveal());
+}

--- a/src/warehouse/conflictRegistry.ts
+++ b/src/warehouse/conflictRegistry.ts
@@ -1,0 +1,61 @@
+import * as vscode from 'vscode';
+import { NoteMetadata, NoteScope } from '../notes/notesStore';
+
+export interface ConflictRecord {
+  noteId: string;
+  scope: NoteScope;
+  title: string;
+  category: string;
+  /** Local-side metadata at the moment the conflict was detected. */
+  local: NoteMetadata;
+  /** Remote-side metadata snapshot. */
+  remote: { updatedAt: string };
+  /** Pre-fetched remote content so the panel doesn't have to re-clone. */
+  remoteContent: string;
+  /** Local content snapshot. */
+  localContent: string;
+  detectedAt: string;
+}
+
+export class ConflictRegistry implements vscode.Disposable {
+  private readonly conflicts = new Map<string, ConflictRecord>();
+  private readonly emitter = new vscode.EventEmitter<void>();
+  public readonly onDidChange = this.emitter.event;
+
+  public list(): ConflictRecord[] {
+    return [...this.conflicts.values()].sort((a, b) =>
+      a.detectedAt.localeCompare(b.detectedAt),
+    );
+  }
+
+  public count(): number {
+    return this.conflicts.size;
+  }
+
+  public get(id: string): ConflictRecord | undefined {
+    return this.conflicts.get(id);
+  }
+
+  public record(record: ConflictRecord): void {
+    this.conflicts.set(record.noteId, record);
+    this.emitter.fire();
+  }
+
+  public resolve(id: string): ConflictRecord | undefined {
+    const r = this.conflicts.get(id);
+    if (!r) return undefined;
+    this.conflicts.delete(id);
+    this.emitter.fire();
+    return r;
+  }
+
+  public clear(): void {
+    if (this.conflicts.size === 0) return;
+    this.conflicts.clear();
+    this.emitter.fire();
+  }
+
+  public dispose(): void {
+    this.emitter.dispose();
+  }
+}

--- a/src/warehouse/warehouseCommands.ts
+++ b/src/warehouse/warehouseCommands.ts
@@ -7,5 +7,8 @@ export function registerWarehouseCommands(manager: WarehouseManager): vscode.Dis
     vscode.commands.registerCommand('markItDown.warehouse.pull', () => manager.pullCommand()),
     vscode.commands.registerCommand('markItDown.warehouse.openOnGitHub', () => manager.openOnGitHub()),
     vscode.commands.registerCommand('markItDown.warehouse.openLog', () => manager.openLog()),
+    vscode.commands.registerCommand('markItDown.warehouse.openConflicts', () =>
+      manager.conflictPanel.reveal(),
+    ),
   ];
 }

--- a/src/warehouse/warehouseManager.ts
+++ b/src/warehouse/warehouseManager.ts
@@ -5,11 +5,15 @@ import { log } from './warehouseLog';
 import { WarehouseStatusBar } from './warehouseStatusBar';
 import { PushPlan, SecretsDetectedError, SyncSummary, WarehouseSync } from './warehouseSync';
 import { WarehouseTransport } from './warehouseTransport';
+import { ConflictRegistry } from './conflictRegistry';
+import { ConflictPanel } from './conflictPanel';
 
 export class WarehouseManager implements vscode.Disposable {
   private readonly transport: WarehouseTransport;
   private readonly sync: WarehouseSync;
   private readonly statusBar: WarehouseStatusBar;
+  public readonly conflicts: ConflictRegistry;
+  public readonly conflictPanel: ConflictPanel;
   private readonly subs: vscode.Disposable[] = [];
   private autoPushTimer: NodeJS.Timeout | undefined;
   private currentConfig: WarehouseConfig;
@@ -20,11 +24,15 @@ export class WarehouseManager implements vscode.Disposable {
     private readonly store: NotesStore,
   ) {
     this.transport = new WarehouseTransport(context.globalStorageUri);
-    this.sync = new WarehouseSync(context, store, this.transport);
+    this.conflicts = new ConflictRegistry();
+    this.sync = new WarehouseSync(context, store, this.transport, this.conflicts);
     this.statusBar = new WarehouseStatusBar();
+    this.conflictPanel = new ConflictPanel(context, this.conflicts, store);
     this.currentConfig = readConfig();
 
     this.subs.push(
+      this.conflicts,
+      this.conflictPanel,
       vscode.workspace.onDidChangeConfiguration(e => {
         if (isAffected(e)) {
           this.currentConfig = readConfig();
@@ -32,6 +40,7 @@ export class WarehouseManager implements vscode.Disposable {
         }
       }),
       this.store.onDidChange(() => this.maybeSchedulePush()),
+      this.conflicts.onDidChange(() => this.refreshStatusBar()),
     );
     this.refreshStatusBar();
   }
@@ -185,9 +194,13 @@ export class WarehouseManager implements vscode.Disposable {
   private refreshStatusBar(): void {
     if (!this.currentConfig.enabled) {
       this.statusBar.set('disabled');
-    } else {
-      this.statusBar.set('idle', `${this.currentConfig.repo}@${this.currentConfig.branch}`);
+      return;
     }
+    if (this.conflicts.count() > 0) {
+      this.statusBar.set('conflict', `${this.conflicts.count()} note(s) diverged. Click to resolve.`);
+      return;
+    }
+    this.statusBar.set('idle', `${this.currentConfig.repo}@${this.currentConfig.branch}`);
   }
 
   private report(summary: SyncSummary): void {

--- a/src/warehouse/warehouseStatusBar.ts
+++ b/src/warehouse/warehouseStatusBar.ts
@@ -55,7 +55,6 @@ export class WarehouseStatusBar implements vscode.Disposable {
       50,
     );
     this.item.name = 'Mark It Down Warehouse Sync';
-    this.item.command = 'markItDown.warehouse.openLog';
     this.set('disabled');
     this.item.show();
   }
@@ -70,6 +69,9 @@ export class WarehouseStatusBar implements vscode.Disposable {
       label: `Mark It Down warehouse: ${render.text}${detail ? `, ${detail}` : ''}`,
       role: 'button',
     };
+    this.item.command = state === 'conflict'
+      ? 'markItDown.warehouse.openConflicts'
+      : 'markItDown.warehouse.openLog';
   }
 
   public state(): SyncState {

--- a/src/warehouse/warehouseSync.ts
+++ b/src/warehouse/warehouseSync.ts
@@ -5,6 +5,7 @@ import { PERSONAL_WORKSPACE_ID, scopeDir, WarehouseConfig } from './warehouseCon
 import { log } from './warehouseLog';
 import { scanForSecrets, SecretFinding } from './secretScanner';
 import { WarehouseClone, WarehouseTransport } from './warehouseTransport';
+import { ConflictRegistry } from './conflictRegistry';
 
 export interface SyncSummary {
   pulled: { added: number; updated: number; conflicts: number };
@@ -43,6 +44,7 @@ export class WarehouseSync {
     private readonly context: vscode.ExtensionContext,
     private readonly store: NotesStore,
     private readonly transport: WarehouseTransport,
+    private readonly conflicts: ConflictRegistry,
   ) {}
 
   public async pull(config: WarehouseConfig): Promise<SyncSummary['pulled']> {
@@ -82,6 +84,21 @@ export class WarehouseSync {
         if (localChangedSinceSync && remoteChangedSinceSync && localTime !== remoteTime) {
           conflicts++;
           log('warn', `conflict on note ${local.id} (${local.title}); keeping local copy`);
+          const remoteContent = await this.readRemoteContent(config, clone, scope, entry.filename);
+          if (remoteContent !== undefined) {
+            const localContent = await this.store.readContent(local).catch(() => '');
+            this.conflicts.record({
+              noteId: local.id,
+              scope: local.scope,
+              title: local.title,
+              category: local.category,
+              local,
+              remote: { updatedAt: entry.updatedAt },
+              localContent,
+              remoteContent,
+              detectedAt: new Date().toISOString(),
+            });
+          }
           continue;
         }
         const content = await this.readRemoteContent(config, clone, scope, entry.filename);


### PR DESCRIPTION
## Summary
- New `ConflictRegistry` + `ConflictPanel` webview (left = local, right = remote, per-note actions)
- Status-bar `conflict` state now opens the panel on click
- New command: `Warehouse: Resolve Conflicts`
- Per-note resolutions wired to NotesStore (Replace with remote = importNote)
- Resolves the future-work seed in F9 (#10) docs

## Closes
Closes #39

## Test plan
- [x] `npm test` 80/80 passing
- [x] `npm run compile` clean
- [ ] F5: configure warehouse, edit a note locally + remotely, run Sync Now, verify the conflict appears in the panel and each resolution path works

## Linked issue
[#39 — Side-by-side conflict-resolution UI for the warehouse](https://github.com/fadymondy/mark-it-down/issues/39)