### PR TITLE
feat(notes): tags as a second dimension orthogonal to category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — v2.0: Tags (#42)
+
+- New optional `tags?: string[]` field on `NoteMetadata` — multi-tag-per-note, orthogonal to `category`
+- Tags are normalized: lowercase, alphanumeric + dashes, deduped + sorted (e.g. `Postgres Tuning, design` → `["design", "postgres-tuning"]`)
+- `NotesStore.setTags(id, tags[])` + `tagsInUse(scope?)` helpers
+- 2 new commands:
+  - `Mark It Down: Edit Tags` — context menu on a note + command palette; opens an InputBox prefilled with current tags
+  - `Mark It Down: Filter by Tag` — Quick Pick over all tags in use → Quick Pick of matching notes → opens the chosen one
+- Notes tree renders up to 3 tag badges in the description (`#design #postgres-tuning · 14:32`); full tag list in the tooltip
+- MCP `list_notes` accepts an optional `tag` filter (case-insensitive); `create_note` + `update_note` accept a `tags: string[]` patch
+- `MdNote` interface (MCP-side) gains the same `tags?` field
+
 ### Added — v1.2 polish: search across notes (#41)
 
 - New `packages/core/src/search/searcher.ts` — pure-function fuzzy search (no deps), shared by sidebar + MCP. Per-token scoring: exact title (+10), partial title (+5), category (+3), body occurrences (+1, capped at 5). Tie-breaks by recency.

--- a/package.json
+++ b/package.json
@@ -217,6 +217,18 @@
         "icon": "$(search)"
       },
       {
+        "command": "markItDown.notes.editTags",
+        "title": "Edit Tags",
+        "category": "Mark It Down",
+        "icon": "$(tag)"
+      },
+      {
+        "command": "markItDown.notes.filterByTag",
+        "title": "Filter by Tag",
+        "category": "Mark It Down",
+        "icon": "$(filter)"
+      },
+      {
         "command": "markItDown.notes.revealStorage",
         "title": "Reveal Notes Folder",
         "category": "Mark It Down",
@@ -416,6 +428,11 @@
           "command": "markItDown.notes.move",
           "when": "view == markItDown.notes && viewItem =~ /^markItDown.notes.note./",
           "group": "modify@1"
+        },
+        {
+          "command": "markItDown.notes.editTags",
+          "when": "view == markItDown.notes && viewItem =~ /^markItDown.notes.note./",
+          "group": "modify@2"
         }
       ],
       "commandPalette": [

--- a/src/mcp/notesAdapter.ts
+++ b/src/mcp/notesAdapter.ts
@@ -5,6 +5,7 @@ export interface MdNote {
   id: string;
   title: string;
   category: string;
+  tags?: string[];
   scope: 'global';
   createdAt: string;
   updatedAt: string;
@@ -21,10 +22,14 @@ const INDEX_FILENAME = '_mcp-index.json';
 export class NotesAdapter {
   constructor(private readonly notesDir: string) {}
 
-  async listNotes(filter: { category?: string } = {}): Promise<MdNote[]> {
+  async listNotes(filter: { category?: string; tag?: string } = {}): Promise<MdNote[]> {
     const idx = await this.readIndex();
+    let out = idx.notes;
     const cat = filter.category?.trim();
-    return cat ? idx.notes.filter(n => n.category === cat) : idx.notes;
+    if (cat) out = out.filter(n => n.category === cat);
+    const tag = filter.tag?.trim().toLowerCase();
+    if (tag) out = out.filter(n => (n.tags ?? []).includes(tag));
+    return out;
   }
 
   async getNote(id: string): Promise<{ meta: MdNote; content: string } | undefined> {
@@ -35,13 +40,14 @@ export class NotesAdapter {
     return { meta, content };
   }
 
-  async createNote(input: { title: string; category: string; content?: string }): Promise<MdNote> {
+  async createNote(input: { title: string; category: string; content?: string; tags?: string[] }): Promise<MdNote> {
     const now = new Date().toISOString();
     const id = randomId();
     const meta: MdNote = {
       id,
       title: input.title.trim() || 'Untitled note',
       category: input.category.trim() || 'Drafts',
+      tags: input.tags ? normalizeTags(input.tags) : undefined,
       scope: 'global',
       createdAt: now,
       updatedAt: now,
@@ -62,7 +68,7 @@ export class NotesAdapter {
 
   async updateNote(
     id: string,
-    patch: { title?: string; category?: string; content?: string },
+    patch: { title?: string; category?: string; content?: string; tags?: string[] },
   ): Promise<MdNote> {
     const idx = await this.readIndex();
     const i = idx.notes.findIndex(n => n.id === id);
@@ -70,6 +76,10 @@ export class NotesAdapter {
     const next: MdNote = { ...idx.notes[i] };
     if (patch.title !== undefined) next.title = patch.title.trim() || next.title;
     if (patch.category !== undefined) next.category = patch.category.trim() || next.category;
+    if (patch.tags !== undefined) {
+      const cleaned = normalizeTags(patch.tags);
+      next.tags = cleaned.length > 0 ? cleaned : undefined;
+    }
     next.updatedAt = new Date().toISOString();
     if (patch.content !== undefined) {
       await fs.writeFile(this.notePath(next.filename), patch.content, 'utf8');
@@ -123,6 +133,13 @@ export class NotesAdapter {
     await this.ensureDir();
     await fs.writeFile(this.indexPath(), JSON.stringify(idx, null, 2) + '\n', 'utf8');
   }
+}
+
+function normalizeTags(tags: string[]): string[] {
+  const cleaned = tags
+    .map(t => t.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, ''))
+    .filter(t => t.length > 0);
+  return [...new Set(cleaned)].sort();
 }
 
 function randomId(): string {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,13 +28,14 @@ const server = new McpServer(
 server.registerTool(
   'list_notes',
   {
-    description: 'List notes in the Mark It Down warehouse. Optionally filter by category.',
+    description: 'List notes in the Mark It Down warehouse. Optionally filter by category and/or tag.',
     inputSchema: {
       category: z.string().optional().describe('Restrict to notes in this category'),
+      tag: z.string().optional().describe('Restrict to notes carrying this tag (lowercase)'),
     },
   },
-  async ({ category }) => {
-    const notes = await adapter.listNotes({ category });
+  async ({ category, tag }) => {
+    const notes = await adapter.listNotes({ category, tag });
     return {
       content: [
         {
@@ -72,15 +73,16 @@ server.registerTool(
 server.registerTool(
   'create_note',
   {
-    description: 'Create a new global note with optional initial content.',
+    description: 'Create a new global note with optional initial content + tags.',
     inputSchema: {
       title: z.string().describe('Note title'),
       category: z.string().describe('Category, e.g. Daily / Reference / Snippet / Drafts'),
       content: z.string().optional().describe('Initial markdown content (default: "# <title>\\n\\n")'),
+      tags: z.array(z.string()).optional().describe('Tags (lowercase, alphanumeric + dashes; cross-cut categories)'),
     },
   },
-  async ({ title, category, content }) => {
-    const meta = await adapter.createNote({ title, category, content });
+  async ({ title, category, content, tags }) => {
+    const meta = await adapter.createNote({ title, category, content, tags });
     return {
       content: [{ type: 'text', text: JSON.stringify(meta, null, 2) }],
     };
@@ -90,17 +92,18 @@ server.registerTool(
 server.registerTool(
   'update_note',
   {
-    description: 'Update a note. Any of title / category / content may be patched; updatedAt bumps.',
+    description: 'Update a note. Any of title / category / content / tags may be patched; updatedAt bumps.',
     inputSchema: {
       id: z.string(),
       title: z.string().optional(),
       category: z.string().optional(),
       content: z.string().optional(),
+      tags: z.array(z.string()).optional(),
     },
   },
-  async ({ id, title, category, content }) => {
+  async ({ id, title, category, content, tags }) => {
     try {
-      const next = await adapter.updateNote(id, { title, category, content });
+      const next = await adapter.updateNote(id, { title, category, content, tags });
       return { content: [{ type: 'text', text: JSON.stringify(next, null, 2) }] };
     } catch (err) {
       return {

--- a/src/notes/notesCommands.ts
+++ b/src/notes/notesCommands.ts
@@ -61,6 +61,48 @@ export function registerNotesCommands(
       await store.setCategory(note.id, category);
     }),
 
+    vscode.commands.registerCommand('markItDown.notes.editTags', async (target?: NoteTreeNode | string) => {
+      const note = await resolveNote(store, target);
+      if (!note) return;
+      const current = (note.tags ?? []).join(', ');
+      const next = await vscode.window.showInputBox({
+        prompt: 'Tags (comma-separated; lowercase, alphanumeric + dashes)',
+        value: current,
+        placeHolder: 'design, retrospective, postgres',
+      });
+      if (next === undefined) return;
+      await store.setTags(note.id, next.split(/[,\s]+/));
+    }),
+
+    vscode.commands.registerCommand('markItDown.notes.filterByTag', async () => {
+      const tags = store.tagsInUse();
+      if (tags.length === 0) {
+        vscode.window.showInformationMessage('Mark It Down: no tags yet — use "Edit Tags" on a note first.');
+        return;
+      }
+      const choice = await vscode.window.showQuickPick(tags, { placeHolder: 'Filter notes by tag' });
+      if (!choice) return;
+      const matches = store.listAll().filter(n => (n.tags ?? []).includes(choice));
+      if (matches.length === 0) {
+        vscode.window.showInformationMessage(`Mark It Down: no notes tagged "${choice}".`);
+        return;
+      }
+      const picked = await vscode.window.showQuickPick(
+        matches
+          .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+          .map(n => ({
+            label: n.title,
+            description: `${n.scope}/${n.category}`,
+            detail: (n.tags ?? []).map(t => `#${t}`).join(' '),
+            id: n.id,
+          })),
+        { placeHolder: `Notes tagged "${choice}" (${matches.length})` },
+      );
+      if (picked) {
+        await vscode.commands.executeCommand('markItDown.notes.open', picked.id);
+      }
+    }),
+
     vscode.commands.registerCommand('markItDown.notes.delete', async (target?: NoteTreeNode | string) => {
       const note = await resolveNote(store, target);
       if (!note) return;

--- a/src/notes/notesStore.ts
+++ b/src/notes/notesStore.ts
@@ -6,6 +6,8 @@ export interface NoteMetadata {
   id: string;
   title: string;
   category: string;
+  /** Free-form tags. Multiple tags per note. Cross-cuts categories. */
+  tags?: string[];
   scope: NoteScope;
   createdAt: string;
   updatedAt: string;
@@ -106,6 +108,11 @@ export class NotesStore {
     return this.update(id, n => ({ ...n, category }));
   }
 
+  public async setTags(id: string, tags: string[]): Promise<NoteMetadata> {
+    const cleaned = normalizeTags(tags);
+    return this.update(id, n => ({ ...n, tags: cleaned.length > 0 ? cleaned : undefined }));
+  }
+
   public async touch(uri: vscode.Uri): Promise<void> {
     const note = this.getByUri(uri);
     if (!note) {
@@ -127,6 +134,15 @@ export class NotesStore {
       // file already gone — index update is what matters
     }
     return note;
+  }
+
+  public tagsInUse(scope?: NoteScope): string[] {
+    const source = scope ? this.read(scope) : this.listAll();
+    const all = new Set<string>();
+    for (const n of source) {
+      for (const t of n.tags ?? []) all.add(t);
+    }
+    return [...all].sort((a, b) => a.localeCompare(b));
   }
 
   public categoriesInUse(scope?: NoteScope): string[] {
@@ -205,6 +221,13 @@ export class NotesStore {
     }
     return this.context.globalStorageUri;
   }
+}
+
+function normalizeTags(tags: string[]): string[] {
+  const cleaned = tags
+    .map(t => t.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, ''))
+    .filter(t => t.length > 0);
+  return [...new Set(cleaned)].sort();
 }
 
 function randomId(): string {

--- a/src/notes/notesTreeProvider.ts
+++ b/src/notes/notesTreeProvider.ts
@@ -133,8 +133,11 @@ function categoryItem(scope: NoteScope, category: string): vscode.TreeItem {
 
 function noteItem(note: NoteMetadata, store: NotesStore): vscode.TreeItem {
   const item = new vscode.TreeItem(note.title || 'Untitled note', vscode.TreeItemCollapsibleState.None);
-  item.description = formatTimestamp(note.updatedAt);
-  item.tooltip = `${note.title}\n${note.category} · ${note.scope}\nupdated ${note.updatedAt}`;
+  const ts = formatTimestamp(note.updatedAt);
+  const tagBadges = (note.tags ?? []).slice(0, 3).map(t => `#${t}`).join(' ');
+  item.description = tagBadges ? `${tagBadges} · ${ts}` : ts;
+  const tagLine = (note.tags ?? []).length > 0 ? `\ntags: ${(note.tags ?? []).join(', ')}` : '';
+  item.tooltip = `${note.title}\n${note.category} · ${note.scope}${tagLine}\nupdated ${note.updatedAt}`;
   item.contextValue = `markItDown.notes.note.${note.scope}`;
   item.iconPath = new vscode.ThemeIcon('note');
   item.resourceUri = store.uriFor(note);


### PR DESCRIPTION
## Summary
- New `tags?: string[]` on NoteMetadata; normalized to lowercase + alphanumeric+dashes; deduped + sorted
- 2 new commands: `Edit Tags`, `Filter by Tag`
- Tree shows up to 3 tag badges in the description; full set in the tooltip
- MCP `list_notes` filter + `create_note`/`update_note` patches accept `tags`

## Closes
Closes #42

## Test plan
- [x] `npm test` 91/91 passing
- [x] `npm run compile` clean
- [ ] F5: tag a note via context menu, filter by that tag, verify the tree badges + MCP `list_notes({tag})`

## Linked issue
[#42 — Tags (orthogonal to categories)](https://github.com/fadymondy/mark-it-down/issues/42)