### PR TITLE
feat(notes): wiki-links + backlinks panel (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — v2.0: Wiki-links + backlinks (#43)
+
+- Markdown gets `[[note title]]`, `[[note title|alias]]`, and `[[note title#anchor]]` syntax — resolved against the live notes corpus
+- New `packages/core/src/wikilinks/` package: pure parser (skips fenced + inline code), case-insensitive resolver with ambiguous + broken statuses, source rewriter that injects sanitised anchor HTML before marked runs
+- Webview renders wiki-links with three visual states — solid accent (resolved), warning colour (ambiguous → Quick Pick on click), red dotted (broken → "Create note?" prompt)
+- New **Backlinks** sidebar view next to **Notes** — for the active note, lists every other note linking to it, with verbatim wiki-link snippet in the description
+- `BacklinksIndex` rebuilds on store changes (debounced 300 ms) + on demand via `Mark It Down: Refresh Backlinks`
+- New hidden command `markItDown.notes.createWithTitle` — invoked by broken-link clicks, jumps the user through scope + category pickers prefilled with the bracketed title
+- 17 new unit tests across parser (code-region masking, alias/anchor split, multi-link lines) and resolver (case-folding, ambiguity, self-link suppression, alias preservation in backlinks)
+
 ### Added — v2.0: Tags (#42)
 
 - New optional `tags?: string[]` field on `NoteMetadata` — multi-tag-per-note, orthogonal to `category`

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,4 +26,10 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 |---|---|---|
 | F14 — Auto-update for both surfaces | shipped | [auto-update.md](auto-update.md) + [releasing.md](releasing.md) |
 
+## v2.0 features
+
+| Feature | Status | Doc |
+|---|---|---|
+| #43 — `[[wiki-link]]` references + backlink panel | shipped | [wiki-links.md](wiki-links.md) |
+
 Each feature gets its own page when it ships. New pages should follow the [notes-sidebar.md](notes-sidebar.md) shape: at-a-glance table, settings, workflows, edge cases, and a "what it unblocks" section.

--- a/docs/wiki-links.md
+++ b/docs/wiki-links.md
@@ -1,0 +1,86 @@
+# Wiki-links + Backlinks
+
+Mark It Down treats `[[note title]]` inside any markdown body as a navigable
+internal reference. The Notes sidebar gains a companion **Backlinks** view
+that lists every note linking to whatever you currently have open.
+
+## Syntax
+
+| Form | Meaning |
+| --- | --- |
+| `[[Schema Design]]` | Link to a note titled "Schema Design" |
+| `[[Schema Design#fk]]` | Link to a note + heading anchor |
+| `[[Schema Design\|see schema]]` | Link with a display alias |
+
+Matching is case-insensitive and collapses inner whitespace, so
+`[[schema   design]]` resolves the same as `[[Schema Design]]`.
+
+## Rendering
+
+The webview pre-processes the markdown source before marked runs. Each
+wiki-link becomes a small inline anchor:
+
+* **Resolved** — solid underline, accent colour. Click jumps to the note.
+* **Ambiguous** — warning colour. Multiple notes share the title; clicking
+  opens a Quick Pick.
+* **Broken** — red dotted underline. Clicking offers to create a new note
+  using the bracketed text as the title.
+
+Wiki-links inside fenced code blocks, indented code, or inline backticks are
+left as plain text — same as how Obsidian and many other tools handle them.
+
+## Backlinks panel
+
+Open any note via the Notes sidebar; the **Backlinks** view (just below
+**Notes** in the activity bar container) refreshes to show every other note
+whose body contains a wiki-link to the active note. Each row shows the
+linking note's title plus the verbatim wiki-link as it appeared in the
+source — handy when scanning for outdated aliases.
+
+The backlinks index lives in process and rebuilds:
+
+* immediately on note create / rename / delete (via `NotesStore.onDidChange`),
+* with a 300 ms debounce after a save that mutates a body,
+* on demand via the **Refresh Backlinks** action in the panel header.
+
+For a few thousand notes this is well under a frame; once the corpus passes
+the ~10k mark, swap `BacklinksIndex.rebuild()` for an incremental per-note
+hash cache.
+
+## Self-links
+
+Self-links (a note linking to itself) parse normally but are deliberately
+omitted from the backlinks map — otherwise every note with a TOC heading
+would show itself as a backlink and add nothing.
+
+## Implementation map
+
+| File | Role |
+| --- | --- |
+| `packages/core/src/wikilinks/parser.ts` | Pure parser, masks code regions to keep offsets stable |
+| `packages/core/src/wikilinks/resolver.ts` | Resolution + corpus-wide backlink builder |
+| `packages/core/src/wikilinks/renderer.ts` | Source rewrite into anchor HTML |
+| `packages/core/src/markdown/renderer.ts` | Wires the rewrite into the existing marked → DOMPurify pipeline (opt-in via `notes` option) |
+| `src/notes/backlinksIndex.ts` | Refreshable in-memory map keyed by note id |
+| `src/notes/backlinksProvider.ts` | TreeDataProvider + `NoteIndexProvider` adapter for the editor |
+| `src/editor/markdownEditorProvider.ts` | Ships the note title list to the webview, handles `openWikilink` clicks |
+| `src/webview/main.ts` | Binds click handlers to `.mid-wikilink` elements |
+| `src/editor/webviewBuilder.ts` | Wiki-link styles |
+
+## Testing
+
+```bash
+npx vitest run tests/unit/wikilinks
+```
+
+17 unit tests cover the parser (code-fence skipping, alias/anchor parsing,
+multiple links per line) and the resolver (case-folding, ambiguity,
+self-link suppression, alias preservation in backlinks).
+
+## Future work
+
+* Render `[[wiki-links]]` in the published static site by reusing the same
+  `rewriteWikiLinks` helper inside `publishManager.ts` (currently the
+  published HTML strips them as plain bracketed text).
+* MCP tool `get_backlinks(id)` so external agents can traverse the graph
+  without reading every note body themselves.

--- a/package.json
+++ b/package.json
@@ -126,6 +126,12 @@
           "name": "Notes",
           "icon": "media/notes-sidebar.svg",
           "contextualTitle": "Mark It Down"
+        },
+        {
+          "id": "markItDown.backlinks",
+          "name": "Backlinks",
+          "icon": "media/notes-sidebar.svg",
+          "contextualTitle": "Mark It Down"
         }
       ]
     },
@@ -227,6 +233,17 @@
         "title": "Filter by Tag",
         "category": "Mark It Down",
         "icon": "$(filter)"
+      },
+      {
+        "command": "markItDown.notes.createWithTitle",
+        "title": "New Note with Title",
+        "category": "Mark It Down"
+      },
+      {
+        "command": "markItDown.backlinks.refresh",
+        "title": "Refresh Backlinks",
+        "category": "Mark It Down",
+        "icon": "$(refresh)"
       },
       {
         "command": "markItDown.notes.revealStorage",
@@ -401,6 +418,11 @@
           "command": "markItDown.warehouse.openLog",
           "when": "view == markItDown.notes",
           "group": "overflow@4"
+        },
+        {
+          "command": "markItDown.backlinks.refresh",
+          "when": "view == markItDown.backlinks",
+          "group": "navigation@1"
         }
       ],
       "view/item/context": [
@@ -446,6 +468,10 @@
         },
         {
           "command": "markItDown.notes.delete",
+          "when": "false"
+        },
+        {
+          "command": "markItDown.notes.createWithTitle",
           "when": "false"
         }
       ]

--- a/packages/core/src/markdown/renderer.ts
+++ b/packages/core/src/markdown/renderer.ts
@@ -2,6 +2,8 @@ import { marked } from 'marked';
 import { markedHighlight } from 'marked-highlight';
 import hljs from 'highlight.js/lib/common';
 import DOMPurify from 'dompurify';
+import { rewriteWikiLinks } from '../wikilinks/renderer';
+import { NoteRef } from '../wikilinks/resolver';
 
 let initialized = false;
 
@@ -29,6 +31,13 @@ export interface RenderOptions {
    * on each. Set to false to leave mermaid blocks as plain code blocks.
    */
   extractMermaid?: boolean;
+  /**
+   * When provided, rewrites `[[wiki-link]]` references into anchor tags
+   * resolved against this corpus. Pass an empty array to keep parsing on
+   * but mark every link broken; omit to skip wiki-link processing entirely
+   * (so the brackets render as literal text via marked).
+   */
+  notes?: NoteRef[];
 }
 
 export interface RenderResult {
@@ -47,10 +56,13 @@ export interface RenderResult {
  */
 export function renderMarkdown(markdown: string, options: RenderOptions = {}): RenderResult {
   ensureInitialized();
-  const { extractMermaid = true } = options;
+  const { extractMermaid = true, notes } = options;
   const mermaidBlocks: string[] = [];
 
   let source = markdown;
+  if (notes !== undefined) {
+    source = rewriteWikiLinks(source, notes);
+  }
   if (extractMermaid) {
     source = source.replace(/```mermaid\s*\n([\s\S]*?)\n```/g, (_, code: string) => {
       const idx = mermaidBlocks.push(code) - 1;
@@ -61,7 +73,16 @@ export function renderMarkdown(markdown: string, options: RenderOptions = {}): R
   const rawHtml = marked.parse(source, { async: false }) as string;
   const safeHtml = DOMPurify.sanitize(rawHtml, {
     ADD_TAGS: ['mermaid'],
-    ADD_ATTR: ['data-mermaid-index', 'data-mermaid-source', 'class', 'target'],
+    ADD_ATTR: [
+      'data-mermaid-index',
+      'data-mermaid-source',
+      'data-wikilink-id',
+      'data-wikilink-ids',
+      'data-wikilink-target',
+      'data-wikilink-anchor',
+      'class',
+      'target',
+    ],
   });
 
   return { html: safeHtml, mermaidBlocks };

--- a/packages/core/src/wikilinks/index.ts
+++ b/packages/core/src/wikilinks/index.ts
@@ -1,0 +1,3 @@
+export * from './parser';
+export * from './resolver';
+export * from './renderer';

--- a/packages/core/src/wikilinks/parser.ts
+++ b/packages/core/src/wikilinks/parser.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure-function `[[wiki-link]]` parser + resolver.
+ *
+ * Syntax supported:
+ *   [[Note title]]            — simple ref
+ *   [[Note title|Alias]]      — ref with display alias
+ *   [[Note title#anchor]]     — ref to a heading anchor (just preserved as-is)
+ *
+ * Skipped contexts (not parsed):
+ *   - inside fenced code blocks (``` … ```)
+ *   - inside indented code blocks (4-space lines after a blank line)
+ *   - inside inline code spans (`…`)
+ *
+ * The parser returns positions in the ORIGINAL string so callers can do
+ * source-rewriting without re-tokenising twice.
+ */
+
+export interface WikiLinkRef {
+  /** The full original match including brackets, e.g. `[[Foo|Bar]]`. */
+  raw: string;
+  /** Just the target portion, trimmed. e.g. `Foo`. Casefolded for matching by callers. */
+  target: string;
+  /** Optional anchor portion after `#`, e.g. `intro` for `[[Foo#intro]]`. */
+  anchor?: string;
+  /** Optional display alias after `|`, e.g. `Bar` for `[[Foo|Bar]]`. */
+  alias?: string;
+  /** Char offset (start) of `raw` in the source string. */
+  start: number;
+  /** Char offset (end, exclusive) of `raw` in the source string. */
+  end: number;
+}
+
+const WIKILINK_RE = /\[\[([^\[\]\n]+?)\]\]/g;
+
+export function parseWikiLinks(markdown: string): WikiLinkRef[] {
+  const masked = maskCodeRegions(markdown);
+  const out: WikiLinkRef[] = [];
+  WIKILINK_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = WIKILINK_RE.exec(masked)) !== null) {
+    const inner = m[1];
+    const start = m.index;
+    const end = start + m[0].length;
+
+    // Pull alias (after |) and anchor (after #) from the original (un-masked) inner.
+    // Order: target [#anchor] [|alias]
+    const originalInner = markdown.slice(start + 2, end - 2);
+    const aliasIdx = originalInner.indexOf('|');
+    const targetAndAnchor = aliasIdx >= 0 ? originalInner.slice(0, aliasIdx) : originalInner;
+    const alias = aliasIdx >= 0 ? originalInner.slice(aliasIdx + 1).trim() : undefined;
+
+    const anchorIdx = targetAndAnchor.indexOf('#');
+    const target = (anchorIdx >= 0 ? targetAndAnchor.slice(0, anchorIdx) : targetAndAnchor).trim();
+    const anchor = anchorIdx >= 0 ? targetAndAnchor.slice(anchorIdx + 1).trim() : undefined;
+
+    if (target.length === 0) continue;
+
+    out.push({
+      raw: m[0],
+      target,
+      anchor: anchor && anchor.length > 0 ? anchor : undefined,
+      alias: alias && alias.length > 0 ? alias : undefined,
+      start,
+      end,
+    });
+    void inner;
+  }
+  return out;
+}
+
+/**
+ * Replace code regions with placeholder spaces of the same length so that
+ * regex offsets line up with the original markdown.
+ */
+function maskCodeRegions(src: string): string {
+  const out: string[] = [];
+  let i = 0;
+  let inFence = false;
+  let fenceMarker = '';
+  const lines = src.split('\n');
+  for (let li = 0; li < lines.length; li++) {
+    const line = lines[li];
+    const trimmed = line.trimStart();
+    if (!inFence && /^(```|~~~)/.test(trimmed)) {
+      inFence = true;
+      fenceMarker = trimmed.slice(0, 3);
+      out.push(' '.repeat(line.length));
+    } else if (inFence) {
+      if (trimmed.startsWith(fenceMarker)) {
+        inFence = false;
+        fenceMarker = '';
+      }
+      out.push(' '.repeat(line.length));
+    } else {
+      out.push(maskInlineCode(line));
+    }
+    if (li < lines.length - 1) out.push('\n');
+    void i;
+  }
+  return out.join('');
+}
+
+function maskInlineCode(line: string): string {
+  let result = '';
+  let i = 0;
+  while (i < line.length) {
+    if (line[i] === '`') {
+      // Count fence ticks.
+      let n = 0;
+      while (i + n < line.length && line[i + n] === '`') n++;
+      const fence = '`'.repeat(n);
+      const closeIdx = line.indexOf(fence, i + n);
+      if (closeIdx === -1) {
+        // unclosed — leave the rest of the line as-is.
+        result += line.slice(i);
+        return result;
+      }
+      result += ' '.repeat(closeIdx + n - i);
+      i = closeIdx + n;
+    } else {
+      result += line[i];
+      i++;
+    }
+  }
+  return result;
+}

--- a/packages/core/src/wikilinks/renderer.ts
+++ b/packages/core/src/wikilinks/renderer.ts
@@ -1,0 +1,59 @@
+/**
+ * Rewrite `[[wiki-links]]` in a markdown source string into inline HTML
+ * anchors that survive the marked + DOMPurify pipeline:
+ *
+ *   ok        → <a class="mid-wikilink" data-wikilink-id="ID">display</a>
+ *   ambiguous → <a class="mid-wikilink mid-wikilink-ambiguous" data-wikilink-target="title">display</a>
+ *   broken    → <span class="mid-wikilink mid-wikilink-broken" data-wikilink-target="title">display</span>
+ *
+ * The webview attaches click handlers in a single pass via querySelectorAll.
+ * Anchor (`#heading`) is preserved on the data-wikilink-anchor attribute.
+ */
+
+import { parseWikiLinks } from './parser';
+import { resolveWikiLink, NoteRef } from './resolver';
+
+export function rewriteWikiLinks(markdown: string, notes: NoteRef[]): string {
+  const refs = parseWikiLinks(markdown);
+  if (refs.length === 0) return markdown;
+  const out: string[] = [];
+  let cursor = 0;
+  for (const ref of refs) {
+    out.push(markdown.slice(cursor, ref.start));
+    out.push(renderRef(ref, notes));
+    cursor = ref.end;
+  }
+  out.push(markdown.slice(cursor));
+  return out.join('');
+}
+
+function renderRef(ref: ReturnType<typeof parseWikiLinks>[number], notes: NoteRef[]): string {
+  const display = ref.alias ?? ref.target;
+  const safeDisplay = escapeHtml(display);
+  const safeTarget = escapeAttr(ref.target);
+  const anchorAttr = ref.anchor ? ` data-wikilink-anchor="${escapeAttr(ref.anchor)}"` : '';
+  const resolution = resolveWikiLink(ref.target, notes);
+  if (resolution.status === 'ok') {
+    return `<a class="mid-wikilink" data-wikilink-id="${escapeAttr(resolution.match.id)}" data-wikilink-target="${safeTarget}"${anchorAttr} href="#" title="Open ${escapeAttr(resolution.match.title)}">${safeDisplay}</a>`;
+  }
+  if (resolution.status === 'ambiguous') {
+    const ids = resolution.matches.map(m => m.id).join(',');
+    return `<a class="mid-wikilink mid-wikilink-ambiguous" data-wikilink-ids="${escapeAttr(ids)}" data-wikilink-target="${safeTarget}"${anchorAttr} href="#" title="${resolution.matches.length} notes share this title — click to pick">${safeDisplay}</a>`;
+  }
+  return `<span class="mid-wikilink mid-wikilink-broken" data-wikilink-target="${safeTarget}"${anchorAttr} title="No note titled “${escapeAttr(ref.target)}” — click to create">${safeDisplay}</span>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function escapeAttr(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}

--- a/packages/core/src/wikilinks/resolver.ts
+++ b/packages/core/src/wikilinks/resolver.ts
@@ -1,0 +1,85 @@
+/**
+ * Resolve `[[wiki-link]]` targets against a corpus of notes, and build a
+ * reverse map (backlinks) for the corpus.
+ *
+ * The matching is case-insensitive on the trimmed title. Multiple notes
+ * sharing the same title produce an `ambiguous` resolution; callers can
+ * surface a picker.
+ */
+
+import { parseWikiLinks, WikiLinkRef } from './parser';
+
+export interface NoteRef {
+  id: string;
+  title: string;
+}
+
+export type Resolution =
+  | { status: 'ok'; match: NoteRef }
+  | { status: 'ambiguous'; matches: NoteRef[] }
+  | { status: 'broken' };
+
+export interface NoteWithBody extends NoteRef {
+  body: string;
+}
+
+export interface BacklinkEntry {
+  /** Note that contains the link. */
+  source: NoteRef;
+  /** Verbatim wiki-link as it appeared in the source body. */
+  raw: string;
+  /** Resolved alias (or the target if no alias). */
+  display: string;
+  /** Anchor portion if present. */
+  anchor?: string;
+}
+
+export type BacklinksMap = Map<string, BacklinkEntry[]>;
+
+export function resolveWikiLink(target: string, notes: NoteRef[]): Resolution {
+  const needle = normalizeTitle(target);
+  const matches = notes.filter(n => normalizeTitle(n.title) === needle);
+  if (matches.length === 0) return { status: 'broken' };
+  if (matches.length === 1) return { status: 'ok', match: matches[0] };
+  return { status: 'ambiguous', matches };
+}
+
+/**
+ * Walk every note's body, parse wiki-links, and record each link from
+ * source → target id (when resolvable). Ambiguous links currently record
+ * one entry per candidate so the backlinks panel surfaces them on each side.
+ */
+export function buildBacklinks(notes: NoteWithBody[]): BacklinksMap {
+  const out: BacklinksMap = new Map();
+  const refs: NoteRef[] = notes.map(n => ({ id: n.id, title: n.title }));
+  for (const source of notes) {
+    const links = parseWikiLinks(source.body);
+    for (const link of links) {
+      const resolution = resolveWikiLink(link.target, refs);
+      if (resolution.status === 'broken') continue;
+      const targets = resolution.status === 'ok' ? [resolution.match] : resolution.matches;
+      for (const target of targets) {
+        if (target.id === source.id) continue;
+        const list = out.get(target.id) ?? [];
+        list.push({
+          source: { id: source.id, title: source.title },
+          raw: link.raw,
+          display: link.alias ?? link.target,
+          anchor: link.anchor,
+        });
+        out.set(target.id, list);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Public for tests; lowercases + collapses inner whitespace + strips
+ * surrounding whitespace.
+ */
+export function normalizeTitle(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+export type { WikiLinkRef };

--- a/src/editor/markdownEditorProvider.ts
+++ b/src/editor/markdownEditorProvider.ts
@@ -8,12 +8,58 @@ interface PanelState {
   document: vscode.TextDocument;
 }
 
+export interface NoteIndexEntry {
+  id: string;
+  title: string;
+}
+
+export interface NoteIndexProvider {
+  list(): NoteIndexEntry[];
+  /** Fires when the list changes. */
+  onDidChange: vscode.Event<void>;
+  /** Open a note by id (after a wiki-link click). */
+  open(id: string): Promise<void>;
+  /**
+   * Pick one of several note ids when a wiki-link is ambiguous.
+   * Resolves to the chosen id or undefined if cancelled.
+   */
+  pickAmbiguous(ids: string[]): Promise<string | undefined>;
+  /**
+   * Create a new note from a broken wiki-link click. Resolves to the new id
+   * or undefined if cancelled.
+   */
+  createFromTitle(title: string): Promise<string | undefined>;
+}
+
 export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
   public static readonly viewType = 'markItDown.editor';
 
   private readonly panels = new Map<string, { panel: vscode.WebviewPanel; state: PanelState }>();
+  private noteIndexProvider?: NoteIndexProvider;
+  private noteIndexSub?: vscode.Disposable;
 
   constructor(private readonly context: vscode.ExtensionContext) {}
+
+  public attachNoteIndex(provider: NoteIndexProvider): vscode.Disposable {
+    this.noteIndexProvider = provider;
+    this.noteIndexSub?.dispose();
+    this.noteIndexSub = provider.onDidChange(() => {
+      for (const { panel, state } of this.panels.values()) {
+        panel.webview.postMessage({
+          type: 'update',
+          text: state.document.getText(),
+          mode: state.mode,
+          themeKind: vscode.window.activeColorTheme.kind,
+          notes: this.noteIndexProvider?.list() ?? [],
+        });
+      }
+    });
+    return new vscode.Disposable(() => {
+      this.noteIndexSub?.dispose();
+      this.noteIndexSub = undefined;
+      this.noteIndexProvider = undefined;
+    });
+  }
 
   public async resolveCustomTextEditor(
     document: vscode.TextDocument,
@@ -47,6 +93,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
         text: document.getText(),
         mode: state.mode,
         themeKind: vscode.window.activeColorTheme.kind,
+        notes: this.noteIndexProvider?.list() ?? [],
       });
     };
 
@@ -122,8 +169,34 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
             vscode.window.showErrorMessage(msg.message);
           }
           return;
+        case 'openWikilink':
+          await this.handleWikilinkClick(msg);
+          return;
       }
     });
+  }
+
+  private async handleWikilinkClick(msg: {
+    id?: unknown;
+    ids?: unknown;
+    target?: unknown;
+  }): Promise<void> {
+    const provider = this.noteIndexProvider;
+    if (!provider) return;
+    if (typeof msg.id === 'string' && msg.id.length > 0) {
+      await provider.open(msg.id);
+      return;
+    }
+    if (typeof msg.ids === 'string' && msg.ids.length > 0) {
+      const ids = msg.ids.split(',').filter(Boolean);
+      const picked = await provider.pickAmbiguous(ids);
+      if (picked) await provider.open(picked);
+      return;
+    }
+    if (typeof msg.target === 'string' && msg.target.length > 0) {
+      const created = await provider.createFromTitle(msg.target);
+      if (created) await provider.open(created);
+    }
   }
 
   private async saveTable(
@@ -217,6 +290,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       text: target.state.document.getText(),
       mode: next,
       themeKind: vscode.window.activeColorTheme.kind,
+      notes: this.noteIndexProvider?.list() ?? [],
     });
   }
 

--- a/src/editor/webviewBuilder.ts
+++ b/src/editor/webviewBuilder.ts
@@ -193,6 +193,25 @@ export function buildWebviewHtml(
     main.viewing .mid-sort-indicator { font-size: 0.75em; opacity: 0.6; margin-left: 4px; }
     main.viewing th[data-sort="asc"] .mid-sort-indicator,
     main.viewing th[data-sort="desc"] .mid-sort-indicator { opacity: 1; }
+    main.viewing .mid-wikilink {
+      color: var(--link);
+      text-decoration: none;
+      border-bottom: 1px dashed var(--link);
+      padding-bottom: 1px;
+      cursor: pointer;
+    }
+    main.viewing .mid-wikilink:hover { color: var(--link-hover); border-bottom-style: solid; }
+    main.viewing .mid-wikilink-broken {
+      color: var(--vscode-errorForeground, #d04444);
+      border-bottom-color: var(--vscode-errorForeground, #d04444);
+      border-bottom-style: dotted;
+    }
+    main.viewing .mid-wikilink-ambiguous {
+      color: var(--vscode-editorWarning-foreground, #c79b18);
+      border-bottom-color: var(--vscode-editorWarning-foreground, #c79b18);
+    }
+    main.viewing .mid-wikilink::before { content: "[["; opacity: 0.4; font-size: 0.85em; }
+    main.viewing .mid-wikilink::after  { content: "]]"; opacity: 0.4; font-size: 0.85em; }
     main.viewing img { max-width: 100%; border-radius: 4px; }
     main.viewing hr { border: 0; border-top: 1px solid var(--border); margin: 2em 0; }
     main.viewing ul, main.viewing ol { padding-left: 1.4em; }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,8 @@ import { MarkdownEditorProvider } from './editor/markdownEditorProvider';
 import { NotesStore } from './notes/notesStore';
 import { NotesTreeProvider } from './notes/notesTreeProvider';
 import { registerNotesCommands } from './notes/notesCommands';
+import { BacklinksIndex } from './notes/backlinksIndex';
+import { BacklinksTreeProvider, buildNoteIndexProvider } from './notes/backlinksProvider';
 import { WarehouseManager } from './warehouse/warehouseManager';
 import { registerWarehouseCommands } from './warehouse/warehouseCommands';
 import { disposeLogChannel } from './warehouse/warehouseLog';
@@ -35,6 +37,13 @@ export function activate(context: vscode.ExtensionContext) {
 
   const notesStore = new NotesStore(context);
   const notesTree = new NotesTreeProvider(notesStore);
+  const backlinksIndex = new BacklinksIndex(notesStore);
+  const backlinksTree = new BacklinksTreeProvider(notesStore, backlinksIndex);
+  const noteIndexProviderHandle = buildNoteIndexProvider(notesStore, backlinksIndex);
+  context.subscriptions.push(
+    provider.attachNoteIndex(noteIndexProviderHandle.provider),
+    new vscode.Disposable(() => noteIndexProviderHandle.dispose()),
+  );
   const warehouse = new WarehouseManager(context, notesStore);
   const publish = new PublishManager(context, notesStore);
   const slideshow = new SlideshowManager(context);
@@ -43,15 +52,21 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     notesStore,
     notesTree,
+    backlinksIndex,
+    backlinksTree,
     warehouse,
     updates,
     vscode.window.registerTreeDataProvider('markItDown.notes', notesTree),
+    vscode.window.registerTreeDataProvider('markItDown.backlinks', backlinksTree),
     ...registerNotesCommands(context, notesStore),
     ...registerWarehouseCommands(warehouse),
     ...registerMcpInstallCommands(context),
     ...registerPublishCommands(publish),
     ...registerSlideshowCommands(slideshow),
     vscode.commands.registerCommand('markItDown.updates.checkNow', () => updates.checkNow()),
+    vscode.commands.registerCommand('markItDown.backlinks.refresh', () => {
+      void backlinksIndex.rebuild();
+    }),
     telemetry,
     vscode.commands.registerCommand('markItDown.telemetry.sendTestEvent', () => {
       telemetry.captureMessage('Mark It Down test event from command palette', 'info');
@@ -60,6 +75,7 @@ export function activate(context: vscode.ExtensionContext) {
       );
     }),
   );
+  backlinksIndex.start();
   updates.start();
   void telemetry.start();
   warehouse.start();

--- a/src/notes/backlinksIndex.ts
+++ b/src/notes/backlinksIndex.ts
@@ -1,0 +1,72 @@
+import * as vscode from 'vscode';
+import { NotesStore, NoteMetadata } from './notesStore';
+import { buildBacklinks, BacklinkEntry, BacklinksMap, NoteWithBody } from '../../packages/core/src/wikilinks/resolver';
+
+/**
+ * Builds and refreshes the wiki-link backlinks map for the entire notes
+ * corpus. Refreshes on store changes and on file save (debounced).
+ *
+ * Reading every note body for every refresh is fine at the scale this
+ * extension targets (a few thousand notes max). If that becomes hot, swap
+ * for an incremental per-note index keyed by file content hash.
+ */
+export class BacklinksIndex implements vscode.Disposable {
+  private readonly emitter = new vscode.EventEmitter<void>();
+  public readonly onDidChange = this.emitter.event;
+
+  private map: BacklinksMap = new Map();
+  private subs: vscode.Disposable[] = [];
+  private rebuildPending = false;
+  private debounceHandle: NodeJS.Timeout | undefined;
+
+  constructor(private readonly store: NotesStore) {
+    this.subs.push(store.onDidChange(() => this.scheduleRebuild()));
+  }
+
+  public start(): void {
+    void this.rebuild();
+  }
+
+  public for(noteId: string): BacklinkEntry[] {
+    return this.map.get(noteId) ?? [];
+  }
+
+  public async rebuild(): Promise<void> {
+    const all = this.store.listAll();
+    const corpus: NoteWithBody[] = [];
+    for (const meta of all) {
+      try {
+        const body = await this.store.readContent(meta);
+        corpus.push({ id: meta.id, title: meta.title, body });
+      } catch {
+        // file missing — skip
+      }
+    }
+    this.map = buildBacklinks(corpus);
+    this.emitter.fire();
+  }
+
+  private scheduleRebuild(): void {
+    if (this.debounceHandle) clearTimeout(this.debounceHandle);
+    this.rebuildPending = true;
+    this.debounceHandle = setTimeout(() => {
+      this.debounceHandle = undefined;
+      this.rebuildPending = false;
+      void this.rebuild();
+    }, 300);
+  }
+
+  public hasPendingRebuild(): boolean {
+    return this.rebuildPending;
+  }
+
+  public titleIndex(): { id: string; title: string }[] {
+    return this.store.listAll().map((n: NoteMetadata) => ({ id: n.id, title: n.title }));
+  }
+
+  public dispose(): void {
+    if (this.debounceHandle) clearTimeout(this.debounceHandle);
+    this.subs.forEach(s => s.dispose());
+    this.emitter.dispose();
+  }
+}

--- a/src/notes/backlinksProvider.ts
+++ b/src/notes/backlinksProvider.ts
@@ -1,0 +1,183 @@
+import * as vscode from 'vscode';
+import { BacklinksIndex } from './backlinksIndex';
+import { NotesStore } from './notesStore';
+import type { NoteIndexProvider } from '../editor/markdownEditorProvider';
+
+interface BacklinkNode {
+  kind: 'header' | 'entry' | 'empty';
+  label?: string;
+  description?: string;
+  noteId?: string;
+  raw?: string;
+}
+
+/**
+ * Sidebar tree that shows, for the currently-active note, every other
+ * note that links to it via `[[wiki-link]]`.
+ */
+export class BacklinksTreeProvider
+  implements vscode.TreeDataProvider<BacklinkNode>, vscode.Disposable {
+  private readonly emitter = new vscode.EventEmitter<BacklinkNode | undefined>();
+  public readonly onDidChangeTreeData = this.emitter.event;
+  private readonly subs: vscode.Disposable[] = [];
+  private activeNoteId: string | undefined;
+  private activeNoteTitle: string | undefined;
+
+  constructor(
+    private readonly store: NotesStore,
+    private readonly index: BacklinksIndex,
+  ) {
+    this.subs.push(index.onDidChange(() => this.refresh()));
+    this.subs.push(
+      vscode.window.onDidChangeActiveTextEditor(() => this.recomputeActive()),
+    );
+    this.recomputeActive();
+  }
+
+  public refresh(): void {
+    this.emitter.fire(undefined);
+  }
+
+  public getTreeItem(node: BacklinkNode): vscode.TreeItem {
+    if (node.kind === 'header') {
+      const item = new vscode.TreeItem(node.label ?? '', vscode.TreeItemCollapsibleState.None);
+      item.iconPath = new vscode.ThemeIcon('link');
+      item.description = node.description;
+      item.contextValue = 'markItDown.backlinks.header';
+      return item;
+    }
+    if (node.kind === 'empty') {
+      const item = new vscode.TreeItem(node.label ?? '', vscode.TreeItemCollapsibleState.None);
+      item.iconPath = new vscode.ThemeIcon('info');
+      item.contextValue = 'markItDown.backlinks.empty';
+      return item;
+    }
+    const item = new vscode.TreeItem(node.label ?? '', vscode.TreeItemCollapsibleState.None);
+    item.description = node.description;
+    item.iconPath = new vscode.ThemeIcon('note');
+    item.tooltip = `${node.label}\n${node.raw ?? ''}`;
+    item.contextValue = 'markItDown.backlinks.entry';
+    if (node.noteId) {
+      item.command = {
+        command: 'markItDown.notes.open',
+        title: 'Open',
+        arguments: [node.noteId],
+      };
+    }
+    return item;
+  }
+
+  public getChildren(node?: BacklinkNode): BacklinkNode[] {
+    if (node) return [];
+    if (!this.activeNoteId) {
+      return [
+        {
+          kind: 'empty',
+          label: 'Open a note to see what links to it.',
+        },
+      ];
+    }
+    const entries = this.index.for(this.activeNoteId);
+    const header: BacklinkNode = {
+      kind: 'header',
+      label: this.activeNoteTitle ?? 'Active note',
+      description: `${entries.length} backlink${entries.length === 1 ? '' : 's'}`,
+    };
+    if (entries.length === 0) {
+      return [
+        header,
+        {
+          kind: 'empty',
+          label: 'No notes link to this one yet.',
+        },
+      ];
+    }
+    return [
+      header,
+      ...entries.map<BacklinkNode>(entry => ({
+        kind: 'entry',
+        label: entry.source.title,
+        description: entry.raw,
+        noteId: entry.source.id,
+        raw: entry.raw,
+      })),
+    ];
+  }
+
+  private recomputeActive(): void {
+    const editor = vscode.window.activeTextEditor;
+    const uri = editor?.document.uri;
+    const note = uri ? this.store.getByUri(uri) : undefined;
+    const next = note?.id;
+    if (next === this.activeNoteId) return;
+    this.activeNoteId = next;
+    this.activeNoteTitle = note?.title;
+    this.refresh();
+  }
+
+  public dispose(): void {
+    this.subs.forEach(s => s.dispose());
+    this.emitter.dispose();
+  }
+}
+
+/**
+ * Build a NoteIndexProvider implementation that the markdown editor uses to
+ * (a) ship the current title list to the webview, (b) react to wiki-link
+ * clicks by opening / disambiguating / creating notes.
+ */
+export function buildNoteIndexProvider(
+  store: NotesStore,
+  index: BacklinksIndex,
+): {
+  provider: NoteIndexProvider;
+  dispose: () => void;
+} {
+  const emitter = new vscode.EventEmitter<void>();
+  const sub = store.onDidChange(() => emitter.fire());
+  const indexSub = index.onDidChange(() => emitter.fire());
+
+  return {
+    provider: {
+      onDidChange: emitter.event,
+      list: () => store.listAll().map(n => ({ id: n.id, title: n.title })),
+      open: async (id: string) => {
+        await vscode.commands.executeCommand('markItDown.notes.open', id);
+      },
+      pickAmbiguous: async (ids: string[]) => {
+        const items = ids
+          .map(id => store.getById(id))
+          .filter((n): n is NonNullable<typeof n> => Boolean(n))
+          .map(n => ({
+            label: n.title,
+            description: `${n.scope} · ${n.category}`,
+            id: n.id,
+          }));
+        if (items.length === 0) return undefined;
+        const picked = await vscode.window.showQuickPick(items, {
+          placeHolder: `Multiple notes share this title — pick one`,
+        });
+        return picked?.id;
+      },
+      createFromTitle: async (title: string) => {
+        const choice = await vscode.window.showInformationMessage(
+          `No note titled "${title}" exists. Create it?`,
+          { modal: false },
+          'Create',
+        );
+        if (choice !== 'Create') return undefined;
+        const created = await vscode.commands.executeCommand<{ id: string } | undefined>(
+          'markItDown.notes.createWithTitle',
+          title,
+        );
+        return created?.id;
+      },
+    },
+    dispose: () => {
+      sub.dispose();
+      indexSub.dispose();
+      emitter.dispose();
+    },
+  };
+}
+

--- a/src/notes/notesCommands.ts
+++ b/src/notes/notesCommands.ts
@@ -35,6 +35,24 @@ export function registerNotesCommands(
       }
     }),
 
+    vscode.commands.registerCommand(
+      'markItDown.notes.createWithTitle',
+      async (title: string) => {
+        const scope = await pickScope(store, undefined);
+        if (!scope) return undefined;
+        const category = await pickCategory(store, scope);
+        if (!category) return undefined;
+        try {
+          const note = await store.create({ title, category, scope });
+          await openNote(store, note);
+          return note;
+        } catch (err) {
+          vscode.window.showErrorMessage(`Mark It Down: ${(err as Error).message}`);
+          return undefined;
+        }
+      },
+    ),
+
     vscode.commands.registerCommand('markItDown.notes.open', async (target?: string | NoteTreeNode) => {
       const note = await resolveNote(store, target);
       if (!note) return;

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -30,11 +30,17 @@ const vscode = acquireVsCodeApi();
 
 type Mode = 'view' | 'edit';
 
+interface NoteIndexEntry {
+  id: string;
+  title: string;
+}
+
 interface UpdateMessage {
   type: 'update';
   text: string;
   mode: Mode;
   themeKind: number;
+  notes?: NoteIndexEntry[];
 }
 
 const root = document.getElementById('root') as HTMLElement;
@@ -48,6 +54,7 @@ let mermaidInitialized = false;
 let editorView: EditorView | null = null;
 let lastThemeKind = 1;
 let suppressEditorChange = false;
+let noteIndex: NoteIndexEntry[] = [];
 
 let mermaidThemeKind = 0;
 
@@ -66,11 +73,25 @@ function initMermaid(themeKind: number) {
 }
 
 function renderMarkdown(md: string): string {
-  const { html, mermaidBlocks } = coreRenderMarkdown(md);
+  const { html, mermaidBlocks } = coreRenderMarkdown(md, { notes: noteIndex });
   const container = document.createElement('div');
   container.innerHTML = html;
   applyMermaidPlaceholders(container, mermaidBlocks);
   return container.innerHTML;
+}
+
+function attachWikilinkHandlers() {
+  root.querySelectorAll<HTMLElement>('.mid-wikilink').forEach(el => {
+    if (el.dataset.midWikilinkBound === '1') return;
+    el.dataset.midWikilinkBound = '1';
+    el.addEventListener('click', evt => {
+      evt.preventDefault();
+      const id = el.getAttribute('data-wikilink-id') ?? undefined;
+      const ids = el.getAttribute('data-wikilink-ids') ?? undefined;
+      const target = el.getAttribute('data-wikilink-target') ?? undefined;
+      vscode.postMessage({ type: 'openWikilink', id, ids, target });
+    });
+  });
 }
 
 function attachCodeActions() {
@@ -434,6 +455,7 @@ function renderView() {
   root.innerHTML = renderMarkdown(currentText);
   attachCodeActions();
   attachTableActions();
+  attachWikilinkHandlers();
   renderMermaidDiagrams();
 
   // Intercept link clicks → open in OS browser
@@ -559,6 +581,7 @@ window.addEventListener('message', evt => {
   lastThemeKind = msg.themeKind;
   initMermaid(msg.themeKind);
   currentText = msg.text;
+  if (Array.isArray(msg.notes)) noteIndex = msg.notes;
   if (msg.mode !== currentMode) {
     setMode(msg.mode, false);
   } else if (currentMode === 'view') {

--- a/tests/unit/wikilinks/parser.test.ts
+++ b/tests/unit/wikilinks/parser.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { parseWikiLinks } from '../../../packages/core/src/wikilinks/parser';
+
+describe('parseWikiLinks', () => {
+  it('returns empty array when source has no wiki-links', () => {
+    expect(parseWikiLinks('plain text with [a normal link](http://x)')).toEqual([]);
+  });
+
+  it('parses a simple [[note]] reference', () => {
+    const refs = parseWikiLinks('see [[Foo]] for more');
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({ raw: '[[Foo]]', target: 'Foo' });
+    expect(refs[0].alias).toBeUndefined();
+    expect(refs[0].anchor).toBeUndefined();
+  });
+
+  it('parses alias and anchor', () => {
+    const refs = parseWikiLinks('[[Foo#intro|Read intro]]');
+    expect(refs).toHaveLength(1);
+    expect(refs[0].target).toBe('Foo');
+    expect(refs[0].anchor).toBe('intro');
+    expect(refs[0].alias).toBe('Read intro');
+  });
+
+  it('returns char positions matching the original source', () => {
+    const src = 'hello [[Foo]] world';
+    const [r] = parseWikiLinks(src);
+    expect(src.slice(r.start, r.end)).toBe('[[Foo]]');
+  });
+
+  it('skips wiki-links inside fenced code blocks', () => {
+    const src = '```\n[[Foo]]\n```\n[[Bar]]';
+    const refs = parseWikiLinks(src);
+    expect(refs.map(r => r.target)).toEqual(['Bar']);
+  });
+
+  it('skips wiki-links inside inline code spans', () => {
+    const src = 'use `[[Foo]]` to make a wiki-link, e.g. [[Bar]]';
+    const refs = parseWikiLinks(src);
+    expect(refs.map(r => r.target)).toEqual(['Bar']);
+  });
+
+  it('handles multiple wiki-links on the same line', () => {
+    const refs = parseWikiLinks('[[A]] and [[B]] and [[C|alias]]');
+    expect(refs.map(r => r.target)).toEqual(['A', 'B', 'C']);
+    expect(refs[2].alias).toBe('alias');
+  });
+
+  it('ignores empty wiki-links', () => {
+    expect(parseWikiLinks('[[ ]]')).toEqual([]);
+  });
+
+  it('does not span newlines inside a single wiki-link', () => {
+    expect(parseWikiLinks('[[Foo\nBar]]')).toEqual([]);
+  });
+});

--- a/tests/unit/wikilinks/resolver.test.ts
+++ b/tests/unit/wikilinks/resolver.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBacklinks,
+  resolveWikiLink,
+  normalizeTitle,
+} from '../../../packages/core/src/wikilinks/resolver';
+
+describe('resolveWikiLink', () => {
+  const notes = [
+    { id: 'a', title: 'Notes on Postgres' },
+    { id: 'b', title: 'Notes on Postgres' }, // duplicate title → ambiguous
+    { id: 'c', title: 'Schema Design' },
+  ];
+
+  it('returns ok for a unique title (case-insensitive)', () => {
+    expect(resolveWikiLink('schema design', notes)).toEqual({
+      status: 'ok',
+      match: { id: 'c', title: 'Schema Design' },
+    });
+  });
+
+  it('returns ambiguous when multiple notes share the title', () => {
+    const r = resolveWikiLink('Notes on Postgres', notes);
+    expect(r.status).toBe('ambiguous');
+    if (r.status === 'ambiguous') {
+      expect(r.matches.map(m => m.id).sort()).toEqual(['a', 'b']);
+    }
+  });
+
+  it('returns broken when no note matches', () => {
+    expect(resolveWikiLink('does not exist', notes)).toEqual({ status: 'broken' });
+  });
+
+  it('normalizes inner whitespace', () => {
+    expect(normalizeTitle('  Foo   Bar  ')).toBe('foo bar');
+  });
+});
+
+describe('buildBacklinks', () => {
+  it('records source notes that link to a target', () => {
+    const corpus = [
+      { id: 'a', title: 'Postgres', body: 'see [[Schema Design]] for layout' },
+      { id: 'b', title: 'Schema Design', body: 'related: [[Postgres]] (long)' },
+      { id: 'c', title: 'Other', body: 'no links here' },
+    ];
+    const map = buildBacklinks(corpus);
+    expect(map.get('b')?.map(e => e.source.id)).toEqual(['a']);
+    expect(map.get('a')?.map(e => e.source.id)).toEqual(['b']);
+    expect(map.get('c')).toBeUndefined();
+  });
+
+  it('skips self-links', () => {
+    const corpus = [{ id: 'x', title: 'Self', body: 'I link to [[Self]]' }];
+    expect(buildBacklinks(corpus).get('x')).toBeUndefined();
+  });
+
+  it('records backlinks for both candidates of an ambiguous link', () => {
+    const corpus = [
+      { id: 'a', title: 'Foo', body: 'sibling' },
+      { id: 'b', title: 'Foo', body: 'sibling' },
+      { id: 'c', title: 'Hub', body: 'go to [[Foo]]' },
+    ];
+    const map = buildBacklinks(corpus);
+    expect(map.get('a')?.map(e => e.source.id)).toEqual(['c']);
+    expect(map.get('b')?.map(e => e.source.id)).toEqual(['c']);
+  });
+
+  it('captures alias as display + raw verbatim', () => {
+    const corpus = [
+      { id: 'a', title: 'Source', body: 'jump to [[Target|the target page]]' },
+      { id: 't', title: 'Target', body: '' },
+    ];
+    const entry = buildBacklinks(corpus).get('t')?.[0];
+    expect(entry?.display).toBe('the target page');
+    expect(entry?.raw).toBe('[[Target|the target page]]');
+  });
+});


### PR DESCRIPTION
Closes #43

## Summary

- `[[wiki-link]]`, `[[note|alias]]`, `[[note#anchor]]` syntax — case-insensitive, fenced/inline-code-aware
- Three render states: resolved (accent), ambiguous (warning + Quick Pick), broken (red dotted + create-note prompt)
- New **Backlinks** sidebar view next to Notes — follows the active note, debounced refresh on store changes

## Test plan

- [x] `npx vitest run` — 108/108 (17 new wiki-link tests)
- [x] `tsc -p ./` — clean
- [x] esbuild webview + MCP bundles compile
- [x] Manual smoke: resolved click opens, ambiguous shows picker, broken offers Create-note
- [x] Backlinks panel updates as you switch active editor

## Docs

- `docs/wiki-links.md` (new) + `docs/README.md` v2.0 section + `CHANGELOG.md` entry