### PR TITLE
feat(notes): drag-drop attachments synced to warehouse + published site (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — v2.0: Note attachments (#44)
+
+- Each note can carry binary attachments stored at `<storage>/notes/<id>-attachments/<filename>`; the dir is created lazily on first attachment and removed when the note is deleted
+- Drag-drop one or many files onto the editor (view or edit mode) — webview reads each via FileReader, base64-encodes, posts `attachUpload` to the host, store sanitises + de-duplicates the filename, then a relative markdown reference (`![]()` for images, `[]()` otherwise) is appended at the end of the note
+- New `packages/core/src/attachments/` package: pure helpers for filename sanitisation (path-traversal safe, alphanumeric+dot+dash+underscore only, 96-char cap that preserves extension), collision resolution (`a.png` → `a-1.png`, `a-2.png`, …), image-extension detection, markdown-reference emission
+- `NotesStore` extensions: `attachmentsDirUri`, `attachmentUri`, `listAttachments`, `addAttachment`, `deleteAttachment`; `importNote` now accepts an optional `attachments` payload so warehouse pull can materialise binaries
+- Warehouse sync: `materializeScope` copies each note's attachment dir verbatim, indexes filenames as `attachments?: string[]` in `_index.json`, and deletes the dir on note removal; pull side calls `readRemoteAttachments` and threads them through `importNote`
+- Publish: `collectAll` returns `{ pages, attachments }`; `runBuildAndPush` copies each attachment to `notes/<id>-attachments/<filename>` next to its rendered page so relative links resolve naturally on GitHub Pages
+- 19 new unit tests across the pure helpers (sanitisation incl. path traversal, length cap with extension preservation, collision resolution with + without extension, image detection across 7 cases, markdown emission for image / non-image / aliased)
+
 ### Added — v2.0: Wiki-links + backlinks (#43)
 
 - Markdown gets `[[note title]]`, `[[note title|alias]]`, and `[[note title#anchor]]` syntax — resolved against the live notes corpus

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,5 +31,6 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 | Feature | Status | Doc |
 |---|---|---|
 | #43 — `[[wiki-link]]` references + backlink panel | shipped | [wiki-links.md](wiki-links.md) |
+| #44 — Note attachments (drag-drop + warehouse + publish) | shipped | [note-attachments.md](note-attachments.md) |
 
 Each feature gets its own page when it ships. New pages should follow the [notes-sidebar.md](notes-sidebar.md) shape: at-a-glance table, settings, workflows, edge cases, and a "what it unblocks" section.

--- a/docs/note-attachments.md
+++ b/docs/note-attachments.md
@@ -1,0 +1,97 @@
+# Note Attachments
+
+Each note can hold binary attachments (images, PDFs, ZIP, anything). They
+live alongside the markdown file and travel with the warehouse + the
+published static site.
+
+## Storage layout
+
+```
+<storage-root>/notes/
+  <note-id>.md
+  <note-id>-attachments/
+    diagram.png
+    spec.pdf
+    archive.zip
+```
+
+The directory is created lazily on the first attachment, removed when the
+note is deleted, and replicated verbatim to the warehouse repo so other
+machines pick it up on `Warehouse: Pull`.
+
+## Drag-and-drop
+
+Drop one or many files onto the editor (view or edit mode); each file is
+read as base64, sent to the extension via `attachUpload`, written into the
+attachments dir with a sanitised + collision-resolved filename, and then a
+markdown reference is appended at the end of the note:
+
+* image-like file → `![filename](id-attachments/filename)`
+* anything else → `[filename](id-attachments/filename)`
+
+Move the inserted line wherever you'd like. Multiple drops in quick
+succession all stack at the bottom in arrival order.
+
+### Filename hygiene
+
+* Path separators (`/`, `\`) and any character outside `[A-Za-z0-9._-]` are
+  collapsed to `-`.
+* Leading/trailing dashes are stripped.
+* Maximum length is **96 characters**, preserving the extension.
+* On collision, `-1`, `-2`, … are appended to the basename until a free
+  slot is found. After 10k attempts (essentially never), a timestamp suffix
+  is used as a last resort.
+
+## Warehouse sync
+
+`materializeScope` copies each attachment into `<scope>/<id>-attachments/`
+on the warehouse clone, lists the filenames in `_index.json` under
+`attachments?: string[]`, and deletes the dir whenever a note disappears
+from the local index. Pull mirrors this — `readRemoteAttachments` walks the
+listed names and `importNote` writes them next to the new local note.
+
+This means the **commit churn includes binary diffs**. For huge attachments
+this is fine but suboptimal — Git LFS support is a future-work item.
+
+## Published site
+
+`PublishManager.collectAll` walks `listAttachments(note)` and queues each
+file into a parallel `attachments[]` plan. After page rendering, each
+attachment is copied verbatim into `notes/<id>-attachments/<filename>` so
+the relative links inside the markdown body resolve naturally.
+
+The build wipes the publish branch's working copy before each run, so
+removed attachments stop being served on the next deploy.
+
+## Limitations (intentionally out of scope for the first cut)
+
+- No size cap — multi-GB drops will still try to fit in memory because the
+  webview encodes via FileReader. If you need that, add a streaming
+  workaround.
+- No re-link rewriting on note rename. The folder is keyed by **id**, not
+  title, so renames don't break links. But if you manually rename a file
+  in the attachments dir on disk, the markdown body won't follow.
+- No drag-drop **out** of the note (e.g. reusing an attachment in another
+  note). Copy the markdown reference yourself if needed.
+- No Git LFS — every push still goes through the standard transport.
+
+## Implementation map
+
+| File | Role |
+| --- | --- |
+| `packages/core/src/attachments/index.ts` | Pure helpers (sanitise, collision, image detection, markdown emission) |
+| `src/notes/notesStore.ts` | `addAttachment`, `listAttachments`, `deleteAttachment`, `attachmentUri`, `importNote(meta, content, attachments?)` |
+| `src/notes/notesAttachmentUploader.ts` | Bridges the editor IPC into the store |
+| `src/editor/markdownEditorProvider.ts` | `attachAttachmentUploader`, handles `attachUpload` messages |
+| `src/webview/main.ts` | `bindDragDropAttachments` — captures files, base64-encodes, posts to host |
+| `src/warehouse/warehouseSync.ts` | Copies attachment dirs both ways, indexes them in `_index.json` |
+| `src/publish/publishManager.ts` | Copies attachments into the static site |
+
+## Testing
+
+```bash
+npx vitest run tests/unit/attachments
+```
+
+19 tests cover the pure helpers (filename sanitisation, path traversal,
+length cap, collision resolution, image detection, markdown emission).

--- a/packages/core/src/attachments/index.ts
+++ b/packages/core/src/attachments/index.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure helpers for note attachment filenames + relative-link emission.
+ *
+ * Storage layout: each note `<id>.md` has a sibling directory
+ * `<id>-attachments/` that holds the binary files. Markdown bodies refer
+ * to attachments via relative links: `<id>-attachments/<filename>`.
+ */
+
+const ATTACHMENT_DIR_SUFFIX = '-attachments';
+const SAFE_NAME = /[^A-Za-z0-9._-]+/g;
+const MAX_NAME_LENGTH = 96;
+
+export function attachmentDirName(noteId: string): string {
+  return `${noteId}${ATTACHMENT_DIR_SUFFIX}`;
+}
+
+export function relativeAttachmentPath(noteId: string, filename: string): string {
+  return `${attachmentDirName(noteId)}/${filename}`;
+}
+
+/**
+ * Best-effort sanitisation: strip path separators, collapse unsafe runs to
+ * dashes, trim the basename to MAX_NAME_LENGTH while preserving the extension.
+ */
+export function sanitizeAttachmentName(rawName: string): string {
+  const base = rawName.split(/[/\\]+/).pop() ?? rawName;
+  const cleaned = base.replace(SAFE_NAME, '-').replace(/^-+|-+$/g, '');
+  if (cleaned.length === 0) return 'attachment';
+  if (cleaned.length <= MAX_NAME_LENGTH) return cleaned;
+  const dot = cleaned.lastIndexOf('.');
+  if (dot < 0 || dot === 0) return cleaned.slice(0, MAX_NAME_LENGTH);
+  const ext = cleaned.slice(dot);
+  const stem = cleaned.slice(0, dot);
+  const allowedStem = MAX_NAME_LENGTH - ext.length;
+  return allowedStem > 0 ? stem.slice(0, allowedStem) + ext : cleaned.slice(0, MAX_NAME_LENGTH);
+}
+
+/**
+ * Resolve a collision-free name given the set of existing filenames in the
+ * attachment dir. Appends `-1`, `-2`, … to the basename until a free slot
+ * is found.
+ */
+export function resolveCollision(name: string, existing: Iterable<string>): string {
+  const existingSet = new Set(existing);
+  if (!existingSet.has(name)) return name;
+  const dot = name.lastIndexOf('.');
+  const stem = dot > 0 ? name.slice(0, dot) : name;
+  const ext = dot > 0 ? name.slice(dot) : '';
+  for (let i = 1; i < 10_000; i++) {
+    const candidate = `${stem}-${i}${ext}`;
+    if (!existingSet.has(candidate)) return candidate;
+  }
+  return `${stem}-${Date.now()}${ext}`;
+}
+
+const IMAGE_EXTENSIONS = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp', '.avif', '.heic', '.heif',
+]);
+
+export function isImageAttachment(filename: string): boolean {
+  const dot = filename.lastIndexOf('.');
+  if (dot < 0) return false;
+  return IMAGE_EXTENSIONS.has(filename.slice(dot).toLowerCase());
+}
+
+/**
+ * Emit a markdown reference for an attachment. Images get `![]()`, other
+ * file types get `[]()` so they render as plain links.
+ */
+export function attachmentMarkdown(noteId: string, filename: string, label?: string): string {
+  const ref = relativeAttachmentPath(noteId, filename);
+  const display = label ?? filename;
+  return isImageAttachment(filename) ? `![${display}](${ref})` : `[${display}](${ref})`;
+}

--- a/src/editor/markdownEditorProvider.ts
+++ b/src/editor/markdownEditorProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { buildWebviewHtml } from './webviewBuilder';
+import { attachmentMarkdown } from '../../packages/core/src/attachments';
 
 type Mode = 'view' | 'edit';
 
@@ -31,14 +32,37 @@ export interface NoteIndexProvider {
   createFromTitle(title: string): Promise<string | undefined>;
 }
 
+export interface AttachmentUploader {
+  /**
+   * Save an attachment for the note backing the supplied document URI.
+   * Returns the resolved on-disk filename, or undefined if the document
+   * is not a note managed by the store.
+   */
+  save(
+    documentUri: vscode.Uri,
+    rawName: string,
+    bytes: Uint8Array,
+  ): Promise<{ noteId: string; filename: string } | undefined>;
+}
+
 export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
   public static readonly viewType = 'markItDown.editor';
 
   private readonly panels = new Map<string, { panel: vscode.WebviewPanel; state: PanelState }>();
   private noteIndexProvider?: NoteIndexProvider;
   private noteIndexSub?: vscode.Disposable;
+  private attachmentUploader?: AttachmentUploader;
 
   constructor(private readonly context: vscode.ExtensionContext) {}
+
+  public attachAttachmentUploader(uploader: AttachmentUploader): vscode.Disposable {
+    this.attachmentUploader = uploader;
+    return new vscode.Disposable(() => {
+      if (this.attachmentUploader === uploader) {
+        this.attachmentUploader = undefined;
+      }
+    });
+  }
 
   public attachNoteIndex(provider: NoteIndexProvider): vscode.Disposable {
     this.noteIndexProvider = provider;
@@ -172,8 +196,51 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
         case 'openWikilink':
           await this.handleWikilinkClick(msg);
           return;
+        case 'attachUpload':
+          await this.handleAttachmentUpload(document, msg);
+          return;
       }
     });
+  }
+
+  private async handleAttachmentUpload(
+    document: vscode.TextDocument,
+    msg: { name?: unknown; bytesBase64?: unknown; insert?: unknown },
+  ): Promise<void> {
+    const uploader = this.attachmentUploader;
+    if (!uploader) {
+      vscode.window.showWarningMessage('Mark It Down: attachments require a managed note. Save this file as a note first.');
+      return;
+    }
+    const name = typeof msg.name === 'string' ? msg.name : 'attachment';
+    const b64 = typeof msg.bytesBase64 === 'string' ? msg.bytesBase64 : undefined;
+    if (!b64) {
+      vscode.window.showErrorMessage('Mark It Down: dropped file payload was empty.');
+      return;
+    }
+    const bytes = Buffer.from(b64, 'base64');
+    let result;
+    try {
+      result = await uploader.save(document.uri, name, bytes);
+    } catch (err) {
+      vscode.window.showErrorMessage(`Mark It Down: attachment upload failed — ${(err as Error).message}`);
+      return;
+    }
+    if (!result) {
+      vscode.window.showWarningMessage('Mark It Down: this file is not a managed note — drag-drop is only supported inside the notes warehouse.');
+      return;
+    }
+    const insertMd = msg.insert === false
+      ? null
+      : attachmentMarkdown(result.noteId, result.filename);
+    if (insertMd) {
+      const edit = new vscode.WorkspaceEdit();
+      const text = document.getText();
+      const trailing = text.length > 0 && !text.endsWith('\n') ? '\n' : '';
+      edit.insert(document.uri, document.positionAt(text.length), `${trailing}\n${insertMd}\n`);
+      await vscode.workspace.applyEdit(edit);
+    }
+    vscode.window.setStatusBarMessage(`Mark It Down: attached ${result.filename}`, 2500);
   }
 
   private async handleWikilinkClick(msg: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { NotesTreeProvider } from './notes/notesTreeProvider';
 import { registerNotesCommands } from './notes/notesCommands';
 import { BacklinksIndex } from './notes/backlinksIndex';
 import { BacklinksTreeProvider, buildNoteIndexProvider } from './notes/backlinksProvider';
+import { buildAttachmentUploader } from './notes/notesAttachmentUploader';
 import { WarehouseManager } from './warehouse/warehouseManager';
 import { registerWarehouseCommands } from './warehouse/warehouseCommands';
 import { disposeLogChannel } from './warehouse/warehouseLog';
@@ -43,6 +44,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     provider.attachNoteIndex(noteIndexProviderHandle.provider),
     new vscode.Disposable(() => noteIndexProviderHandle.dispose()),
+    provider.attachAttachmentUploader(buildAttachmentUploader(notesStore)),
   );
   const warehouse = new WarehouseManager(context, notesStore);
   const publish = new PublishManager(context, notesStore);

--- a/src/notes/notesAttachmentUploader.ts
+++ b/src/notes/notesAttachmentUploader.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+import { NotesStore } from './notesStore';
+import type { AttachmentUploader } from '../editor/markdownEditorProvider';
+
+/**
+ * Bridges the editor's `attachUpload` IPC into NotesStore. Looks up the
+ * note backing the document URI and writes the bytes into its sibling
+ * attachments dir.
+ */
+export function buildAttachmentUploader(store: NotesStore): AttachmentUploader {
+  return {
+    async save(documentUri: vscode.Uri, rawName: string, bytes: Uint8Array) {
+      const note = store.getByUri(documentUri);
+      if (!note) return undefined;
+      const result = await store.addAttachment(note, rawName, bytes);
+      return { noteId: note.id, filename: result.filename };
+    },
+  };
+}

--- a/src/notes/notesStore.ts
+++ b/src/notes/notesStore.ts
@@ -1,6 +1,17 @@
 import * as vscode from 'vscode';
+import {
+  attachmentDirName,
+  resolveCollision,
+  sanitizeAttachmentName,
+} from '../../packages/core/src/attachments';
 
 export type NoteScope = 'workspace' | 'global';
+
+export interface AttachmentInfo {
+  filename: string;
+  size: number;
+  mtime: number;
+}
 
 export interface NoteMetadata {
   id: string;
@@ -56,6 +67,63 @@ export class NotesStore {
     return vscode.Uri.joinPath(root, NOTES_SUBDIR, note.filename);
   }
 
+  public attachmentsDirUri(note: NoteMetadata): vscode.Uri {
+    const root = this.storageRoot(note.scope);
+    return vscode.Uri.joinPath(root, NOTES_SUBDIR, attachmentDirName(note.id));
+  }
+
+  public attachmentUri(note: NoteMetadata, filename: string): vscode.Uri {
+    return vscode.Uri.joinPath(this.attachmentsDirUri(note), filename);
+  }
+
+  public async listAttachments(note: NoteMetadata): Promise<AttachmentInfo[]> {
+    const dir = this.attachmentsDirUri(note);
+    let entries: [string, vscode.FileType][];
+    try {
+      entries = await vscode.workspace.fs.readDirectory(dir);
+    } catch {
+      return [];
+    }
+    const out: AttachmentInfo[] = [];
+    for (const [name, kind] of entries) {
+      if (kind !== vscode.FileType.File) continue;
+      try {
+        const stat = await vscode.workspace.fs.stat(vscode.Uri.joinPath(dir, name));
+        out.push({ filename: name, size: stat.size, mtime: stat.mtime });
+      } catch {
+        // skipped — listed but no longer there
+      }
+    }
+    out.sort((a, b) => a.filename.localeCompare(b.filename));
+    return out;
+  }
+
+  public async addAttachment(
+    note: NoteMetadata,
+    rawName: string,
+    bytes: Uint8Array,
+  ): Promise<{ filename: string; uri: vscode.Uri }> {
+    const dir = this.attachmentsDirUri(note);
+    await vscode.workspace.fs.createDirectory(dir);
+    const existing = (await this.listAttachments(note)).map(a => a.filename);
+    const safe = sanitizeAttachmentName(rawName);
+    const filename = resolveCollision(safe, existing);
+    const uri = vscode.Uri.joinPath(dir, filename);
+    await vscode.workspace.fs.writeFile(uri, bytes);
+    await this.touch(this.uriFor(note));
+    return { filename, uri };
+  }
+
+  public async deleteAttachment(note: NoteMetadata, filename: string): Promise<void> {
+    const uri = this.attachmentUri(note, filename);
+    try {
+      await vscode.workspace.fs.delete(uri, { useTrash: false });
+    } catch {
+      // already gone
+    }
+    await this.touch(this.uriFor(note));
+  }
+
   public async create(input: CreateNoteInput): Promise<NoteMetadata> {
     if (input.scope === 'workspace' && !this.hasWorkspaceStorage()) {
       throw new Error('Workspace notes require an open workspace folder.');
@@ -82,7 +150,11 @@ export class NotesStore {
     return note;
   }
 
-  public async importNote(meta: NoteMetadata, content: string): Promise<NoteMetadata> {
+  public async importNote(
+    meta: NoteMetadata,
+    content: string,
+    attachments?: { filename: string; bytes: Uint8Array }[],
+  ): Promise<NoteMetadata> {
     if (meta.scope === 'workspace' && !this.hasWorkspaceStorage()) {
       throw new Error('Workspace storage unavailable; cannot import workspace note.');
     }
@@ -92,6 +164,16 @@ export class NotesStore {
     const index = this.read(meta.scope).filter(n => n.id !== meta.id);
     index.push({ ...meta });
     await this.write(meta.scope, index);
+    if (attachments && attachments.length > 0) {
+      const dir = this.attachmentsDirUri(meta);
+      await vscode.workspace.fs.createDirectory(dir);
+      for (const att of attachments) {
+        await vscode.workspace.fs.writeFile(
+          vscode.Uri.joinPath(dir, att.filename),
+          att.bytes,
+        );
+      }
+    }
     return meta;
   }
 
@@ -132,6 +214,14 @@ export class NotesStore {
       await vscode.workspace.fs.delete(this.uriFor(note));
     } catch {
       // file already gone — index update is what matters
+    }
+    try {
+      await vscode.workspace.fs.delete(this.attachmentsDirUri(note), {
+        recursive: true,
+        useTrash: false,
+      });
+    } catch {
+      // dir didn't exist — fine
     }
     return note;
   }

--- a/src/publish/publishManager.ts
+++ b/src/publish/publishManager.ts
@@ -7,7 +7,13 @@ import { log } from '../warehouse/warehouseLog';
 import { findTheme } from '../themes/themes';
 import { PublishConfig, readPublishConfig } from './publishConfig';
 import { buildSiteAssets, PageInput, renderIndex, renderPage } from './staticGenerator';
+import { attachmentDirName } from '../../packages/core/src/attachments';
 import lunr from 'lunr';
+
+interface AttachmentToCopy {
+  srcUri: vscode.Uri;
+  destPathFromRoot: string;
+}
 
 export interface PublishResult {
   pages: number;
@@ -36,12 +42,12 @@ export class PublishManager {
       }
       return undefined;
     }
-    const sources = await this.collectAll(wh, pub);
-    if (sources.length === 0) {
+    const { pages, attachments } = await this.collectAll(wh, pub);
+    if (pages.length === 0) {
       vscode.window.showInformationMessage('Mark It Down: nothing to publish.');
       return undefined;
     }
-    return this.runBuildAndPush(wh, pub, sources);
+    return this.runBuildAndPush(wh, pub, pages, attachments);
   }
 
   public async publishCurrent(): Promise<PublishResult | undefined> {
@@ -66,7 +72,7 @@ export class PublishManager {
       pathFromRoot: `${baseName}.html`,
       markdown,
     };
-    return this.runBuildAndPush(wh, pub, [page]);
+    return this.runBuildAndPush(wh, pub, [page], []);
   }
 
   public async copyShareUrl(uri?: vscode.Uri): Promise<void> {
@@ -103,26 +109,39 @@ export class PublishManager {
     return false;
   }
 
-  private async collectAll(wh: WarehouseConfig, _pub: PublishConfig): Promise<PageInput[]> {
+  private async collectAll(
+    wh: WarehouseConfig,
+    _pub: PublishConfig,
+  ): Promise<{ pages: PageInput[]; attachments: AttachmentToCopy[] }> {
+    void wh;
     // For v1 we publish all global notes. Workspace notes per workspace are out of scope here.
     const notes = this.notesStore.listByScope('global');
-    const out: PageInput[] = [];
+    const pages: PageInput[] = [];
+    const attachments: AttachmentToCopy[] = [];
     for (const note of notes) {
       const content = await this.notesStore.readContent(note);
       const slug = slugify(note.title);
-      out.push({
+      pages.push({
         title: note.title,
         pathFromRoot: `notes/${slug}-${note.id}.html`,
         markdown: content,
       });
+      const noteAttachments = await this.notesStore.listAttachments(note);
+      for (const att of noteAttachments) {
+        attachments.push({
+          srcUri: this.notesStore.attachmentUri(note, att.filename),
+          destPathFromRoot: `notes/${attachmentDirName(note.id)}/${att.filename}`,
+        });
+      }
     }
-    return out;
+    return { pages, attachments };
   }
 
   private async runBuildAndPush(
     wh: WarehouseConfig,
     pub: PublishConfig,
     pages: PageInput[],
+    attachments: AttachmentToCopy[],
   ): Promise<PublishResult> {
     const cloneRoot = path.join(this.context.globalStorageUri.fsPath, 'warehouse', repoSlug(wh));
     const worktreeRoot = path.join(this.context.globalStorageUri.fsPath, 'publish', repoSlug(wh));
@@ -177,6 +196,18 @@ export class PublishManager {
       const out = path.join(subRoot, rendered.pathFromRoot);
       await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.dirname(out)));
       await vscode.workspace.fs.writeFile(vscode.Uri.file(out), new TextEncoder().encode(rendered.html));
+    }
+
+    // Copy note attachments next to their owning notes
+    for (const att of attachments) {
+      const dest = path.join(subRoot, att.destPathFromRoot);
+      await vscode.workspace.fs.createDirectory(vscode.Uri.file(path.dirname(dest)));
+      try {
+        const bytes = await vscode.workspace.fs.readFile(att.srcUri);
+        await vscode.workspace.fs.writeFile(vscode.Uri.file(dest), bytes);
+      } catch (err) {
+        log('warn', `failed to copy attachment ${att.destPathFromRoot}: ${(err as Error).message}`);
+      }
     }
 
     // index.html (overrides any same-named page from the page set; that's fine)

--- a/src/warehouse/warehouseSync.ts
+++ b/src/warehouse/warehouseSync.ts
@@ -6,6 +6,7 @@ import { log } from './warehouseLog';
 import { scanForSecrets, SecretFinding } from './secretScanner';
 import { WarehouseClone, WarehouseTransport } from './warehouseTransport';
 import { ConflictRegistry } from './conflictRegistry';
+import { attachmentDirName } from '../../packages/core/src/attachments';
 
 export interface SyncSummary {
   pulled: { added: number; updated: number; conflicts: number };
@@ -28,6 +29,8 @@ interface WarehouseIndexEntry {
   createdAt: string;
   updatedAt: string;
   filename: string;
+  /** Sorted list of attachment filenames (just basenames; no slashes). */
+  attachments?: string[];
 }
 
 interface WarehouseIndex {
@@ -69,7 +72,8 @@ export class WarehouseSync {
         if (!local) {
           const content = await this.readRemoteContent(config, clone, scope, entry.filename);
           if (content === undefined) continue;
-          await this.store.importNote(toMetadata(entry, scope), content);
+          const attachments = await this.readRemoteAttachments(config, clone, scope, entry);
+          await this.store.importNote(toMetadata(entry, scope), content, attachments);
           added++;
           continue;
         }
@@ -103,7 +107,8 @@ export class WarehouseSync {
         }
         const content = await this.readRemoteContent(config, clone, scope, entry.filename);
         if (content === undefined) continue;
-        await this.store.importNote(toMetadata(entry, scope), content);
+        const attachments = await this.readRemoteAttachments(config, clone, scope, entry);
+        await this.store.importNote(toMetadata(entry, scope), content, attachments);
         updated++;
       }
     }
@@ -139,14 +144,21 @@ export class WarehouseSync {
       }
     }
 
-    plan.files = [
-      ...new Set([
-        ...plan.added.flatMap(n => this.filesForNote(config, n)),
-        ...plan.updated.flatMap(n => this.filesForNote(config, n)),
-        ...plan.deleted.map(e => `${scopeDir(config, e.scope)}/${e.filename}`),
-        ...this.indexFiles(config),
-      ]),
-    ];
+    const fileSet = new Set<string>();
+    for (const n of plan.added) {
+      for (const f of await this.filesForNote(config, n)) fileSet.add(f);
+    }
+    for (const n of plan.updated) {
+      for (const f of await this.filesForNote(config, n)) fileSet.add(f);
+    }
+    for (const e of plan.deleted) {
+      fileSet.add(`${scopeDir(config, e.scope)}/${e.filename}`);
+      for (const att of e.attachments ?? []) {
+        fileSet.add(`${scopeDir(config, e.scope)}/${attachmentDirName(e.id)}/${att}`);
+      }
+    }
+    for (const f of this.indexFiles(config)) fileSet.add(f);
+    plan.files = [...fileSet];
     return plan;
   }
 
@@ -182,6 +194,12 @@ export class WarehouseSync {
         await vscode.workspace.fs.delete(vscode.Uri.file(abs));
       } catch {
         // already gone — fine
+      }
+      const attDir = path.join(clone.root, scopeDir(config, entry.scope), attachmentDirName(entry.id));
+      try {
+        await vscode.workspace.fs.delete(vscode.Uri.file(attDir), { recursive: true, useTrash: false });
+      } catch {
+        // didn't exist — fine
       }
     }
 
@@ -219,16 +237,30 @@ export class WarehouseSync {
     const dir = path.join(clone.root, scopeDir(config, scope));
     await vscode.workspace.fs.createDirectory(vscode.Uri.file(dir));
     const notes = this.store.listByScope(scope);
+    const attachmentsByNote = new Map<string, string[]>();
     for (const note of notes) {
       const content = await this.store.readContent(note);
       const target = vscode.Uri.file(path.join(dir, note.filename));
       await vscode.workspace.fs.writeFile(target, new TextEncoder().encode(content));
+      const attachments = await this.store.listAttachments(note);
+      attachmentsByNote.set(note.id, attachments.map(a => a.filename));
+      if (attachments.length > 0) {
+        const subdir = path.join(dir, attachmentDirName(note.id));
+        await vscode.workspace.fs.createDirectory(vscode.Uri.file(subdir));
+        for (const att of attachments) {
+          const bytes = await vscode.workspace.fs.readFile(this.store.attachmentUri(note, att.filename));
+          await vscode.workspace.fs.writeFile(vscode.Uri.file(path.join(subdir, att.filename)), bytes);
+        }
+      }
     }
     const index: WarehouseIndex = {
       scope,
       workspaceId: scope === 'global' ? PERSONAL_WORKSPACE_ID : config.workspaceId,
       generatedAt: new Date().toISOString(),
-      notes: notes.map(toIndexEntry),
+      notes: notes.map(n => ({
+        ...toIndexEntry(n),
+        attachments: attachmentsByNote.get(n.id)?.length ? attachmentsByNote.get(n.id) : undefined,
+      })),
     };
     const indexUri = vscode.Uri.file(path.join(dir, '_index.json'));
     await vscode.workspace.fs.writeFile(
@@ -237,9 +269,14 @@ export class WarehouseSync {
     );
   }
 
-  private filesForNote(config: WarehouseConfig, note: NoteMetadata): string[] {
+  private async filesForNote(config: WarehouseConfig, note: NoteMetadata): Promise<string[]> {
     const dir = scopeDir(config, note.scope);
-    return [`${dir}/${note.filename}`, `${dir}/_index.json`];
+    const out = [`${dir}/${note.filename}`, `${dir}/_index.json`];
+    const attachments = await this.store.listAttachments(note);
+    for (const att of attachments) {
+      out.push(`${dir}/${attachmentDirName(note.id)}/${att.filename}`);
+    }
+    return out;
   }
 
   private indexFiles(config: WarehouseConfig): string[] {
@@ -283,6 +320,28 @@ export class WarehouseSync {
     }
     const buf = await vscode.workspace.fs.readFile(vscode.Uri.file(this.transport.absolute(clone, rel)));
     return new TextDecoder().decode(buf);
+  }
+
+  private async readRemoteAttachments(
+    config: WarehouseConfig,
+    clone: WarehouseClone,
+    scope: NoteScope,
+    entry: WarehouseIndexEntry,
+  ): Promise<{ filename: string; bytes: Uint8Array }[]> {
+    const list = entry.attachments ?? [];
+    if (list.length === 0) return [];
+    const dir = `${scopeDir(config, scope)}/${attachmentDirName(entry.id)}`;
+    const out: { filename: string; bytes: Uint8Array }[] = [];
+    for (const filename of list) {
+      const rel = `${dir}/${filename}`;
+      if (!(await this.transport.fileExists(clone, rel))) {
+        log('warn', `attachment listed in index but missing on disk: ${rel}`);
+        continue;
+      }
+      const bytes = await vscode.workspace.fs.readFile(vscode.Uri.file(this.transport.absolute(clone, rel)));
+      out.push({ filename, bytes });
+    }
+    return out;
   }
 
   private async scanPlan(plan: PushPlan): Promise<Map<string, SecretFinding[]>> {

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -602,6 +602,45 @@ window.addEventListener('message', evt => {
   }
 });
 
+function bindDragDropAttachments() {
+  const stop = (evt: DragEvent) => {
+    if (!evt.dataTransfer) return;
+    const types = evt.dataTransfer.types;
+    if (!types || ![...types].includes('Files')) return;
+    evt.preventDefault();
+  };
+  document.addEventListener('dragenter', stop);
+  document.addEventListener('dragover', stop);
+  document.addEventListener('drop', evt => {
+    if (!evt.dataTransfer || evt.dataTransfer.files.length === 0) return;
+    evt.preventDefault();
+    const files = Array.from(evt.dataTransfer.files);
+    files.forEach(file => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result;
+        if (typeof result !== 'string') return;
+        const commaIdx = result.indexOf(',');
+        const bytesBase64 = commaIdx >= 0 ? result.slice(commaIdx + 1) : result;
+        vscode.postMessage({
+          type: 'attachUpload',
+          name: file.name,
+          bytesBase64,
+        });
+      };
+      reader.onerror = () => {
+        vscode.postMessage({
+          type: 'showError',
+          message: `Mark It Down: failed to read ${file.name}`,
+        });
+      };
+      reader.readAsDataURL(file);
+    });
+  });
+}
+
+bindDragDropAttachments();
+
 // Tell the host we're ready
 vscode.postMessage({ type: 'ready' });
 

--- a/tests/unit/attachments/attachments.test.ts
+++ b/tests/unit/attachments/attachments.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  attachmentDirName,
+  attachmentMarkdown,
+  isImageAttachment,
+  relativeAttachmentPath,
+  resolveCollision,
+  sanitizeAttachmentName,
+} from '../../../packages/core/src/attachments';
+
+describe('attachmentDirName', () => {
+  it('appends -attachments to the note id', () => {
+    expect(attachmentDirName('abc123')).toBe('abc123-attachments');
+  });
+});
+
+describe('relativeAttachmentPath', () => {
+  it('joins the dir + filename with a slash', () => {
+    expect(relativeAttachmentPath('abc', 'photo.png')).toBe('abc-attachments/photo.png');
+  });
+});
+
+describe('sanitizeAttachmentName', () => {
+  it('strips unsafe characters and runs of whitespace', () => {
+    expect(sanitizeAttachmentName('My Photo (1).png')).toBe('My-Photo-1-.png');
+  });
+
+  it('strips path traversal segments', () => {
+    expect(sanitizeAttachmentName('../../etc/passwd')).toBe('passwd');
+    expect(sanitizeAttachmentName('C:\\Windows\\System32\\foo.dll')).toBe('foo.dll');
+  });
+
+  it('falls back to "attachment" for empty input', () => {
+    expect(sanitizeAttachmentName('')).toBe('attachment');
+    expect(sanitizeAttachmentName('!!!')).toBe('attachment');
+  });
+
+  it('caps stem length while preserving extension', () => {
+    const long = 'a'.repeat(120) + '.png';
+    const out = sanitizeAttachmentName(long);
+    expect(out.endsWith('.png')).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(96);
+  });
+});
+
+describe('resolveCollision', () => {
+  it('returns the original name when no collision', () => {
+    expect(resolveCollision('a.png', [])).toBe('a.png');
+  });
+
+  it('appends -1, -2, … on collision', () => {
+    expect(resolveCollision('a.png', ['a.png'])).toBe('a-1.png');
+    expect(resolveCollision('a.png', ['a.png', 'a-1.png'])).toBe('a-2.png');
+    expect(resolveCollision('a.png', ['a.png', 'a-1.png', 'a-2.png'])).toBe('a-3.png');
+  });
+
+  it('handles names without extensions', () => {
+    expect(resolveCollision('LICENSE', ['LICENSE'])).toBe('LICENSE-1');
+  });
+});
+
+describe('isImageAttachment', () => {
+  it.each([
+    ['photo.png', true],
+    ['photo.PNG', true],
+    ['photo.jpeg', true],
+    ['vector.svg', true],
+    ['notes.pdf', false],
+    ['archive.zip', false],
+    ['no-extension', false],
+  ])('detects %s as image=%s', (name, expected) => {
+    expect(isImageAttachment(name)).toBe(expected);
+  });
+});
+
+describe('attachmentMarkdown', () => {
+  it('emits ![]() for images', () => {
+    expect(attachmentMarkdown('abc', 'photo.png')).toBe('![photo.png](abc-attachments/photo.png)');
+  });
+
+  it('emits []() for non-images', () => {
+    expect(attachmentMarkdown('abc', 'spec.pdf')).toBe('[spec.pdf](abc-attachments/spec.pdf)');
+  });
+
+  it('respects custom label', () => {
+    expect(attachmentMarkdown('abc', 'spec.pdf', 'See spec')).toBe('[See spec](abc-attachments/spec.pdf)');
+  });
+});


### PR DESCRIPTION
Closes #44

## Summary

- Drag-drop binary files onto the editor — saved to `<storage>/notes/<id>-attachments/<filename>`, sanitised + collision-resolved, markdown reference inserted (image vs link)
- Warehouse push + pull copies the dirs both ways and records filenames in `_index.json` per note
- Published static site copies attachments next to their owning page so `[label](id-attachments/file.pdf)` resolves on GitHub Pages

## Test plan

- [x] `npx vitest run` — 127/127 (19 new attachment tests)
- [x] `tsc -p ./` — clean
- [x] Webview + MCP bundles compile
- [x] Manual smoke: drop image → renders inline, drop PDF → link, both round-trip via warehouse

## Docs

- `docs/note-attachments.md` (new) + `docs/README.md` v2.0 row + `CHANGELOG.md` entry