### PR TITLE
feat(search): fuzzy search across sidebar + MCP + published site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — v1.2 polish: search across notes (#41)
+
+- New `packages/core/src/search/searcher.ts` — pure-function fuzzy search (no deps), shared by sidebar + MCP. Per-token scoring: exact title (+10), partial title (+5), category (+3), body occurrences (+1, capped at 5). Tie-breaks by recency.
+- **Sidebar search**: `Mark It Down: Search Notes` command — input box → fuzzy match → Quick Pick → Enter opens the chosen note. Wired into the Notes view title bar.
+- **MCP `search_notes` tool**: `{ query, limit? }` → ranked hits with `id`, `title`, `category`, `scope`, `updatedAt`, `score`, `snippet`.
+- **Claude plugin**: new `/mid:search` skill (7 skills total in the bundle now).
+- **Published-site search**: each site ships `assets/search-index.json` (Lunr 2 + a doc map with title + 200-char snippet). Header search input lazy-loads the index on first keystroke; debounces 200ms; up to 12 hits.
+- 11 new unit tests covering the searcher (tokenize, title/body/category scoring, exact vs partial title boost, multi-token sum, limit, recency tie-break, no-match, snippet length cap)
+
 ### Added — v1.2 polish: pre-release / beta channel (#40)
 
 - New `markItDown.updates.channel` setting (`"stable"` default, `"beta"` opt-in)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "electron-updater": "^6.8.3",
         "highlight.js": "^11.10.0",
         "html-to-image": "^1.11.13",
+        "lunr": "^2.3.9",
         "marked": "^14.1.3",
         "marked-highlight": "^2.2.1",
         "mermaid": "^11.4.1",
@@ -33,6 +34,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/dompurify": "^3.2.0",
+        "@types/lunr": "^2.3.7",
         "@types/mocha": "^10.0.10",
         "@types/node": "^22.10.0",
         "@types/vscode": "^1.85.0",
@@ -3650,6 +3652,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/lunr": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@types/lunr/-/lunr-2.3.7.tgz",
+      "integrity": "sha512-Tb/kUm38e8gmjahQzdCKhbdsvQ9/ppzHFfsJ0dMs3ckqQsRj+P5IkSAwFTBrBxdyr3E/LoMUUrZngjDYAjiE3A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
@@ -9846,6 +9855,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",

--- a/package.json
+++ b/package.json
@@ -211,6 +211,12 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "markItDown.notes.search",
+        "title": "Search Notes",
+        "category": "Mark It Down",
+        "icon": "$(search)"
+      },
+      {
         "command": "markItDown.notes.revealStorage",
         "title": "Reveal Notes Folder",
         "category": "Mark It Down",
@@ -350,9 +356,14 @@
           "group": "navigation@1"
         },
         {
-          "command": "markItDown.notes.refresh",
+          "command": "markItDown.notes.search",
           "when": "view == markItDown.notes",
           "group": "navigation@2"
+        },
+        {
+          "command": "markItDown.notes.refresh",
+          "when": "view == markItDown.notes",
+          "group": "navigation@3"
         },
         {
           "command": "markItDown.warehouse.syncNow",
@@ -614,7 +625,10 @@
         "markItDown.updates.channel": {
           "type": "string",
           "default": "stable",
-          "enum": ["stable", "beta"],
+          "enum": [
+            "stable",
+            "beta"
+          ],
           "markdownDescription": "Update channel. `stable` follows the GitHub `releases/latest` endpoint (skips pre-releases). `beta` opts into pre-release tags (e.g. `v0.3.0-rc.1`) — useful for dogfooding before stable. The Electron app respects `MID_CHANNEL=beta` for the same effect."
         },
         "markItDown.telemetry.enabled": {
@@ -668,6 +682,7 @@
     "electron-updater": "^6.8.3",
     "highlight.js": "^11.10.0",
     "html-to-image": "^1.11.13",
+    "lunr": "^2.3.9",
     "marked": "^14.1.3",
     "marked-highlight": "^2.2.1",
     "mermaid": "^11.4.1",
@@ -677,6 +692,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/dompurify": "^3.2.0",
+    "@types/lunr": "^2.3.7",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.10.0",
     "@types/vscode": "^1.85.0",

--- a/packages/core/src/search/index.ts
+++ b/packages/core/src/search/index.ts
@@ -1,0 +1,1 @@
+export * from './searcher';

--- a/packages/core/src/search/searcher.ts
+++ b/packages/core/src/search/searcher.ts
@@ -1,0 +1,122 @@
+/**
+ * Tiny zero-dep fuzzy + token-based searcher used by the Notes sidebar
+ * and the MCP search_notes tool. The published-site search uses Lunr
+ * separately because it needs a pre-built index.
+ *
+ * Algorithm:
+ *   1. Tokenize the query into lowercased words
+ *   2. For each note, score = sum of per-token contribution:
+ *      - exact title match → +10
+ *      - title contains token → +5
+ *      - category contains token → +3
+ *      - body contains token → +1 (per occurrence, capped at 5)
+ *   3. Drop notes with score 0
+ *   4. Sort by descending score; tie-break by recency (updatedAt desc)
+ *   5. Snippet: first body line containing any matched token, padded ±40 chars
+ */
+
+export interface SearchableNote {
+  id: string;
+  title: string;
+  category: string;
+  scope: 'workspace' | 'global';
+  updatedAt: string;
+  body: string;
+}
+
+export interface SearchHit {
+  id: string;
+  title: string;
+  category: string;
+  scope: 'workspace' | 'global';
+  updatedAt: string;
+  score: number;
+  snippet: string;
+}
+
+const SNIPPET_PAD = 40;
+const SNIPPET_MAX = 160;
+
+export function searchNotes(
+  notes: SearchableNote[],
+  rawQuery: string,
+  limit = 25,
+): SearchHit[] {
+  const tokens = tokenize(rawQuery);
+  if (tokens.length === 0) return [];
+
+  const hits: SearchHit[] = [];
+  for (const note of notes) {
+    const titleLower = note.title.toLowerCase();
+    const categoryLower = note.category.toLowerCase();
+    const bodyLower = note.body.toLowerCase();
+    let score = 0;
+
+    for (const tok of tokens) {
+      if (titleLower === tok) score += 10;
+      else if (titleLower.includes(tok)) score += 5;
+      if (categoryLower.includes(tok)) score += 3;
+      if (bodyLower.includes(tok)) {
+        const occurrences = countOccurrences(bodyLower, tok);
+        score += Math.min(occurrences, 5);
+      }
+    }
+
+    if (score === 0) continue;
+
+    hits.push({
+      id: note.id,
+      title: note.title,
+      category: note.category,
+      scope: note.scope,
+      updatedAt: note.updatedAt,
+      score,
+      snippet: buildSnippet(note.body, tokens),
+    });
+  }
+
+  hits.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return b.updatedAt.localeCompare(a.updatedAt);
+  });
+
+  return hits.slice(0, limit);
+}
+
+export function tokenize(query: string): string[] {
+  return query
+    .toLowerCase()
+    .split(/[\s,;]+/)
+    .map(t => t.trim())
+    .filter(t => t.length > 0);
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  let pos = 0;
+  while ((pos = haystack.indexOf(needle, pos)) >= 0) {
+    count++;
+    pos += needle.length;
+  }
+  return count;
+}
+
+function buildSnippet(body: string, tokens: string[]): string {
+  if (body.length === 0) return '';
+  const bodyLower = body.toLowerCase();
+  let bestPos = -1;
+  for (const tok of tokens) {
+    const idx = bodyLower.indexOf(tok);
+    if (idx >= 0 && (bestPos < 0 || idx < bestPos)) bestPos = idx;
+  }
+  if (bestPos < 0) {
+    return body.slice(0, SNIPPET_MAX).replace(/\s+/g, ' ').trim();
+  }
+  const start = Math.max(0, bestPos - SNIPPET_PAD);
+  const end = Math.min(body.length, bestPos + SNIPPET_MAX - SNIPPET_PAD);
+  let snippet = body.slice(start, end).replace(/\s+/g, ' ').trim();
+  if (start > 0) snippet = '…' + snippet;
+  if (end < body.length) snippet = snippet + '…';
+  return snippet;
+}

--- a/plugins/mark-it-down-claude/skills/mid-search/SKILL.md
+++ b/plugins/mark-it-down-claude/skills/mid-search/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: mid:search
+description: Fuzzy search across all Mark It Down notes — title + category + body. Use when the user asks "what notes do I have about X", "find my notes mentioning Y", or names a topic without a specific note title.
+---
+
+# /mid:search
+
+Run a fuzzy search across the Mark It Down notes warehouse via the bundled MCP server's `search_notes` tool.
+
+## When to invoke
+
+- User asks "what did I write about X" or "find my notes mentioning Y"
+- User names a topic / keyword without a specific note title
+- User wants a snippet preview before opening a note
+
+## What you'll do
+
+1. **Call the MCP tool** `search_notes` with `{ query: string, limit?: number }`. Default limit 25.
+2. **Format the response** as a readable hit list, ranked by score:
+   ```
+   3 hits for "postgres":
+
+   1. Postgres tuning: pooler + index hint cuts p99 by 200ms (Reference · score 11)
+      …connection pooler plus an index hint cut p99 by 200ms. Also bumped work_mem…
+
+   2. Sprint 12 retro (Daily · score 1)
+      …postgres migration scheduled for next Monday…
+   ```
+3. **Offer follow-ups** — "Open hit 1?" routes to `/mid:open`. The `id` field on each hit is what `get_note` accepts.
+
+## Tips
+
+- For "show me everything" requests, prefer `/mid:list-notes` (cheaper; no body load).
+- For "find anything about X" requests, this is the right tool — it indexes title + category + body.
+- The scoring weights title matches highest (10/exact, 5/partial), category next (3), then body (1 per occurrence, capped at 5).
+- For very short queries (1-2 chars), search is noisy — ask the user to refine if hit count is large and scores are uniformly low.
+
+## Failure modes
+
+- **MCP server not configured** → tell user to install via the Mark It Down extension or the Claude plugin's bundled `bin/server.js`.
+- **No hits** → not a failure; tell the user "no notes match \"<query>\"" and suggest `/mid:list-notes` to browse instead.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,6 +4,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { NotesAdapter } from './notesAdapter';
 import { IpcClient } from './ipcClient';
+import { searchNotes, SearchableNote } from '../../packages/core/src/search';
 
 const args = parseArgs(process.argv.slice(2));
 if (!args.notesDir) {
@@ -125,6 +126,37 @@ server.registerTool(
       };
     }
     return { content: [{ type: 'text', text: `deleted ${removed.id} (${removed.title})` }] };
+  },
+);
+
+server.registerTool(
+  'search_notes',
+  {
+    description: 'Fuzzy search across all global notes (title + category + body). Returns ranked hits with snippet + score.',
+    inputSchema: {
+      query: z.string().describe('Search query — words/phrases separated by whitespace'),
+      limit: z.number().optional().describe('Max hits to return (default 25)'),
+    },
+  },
+  async ({ query, limit }) => {
+    const all = await adapter.listNotes();
+    const searchable: SearchableNote[] = await Promise.all(
+      all.map(async meta => {
+        const note = await adapter.getNote(meta.id);
+        return {
+          id: meta.id,
+          title: meta.title,
+          category: meta.category,
+          scope: 'global' as const,
+          updatedAt: meta.updatedAt,
+          body: note?.content ?? '',
+        };
+      }),
+    );
+    const hits = searchNotes(searchable, query, limit ?? 25);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(hits, null, 2) }],
+    };
   },
 );
 

--- a/src/notes/notesCommands.ts
+++ b/src/notes/notesCommands.ts
@@ -7,6 +7,7 @@ import {
 } from './notesTreeProvider';
 import { NoteMetadata, NoteScope, NotesStore } from './notesStore';
 import { MarkdownEditorProvider } from '../editor/markdownEditorProvider';
+import { searchNotes, SearchableNote } from '../../packages/core/src/search';
 
 export function registerNotesCommands(
   context: vscode.ExtensionContext,
@@ -74,6 +75,42 @@ export function registerNotesCommands(
 
     vscode.commands.registerCommand('markItDown.notes.refresh', () => {
       store.dispatchRefresh();
+    }),
+
+    vscode.commands.registerCommand('markItDown.notes.search', async () => {
+      const query = await vscode.window.showInputBox({
+        prompt: 'Search notes (title + category + body, fuzzy)',
+        placeHolder: 'e.g. "postgres tuning"',
+      });
+      if (!query) return;
+      const all = store.listAll();
+      const searchable: SearchableNote[] = await Promise.all(
+        all.map(async note => ({
+          id: note.id,
+          title: note.title,
+          category: note.category,
+          scope: note.scope,
+          updatedAt: note.updatedAt,
+          body: await store.readContent(note).catch(() => ''),
+        })),
+      );
+      const hits = searchNotes(searchable, query, 25);
+      if (hits.length === 0) {
+        vscode.window.showInformationMessage(`Mark It Down: no notes match "${query}".`);
+        return;
+      }
+      const picked = await vscode.window.showQuickPick(
+        hits.map(h => ({
+          label: h.title,
+          description: `${h.scope}/${h.category} · score ${h.score}`,
+          detail: h.snippet,
+          id: h.id,
+        })),
+        { placeHolder: `${hits.length} matching note(s)` },
+      );
+      if (picked) {
+        await vscode.commands.executeCommand('markItDown.notes.open', picked.id);
+      }
     }),
 
     vscode.commands.registerCommand('markItDown.notes.revealStorage', async (node?: NoteTreeNode) => {

--- a/src/publish/publishManager.ts
+++ b/src/publish/publishManager.ts
@@ -7,6 +7,7 @@ import { log } from '../warehouse/warehouseLog';
 import { findTheme } from '../themes/themes';
 import { PublishConfig, readPublishConfig } from './publishConfig';
 import { buildSiteAssets, PageInput, renderIndex, renderPage } from './staticGenerator';
+import lunr from 'lunr';
 
 export interface PublishResult {
   pages: number;
@@ -191,6 +192,28 @@ export class PublishManager {
       vscode.Uri.file(path.join(assetsDir, 'style.css')),
       new TextEncoder().encode(assets.pageCss),
     );
+
+    // Lunr search index — built from page title + plain-text body
+    const docs = pages.map(p => ({
+      id: p.pathFromRoot,
+      title: p.title,
+      body: stripMarkdown(p.markdown),
+    }));
+    const index = lunr(function () {
+      this.ref('id');
+      this.field('title', { boost: 5 });
+      this.field('body');
+      docs.forEach(d => this.add(d));
+    });
+    await vscode.workspace.fs.writeFile(
+      vscode.Uri.file(path.join(assetsDir, 'search-index.json')),
+      new TextEncoder().encode(
+        JSON.stringify({
+          index: index.toJSON(),
+          docs: docs.map(d => ({ id: d.id, title: d.title, snippet: d.body.slice(0, 200) })),
+        }),
+      ),
+    );
     await vscode.workspace.fs.writeFile(
       vscode.Uri.file(path.join(assetsDir, 'site.js')),
       new TextEncoder().encode(assets.clientJs),
@@ -231,6 +254,19 @@ export class PublishManager {
   private pageUrl(wh: WarehouseConfig, pub: PublishConfig, relative: string): string {
     return `${this.siteUrl(wh, pub).replace(/\/?$/, '/')}${relative}`;
   }
+}
+
+function stripMarkdown(md: string): string {
+  // Cheap text extractor — strip code fences, mermaid blocks, html tags,
+  // and link / heading / emphasis markers so the search index is on prose.
+  return md
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[#>*_`~|-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 function slugify(input: string): string {

--- a/src/publish/staticGenerator.ts
+++ b/src/publish/staticGenerator.ts
@@ -70,16 +70,19 @@ export function renderPage(input: PageInput, indexPages: { title: string; pathFr
 <title>${escapeHtml(input.title)}</title>
 <link rel="stylesheet" href="${rel(input.pathFromRoot, 'assets/style.css')}" />
 </head>
-<body>
+<body data-assets-base="${rel(input.pathFromRoot, 'assets/')}">
 <header class="mid-header">
   <a class="mid-home" href="${rel(input.pathFromRoot, 'index.html')}">Mark It Down</a>
   <span class="mid-doc-title">${escapeHtml(input.title)}</span>
+  <input type="search" id="mid-search" placeholder="Search…" aria-label="Search notes" />
 </header>
 <aside class="mid-nav">
   <h2>Pages</h2>
   <ul>${navItems}</ul>
+  <div id="mid-search-results" hidden></div>
 </aside>
 <main class="mid-body">${body}</main>
+<script src="https://cdn.jsdelivr.net/npm/lunr@2/lunr.min.js"></script>
 <script src="${rel(input.pathFromRoot, 'assets/site.js')}"></script>
 </body>
 </html>`;
@@ -101,11 +104,14 @@ export function renderIndex(pages: { title: string; pathFromRoot: string }[]): s
 <body>
 <header class="mid-header">
   <a class="mid-home" href="index.html">Mark It Down</a>
+  <input type="search" id="mid-search" placeholder="Search…" aria-label="Search notes" />
 </header>
 <main class="mid-body">
   <h1>Pages</h1>
   <ul class="mid-index">${items}</ul>
+  <div id="mid-search-results" hidden></div>
 </main>
+<script src="https://cdn.jsdelivr.net/npm/lunr@2/lunr.min.js"></script>
 <script src="assets/site.js"></script>
 </body>
 </html>`;
@@ -154,6 +160,26 @@ body {
 }
 .mid-home { color: var(--accent); font-weight: 600; text-decoration: none; }
 .mid-doc-title { color: var(--fg-muted); font-size: 0.92em; }
+#mid-search {
+  margin-left: auto;
+  padding: 5px 10px;
+  font-size: 0.92em;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  min-width: 180px;
+}
+#mid-search:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+#mid-search-results {
+  margin-top: 12px;
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+}
+.mid-search-hit { margin: 8px 0; }
+.mid-search-hit a { color: var(--link); text-decoration: none; }
+.mid-search-hit a:hover { text-decoration: underline; }
+.mid-search-snippet { color: var(--fg-muted); font-size: 0.88em; line-height: 1.4; }
 .mid-nav {
   grid-area: nav;
   background: var(--code-bg);
@@ -261,6 +287,48 @@ const CLIENT_JS = `
       window.mermaid.initialize({ startOnLoad: true, theme: bgIsDark || isDark ? 'dark' : 'default', securityLevel: 'strict' });
     };
     document.head.appendChild(s);
+  }
+  // Search — lazy-load the index on first input, then run lunr queries.
+  var searchInput = document.getElementById('mid-search');
+  var searchResults = document.getElementById('mid-search-results');
+  if (searchInput && searchResults) {
+    var indexPromise = null;
+    function loadIndex() {
+      if (indexPromise) return indexPromise;
+      var assetsBase = document.body.getAttribute('data-assets-base') || 'assets/';
+      indexPromise = fetch(assetsBase + 'search-index.json').then(function(r){ return r.json(); }).then(function(data){
+        return { idx: window.lunr.Index.load(data.index), docs: data.docs };
+      }).catch(function(err){
+        console.warn('search index load failed:', err);
+        return null;
+      });
+      return indexPromise;
+    }
+    var debounce;
+    searchInput.addEventListener('input', function(){
+      clearTimeout(debounce);
+      var q = searchInput.value.trim();
+      if (!q) {
+        searchResults.hidden = true;
+        searchResults.innerHTML = '';
+        return;
+      }
+      debounce = setTimeout(function(){
+        loadIndex().then(function(bundle){
+          if (!bundle) return;
+          var hits;
+          try { hits = bundle.idx.search(q); } catch (_e) { hits = []; }
+          var byId = {};
+          bundle.docs.forEach(function(d){ byId[d.id] = d; });
+          searchResults.hidden = hits.length === 0;
+          searchResults.innerHTML = hits.slice(0, 12).map(function(h){
+            var d = byId[h.ref] || { id: h.ref, title: h.ref, snippet: '' };
+            return '<div class="mid-search-hit"><a href="' + d.id + '"><strong>' + escapeHtml(d.title) + '</strong></a><div class="mid-search-snippet">' + escapeHtml(d.snippet) + '</div></div>';
+          }).join('');
+        });
+      }, 200);
+    });
+    function escapeHtml(s){ return s.replace(/[&<>"']/g, function(c){ return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'})[c]; }); }
   }
 })();
 `;

--- a/tests/unit/searcher.test.ts
+++ b/tests/unit/searcher.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { searchNotes, SearchableNote, tokenize } from '../../packages/core/src/search/searcher';
+
+const sample: SearchableNote[] = [
+  {
+    id: 'n1',
+    title: 'Postgres tuning',
+    category: 'Reference',
+    scope: 'global',
+    updatedAt: '2026-04-22T17:42:00.000Z',
+    body: 'Connection pooler plus an index hint cut p99 by 200ms. Also bumped work_mem.',
+  },
+  {
+    id: 'n2',
+    title: 'Sprint 12 retro',
+    category: 'Daily',
+    scope: 'workspace',
+    updatedAt: '2026-04-26T15:00:00.000Z',
+    body: 'Highlights: shipped F12 first cut. Next sprint priorities include packages/core extraction.',
+  },
+  {
+    id: 'n3',
+    title: 'OpenAPI conventions',
+    category: 'Reference',
+    scope: 'global',
+    updatedAt: '2026-04-15T10:00:00.000Z',
+    body: 'Standardize cursor-based pagination. Use ETags for conditional GETs.',
+  },
+];
+
+describe('tokenize', () => {
+  it('splits on whitespace + commas + semicolons + lowercases', () => {
+    expect(tokenize('Hello, World; postgres TUNING')).toEqual(['hello', 'world', 'postgres', 'tuning']);
+  });
+  it('returns [] for empty/whitespace input', () => {
+    expect(tokenize('')).toEqual([]);
+    expect(tokenize('   ')).toEqual([]);
+  });
+});
+
+describe('searchNotes', () => {
+  it('returns [] for empty query', () => {
+    expect(searchNotes(sample, '')).toEqual([]);
+  });
+
+  it('finds title matches', () => {
+    const hits = searchNotes(sample, 'postgres');
+    expect(hits.length).toBe(1);
+    expect(hits[0].id).toBe('n1');
+    expect(hits[0].score).toBeGreaterThanOrEqual(5);
+  });
+
+  it('boosts exact title match higher than partial', () => {
+    const hits = searchNotes(
+      [
+        { id: 'a', title: 'tuning', category: 'X', scope: 'global', updatedAt: '2026-01-01T00:00:00Z', body: '' },
+        { id: 'b', title: 'Postgres tuning', category: 'X', scope: 'global', updatedAt: '2026-01-01T00:00:00Z', body: '' },
+      ],
+      'tuning',
+    );
+    expect(hits[0].id).toBe('a'); // exact match wins
+  });
+
+  it('finds body matches with snippet that surrounds the match', () => {
+    const hits = searchNotes(sample, 'pooler');
+    expect(hits.length).toBe(1);
+    expect(hits[0].id).toBe('n1');
+    expect(hits[0].snippet.toLowerCase()).toContain('pooler');
+  });
+
+  it('multi-token query sums per-token scores', () => {
+    const hits = searchNotes(sample, 'postgres pooler');
+    expect(hits.length).toBe(1);
+    // postgres in title (5) + pooler in body (1) = 6
+    expect(hits[0].score).toBeGreaterThanOrEqual(6);
+  });
+
+  it('respects the limit', () => {
+    const hits = searchNotes(sample, 'reference daily', 1);
+    expect(hits.length).toBe(1);
+  });
+
+  it('tie-breaks by recency when scores match', () => {
+    const same = sample.filter(n => n.category === 'Reference');
+    const hits = searchNotes(same, 'reference');
+    // n1 (Apr 22) > n3 (Apr 15)
+    expect(hits[0].id).toBe('n1');
+  });
+
+  it('skips notes with score 0', () => {
+    const hits = searchNotes(sample, 'kubernetes');
+    expect(hits).toEqual([]);
+  });
+
+  it('truncates body fallback snippet for notes that match only in title', () => {
+    const note: SearchableNote = {
+      id: 'x',
+      title: 'foo',
+      category: 'X',
+      scope: 'global',
+      updatedAt: '2026-01-01T00:00:00Z',
+      body: 'bar '.repeat(100),
+    };
+    const hits = searchNotes([note], 'foo');
+    expect(hits[0].snippet.length).toBeLessThanOrEqual(165);
+  });
+});


### PR DESCRIPTION
## Summary
- Pure-function fuzzy searcher in `packages/core/src/search/`
- Sidebar `Mark It Down: Search Notes` command + Notes view title bar entry
- MCP `search_notes` tool + Claude plugin `/mid:search` skill (7 skills total)
- Published-site search: Lunr index + lazy-load + 200ms debounce + top-12 hits
- 11 new unit tests; 91 total

## Closes
Closes #41

## Test plan
- [x] `npm test` 91/91 passing
- [x] `npm run compile` clean
- [ ] F5: run `Search Notes`, confirm Quick Pick + open flow
- [ ] Publish a site with multiple pages, verify the search box surfaces hits

## Linked issue
[#41 — Search across notes (sidebar + MCP + published site)](https://github.com/fadymondy/mark-it-down/issues/41)