### PR TITLE
feat(updates): pre-release / beta channel for both surfaces

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - 'v*.*.*'        # stable tags (e.g. v0.3.0)
+      - 'v*.*.*-*'      # pre-release tags (e.g. v0.3.0-rc.1, v0.3.0-beta.2)
 
 permissions:
   contents: write
@@ -107,3 +108,18 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           gh release edit "$TAG" --notes "${{ steps.extract.outputs.notes }}"
+      - name: Mark as pre-release if tag has a hyphen
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          # Pre-release tags look like v0.3.0-rc.1 / v0.3.0-beta.2 — flip
+          # the GitHub release's prerelease flag so the stable channel
+          # poller (which uses /releases/latest) skips them automatically.
+          if [[ "$TAG" == *-* ]]; then
+            gh release edit "$TAG" --prerelease
+            echo "Marked $TAG as pre-release"
+          else
+            gh release edit "$TAG" --prerelease=false
+            echo "Marked $TAG as stable"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — v1.2 polish: pre-release / beta channel (#40)
+
+- New `markItDown.updates.channel` setting (`"stable"` default, `"beta"` opt-in)
+- VSCode poller: stable channel hits `/repos/.../releases/latest` (GitHub auto-skips pre-releases); beta channel hits `/repos/.../releases?per_page=20` and picks the newest non-draft including pre-releases
+- Electron `autoUpdater.channel` / `allowPrerelease` driven by the `MID_CHANNEL=beta` env var (mirror of the VSCode setting)
+- Release workflow now matches both `v*.*.*` (stable) and `v*.*.*-*` (pre-release: `-rc.1` / `-beta.2` / etc.) tag patterns
+- Workflow's release-notes job auto-flips the GitHub release's `prerelease` flag based on whether the tag has a hyphen — stable tags get `prerelease: false`, pre-release tags get `prerelease: true`
+- New "Pre-release / beta channel" section in `docs/auto-update.md` walking through how the two channels diverge
+
 ### Added — v1.2 polish: side-by-side conflict-resolution UI for warehouse (#39)
 
 - New `ConflictRegistry` collects diverged notes during sync (was previously just a log warning)

--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -136,6 +136,11 @@ function setupAutoUpdate(): void {
   // and falls back to GitHub via repository.url at runtime.
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = false; // user has to opt in via menu
+  // Channel: stable | beta. Set via env so the Electron app respects whatever
+  // the VSCode extension wrote (or the user can override with MID_CHANNEL).
+  const channel = process.env.MID_CHANNEL === 'beta' ? 'beta' : 'latest';
+  autoUpdater.channel = channel;
+  autoUpdater.allowPrerelease = channel === 'beta';
   autoUpdater.on('update-available', info => {
     updateState.available = true;
     updateState.version = info.version;

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -46,6 +46,21 @@ Settings:
 | Setting | Default | What it does |
 |---|---|---|
 | `markItDown.updates.checkOnLaunch` | `true` | Poll GitHub on launch + every 6h. Set to `false` to disable; `Check for Updates` command still works manually. |
+| `markItDown.updates.channel` | `"stable"` | `"stable"` follows `releases/latest` (skips pre-releases). `"beta"` opts into pre-release tags (e.g. `v0.3.0-rc.1`). For the Electron app, set `MID_CHANNEL=beta` env var. See [Pre-release / beta channel](#pre-release--beta-channel) below. |
+
+## Pre-release / beta channel
+
+Cut a tag like `v0.3.0-rc.1` or `v0.3.0-beta.2`. The release workflow:
+
+1. Builds Electron installers + `.vsix` as for any release
+2. Sets the GitHub release's `prerelease: true` flag (because the tag has a `-` in it)
+
+The two pollers behave differently per channel:
+
+- **Stable channel** (default): the in-extension poller hits `/repos/.../releases/latest` which GitHub itself filters to skip pre-releases — beta tags are invisible. `electron-updater`'s default channel = `latest` does the same.
+- **Beta channel** (`markItDown.updates.channel: "beta"` / `MID_CHANNEL=beta`): the in-extension poller hits `/repos/.../releases?per_page=20` and picks the newest non-draft (pre-release OR stable). `electron-updater.allowPrerelease = true` does the same on the Electron side.
+
+So beta users see `v0.3.0-rc.1` immediately; stable users wait until you cut `v0.3.0` proper.
 
 ## Electron side
 

--- a/package.json
+++ b/package.json
@@ -611,6 +611,12 @@
           "default": true,
           "markdownDescription": "Check for newer Mark It Down releases on GitHub once per launch (and every 6 hours after). Only used by users on a self-installed `.vsix`; Marketplace installs use VSCode's native update mechanism."
         },
+        "markItDown.updates.channel": {
+          "type": "string",
+          "default": "stable",
+          "enum": ["stable", "beta"],
+          "markdownDescription": "Update channel. `stable` follows the GitHub `releases/latest` endpoint (skips pre-releases). `beta` opts into pre-release tags (e.g. `v0.3.0-rc.1`) — useful for dogfooding before stable. The Electron app respects `MID_CHANNEL=beta` for the same effect."
+        },
         "markItDown.telemetry.enabled": {
           "type": "boolean",
           "default": false,

--- a/src/updates/updateChecker.ts
+++ b/src/updates/updateChecker.ts
@@ -4,7 +4,8 @@ import { compareSemver } from '../../packages/core/src/semver';
 
 const REPO_OWNER = 'fadymondy';
 const REPO_NAME = 'mark-it-down';
-const RELEASE_API = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest`;
+const LATEST_RELEASE_API = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest`;
+const ALL_RELEASES_API = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases?per_page=20`;
 const STATE_KEYS = {
   lastCheckedAt: 'markItDown.updates.lastCheckedAt',
   lastSeenVersion: 'markItDown.updates.lastSeenVersion',
@@ -45,11 +46,16 @@ export class UpdateChecker {
     return vscode.workspace.getConfiguration('markItDown.updates').get<boolean>('checkOnLaunch') ?? true;
   }
 
+  private channel(): 'stable' | 'beta' {
+    const v = vscode.workspace.getConfiguration('markItDown.updates').get<string>('channel') ?? 'stable';
+    return v === 'beta' ? 'beta' : 'stable';
+  }
+
   private async runCheck(opts: { trigger: 'launch' | 'interval' | 'manual' }): Promise<void> {
     const installed = this.installedVersion();
     let release: UpdateInfo | undefined;
     try {
-      release = await fetchLatestRelease();
+      release = await fetchLatestRelease(this.channel());
     } catch (err) {
       if (opts.trigger === 'manual') {
         vscode.window.showErrorMessage(`Mark It Down: update check failed — ${(err as Error).message}`);
@@ -114,10 +120,47 @@ export class UpdateChecker {
   }
 }
 
-function fetchLatestRelease(): Promise<UpdateInfo | undefined> {
+interface RawRelease {
+  tag_name?: string;
+  name?: string;
+  html_url?: string;
+  body?: string;
+  published_at?: string;
+  draft?: boolean;
+  prerelease?: boolean;
+}
+
+function fetchLatestRelease(channel: 'stable' | 'beta'): Promise<UpdateInfo | undefined> {
+  // For stable users we can use the cheap /releases/latest endpoint that
+  // already filters out drafts + pre-releases. For beta users we have to
+  // fetch the full list and pick the newest non-draft (pre-release OR stable).
+  if (channel === 'stable') {
+    return fetchSingle(LATEST_RELEASE_API, raw => {
+      if (raw.draft || raw.prerelease) return undefined;
+      return toUpdateInfo(raw);
+    });
+  }
+  return fetchList(ALL_RELEASES_API, list => {
+    const candidate = list.find(r => !r.draft);
+    return candidate ? toUpdateInfo(candidate) : undefined;
+  });
+}
+
+function toUpdateInfo(raw: RawRelease): UpdateInfo | undefined {
+  if (!raw.tag_name) return undefined;
+  const version = raw.tag_name.replace(/^v/, '');
+  return {
+    version,
+    htmlUrl: raw.html_url ?? `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/tag/${raw.tag_name}`,
+    bodyMarkdown: raw.body ?? '',
+    publishedAt: raw.published_at ?? '',
+  };
+}
+
+function fetchSingle(url: string, pick: (raw: RawRelease) => UpdateInfo | undefined): Promise<UpdateInfo | undefined> {
   return new Promise((resolve, reject) => {
     const req = https.request(
-      RELEASE_API,
+      url,
       {
         method: 'GET',
         headers: {
@@ -131,7 +174,6 @@ function fetchLatestRelease(): Promise<UpdateInfo | undefined> {
         res.on('data', chunk => (body += chunk.toString()));
         res.on('end', () => {
           if (res.statusCode === 404) {
-            // No releases published yet — silently no-op.
             resolve(undefined);
             return;
           }
@@ -140,26 +182,47 @@ function fetchLatestRelease(): Promise<UpdateInfo | undefined> {
             return;
           }
           try {
-            const json = JSON.parse(body) as {
-              tag_name?: string;
-              name?: string;
-              html_url?: string;
-              body?: string;
-              published_at?: string;
-              draft?: boolean;
-              prerelease?: boolean;
-            };
-            if (!json || json.draft || json.prerelease || !json.tag_name) {
-              resolve(undefined);
-              return;
-            }
-            const version = json.tag_name.replace(/^v/, '');
-            resolve({
-              version,
-              htmlUrl: json.html_url ?? `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/tag/${json.tag_name}`,
-              bodyMarkdown: json.body ?? '',
-              publishedAt: json.published_at ?? '',
-            });
+            const json = JSON.parse(body) as RawRelease;
+            resolve(json ? pick(json) : undefined);
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.on('timeout', () => req.destroy(new Error('request timed out')));
+    req.end();
+  });
+}
+
+function fetchList(url: string, pick: (list: RawRelease[]) => UpdateInfo | undefined): Promise<UpdateInfo | undefined> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      url,
+      {
+        method: 'GET',
+        headers: {
+          'User-Agent': 'mark-it-down-vscode-extension',
+          Accept: 'application/vnd.github+json',
+        },
+        timeout: 10_000,
+      },
+      res => {
+        let body = '';
+        res.on('data', chunk => (body += chunk.toString()));
+        res.on('end', () => {
+          if (res.statusCode === 404) {
+            resolve(undefined);
+            return;
+          }
+          if (res.statusCode && res.statusCode >= 400) {
+            reject(new Error(`GitHub API ${res.statusCode}: ${body.slice(0, 200)}`));
+            return;
+          }
+          try {
+            const json = JSON.parse(body) as RawRelease[];
+            resolve(Array.isArray(json) ? pick(json) : undefined);
           } catch (err) {
             reject(err);
           }


### PR DESCRIPTION
## Summary
- `markItDown.updates.channel` (stable | beta) drives both surfaces
- VSCode poller branches between `/releases/latest` (stable) and `/releases?per_page=20` (beta)
- Electron honors `MID_CHANNEL=beta` env var for `autoUpdater.channel` + `allowPrerelease`
- Release workflow accepts `v*.*.*-*` tags + auto-flips the GitHub release's `prerelease` flag
- Docs updated

## Closes
Closes #40

## Test plan
- [x] `npm test` 80/80 passing
- [x] `npm run compile` clean
- [ ] Cut a `v0.1.1-rc.1` tag, verify CI marks the release as pre-release; flip channel to beta and confirm the in-extension poller surfaces it

## Linked issue
[#40 — Pre-release / beta channel for both surfaces](https://github.com/fadymondy/mark-it-down/issues/40)