### PR TITLE
feat(notes): nested category hierarchies via slash separator (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — v2.0: Nested category hierarchies (#45)
+
+- Category names accept `/` as a hierarchy separator — `Reference/Postgres`, `Reference/Postgres/Indexing`, `Daily/2026-04` all coexist as plain category strings (no schema migration)
+- Notes sidebar renders categories as a true tree: each scope shows root segments, expanding a category shows its child segments first then notes that live at the exact path; tooltip surfaces the full path on hover
+- New `packages/core/src/categories/` package: pure helpers `parseCategoryPath`, `joinCategoryPath`, `categoryHasPrefix`, `rootCategories`, `childCategoriesAt` — segment-aware so siblings don't bleed together (`References/Foo` does not match prefix `Reference`)
+- MCP `list_notes` accepts `categoryPrefix` (matches the path itself or anything underneath it); existing `category` filter still does exact match. Trailing slashes on the prefix are stripped before comparison.
+- Tree provider uses the new helpers — flat categories render unchanged (a one-segment path is just a leaf folder)
+- 14 new unit tests covering parse / join / prefix matching (exact, descendant, sibling rejection, empty wildcard) / root collection / child collection at root + at depth + grandchild de-dup + parent-skip
+
 ### Added — v2.0: Note attachments (#44)
 
 - Each note can carry binary attachments stored at `<storage>/notes/<id>-attachments/<filename>`; the dir is created lazily on first attachment and removed when the note is deleted

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,5 +32,6 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 |---|---|---|
 | #43 — `[[wiki-link]]` references + backlink panel | shipped | [wiki-links.md](wiki-links.md) |
 | #44 — Note attachments (drag-drop + warehouse + publish) | shipped | [note-attachments.md](note-attachments.md) |
+| #45 — Nested category hierarchies | shipped | [nested-categories.md](nested-categories.md) |
 
 Each feature gets its own page when it ships. New pages should follow the [notes-sidebar.md](notes-sidebar.md) shape: at-a-glance table, settings, workflows, edge cases, and a "what it unblocks" section.

--- a/docs/nested-categories.md
+++ b/docs/nested-categories.md
@@ -1,0 +1,95 @@
+# Nested Category Hierarchies
+
+Category names support `/` as a hierarchy separator. `Reference/Postgres`,
+`Reference/Postgres/Indexing`, and `Daily/2026-04` all coexist; the Notes
+sidebar renders them as nested folders, the MCP `list_notes` tool gains a
+`categoryPrefix` filter, and the warehouse / publish pipelines need no
+changes — categories are still plain strings on disk.
+
+## Authoring
+
+Nothing about how a note is created changes. The "New Note" command opens
+a Quick Pick of known categories — type a fresh value with slashes
+(`Engineering/Outage Postmortems`) and that becomes the new path. Existing
+notes pick up nesting automatically the next time the tree refreshes.
+
+The configured-categories setting (`markItDown.notes.categories`) accepts
+slash paths too, so you can pre-seed an empty workspace with a tree:
+
+```jsonc
+"markItDown.notes.categories": [
+  "Daily",
+  "Reference",
+  "Reference/Postgres",
+  "Reference/Networking",
+  "Drafts"
+]
+```
+
+## Sidebar tree
+
+Each scope (Workspace / Global) lists its **root** categories — distinct
+first segments across the configured + in-use sets. Expanding a category
+shows:
+
+1. Its child categories first (alphabetical), then
+2. Notes that live at that exact path (most recent first).
+
+So `Reference` could expand to `Networking`, `Postgres`, then any notes
+whose category is exactly `Reference`. `Reference/Postgres` would expand
+to `Indexing` (a deeper child) plus its own notes.
+
+The displayed label is the last segment only; hover the row for the full
+path tooltip.
+
+## MCP filter
+
+`list_notes` accepts:
+
+| Field | Behaviour |
+| --- | --- |
+| `category` | exact match (unchanged) |
+| `categoryPrefix` | matches the path itself or anything underneath it (`Reference` matches `Reference`, `Reference/Postgres`, `Reference/Postgres/Indexing`) |
+| `tag` | tag filter (unchanged) |
+
+The filter is greedy on the prefix only — siblings like `References/Foo`
+do not match `Reference` because the comparison uses path segments, not
+raw `startsWith`. Trailing slashes in the prefix are tolerated and stripped
+before matching.
+
+## Implementation map
+
+| File | Role |
+| --- | --- |
+| `packages/core/src/categories/path.ts` | Pure helpers (parse, join, hasPrefix, rootCategories, childCategoriesAt) |
+| `src/notes/notesTreeProvider.ts` | Tree builds nested segments via `childCategoriesAt` |
+| `src/mcp/notesAdapter.ts` | `listNotes({ categoryPrefix })` uses path-segment match |
+| `src/mcp/server.ts` | `list_notes` input schema gains `categoryPrefix` |
+
+## Backwards compatibility
+
+Existing flat categories ("Drafts", "Daily") render exactly as before —
+they're just one-segment paths. `category` filters in MCP still work.
+The warehouse `_index.json` is untouched (categories are always plain
+strings). No migration needed.
+
+## Limitations
+
+- The Notes sidebar doesn't yet support **dragging a note** between
+  categories. Use the existing `Move to Category…` action.
+- Renaming a parent (e.g. `Reference` → `Refs`) doesn't bulk-rename the
+  children — you'd have to re-categorise each note. Bulk-rename is a
+  natural follow-up.
+- `pickCategory` shows raw paths in a flat Quick Pick. A two-step picker
+  (root → child) is a future polish; the flat list is fine while category
+  counts are small.
+
+## Testing
+
+```bash
+npx vitest run tests/unit/categories
+```
+
+14 tests cover the pure helpers (parse, join, hasPrefix exact + descendant
++ sibling rejection + empty-prefix wildcard, root collection, child
+collection at root + at depth + grandchild de-dup + parent-skip).

--- a/packages/core/src/categories/index.ts
+++ b/packages/core/src/categories/index.ts
@@ -1,0 +1,1 @@
+export * from './path';

--- a/packages/core/src/categories/path.ts
+++ b/packages/core/src/categories/path.ts
@@ -1,0 +1,91 @@
+/**
+ * Category names support `/` as a hierarchy separator.
+ * `Reference/Postgres` lives under the `Reference` parent in the tree;
+ * `Reference/Postgres/Indexing` is a deeper child of that.
+ *
+ * The category string itself remains the canonical id — these helpers are
+ * pure-function projections used by the tree, MCP filters, and tests.
+ */
+
+const SEPARATOR = '/';
+
+export interface CategoryNode {
+  /** Last path segment, e.g. `Postgres`. */
+  name: string;
+  /** Full path from the root, e.g. `Reference/Postgres`. */
+  path: string;
+}
+
+/** Split a category path into its segments, trimming + dropping empties. */
+export function parseCategoryPath(category: string): string[] {
+  return category
+    .split(SEPARATOR)
+    .map(s => s.trim())
+    .filter(s => s.length > 0);
+}
+
+/** Join trusted segments back into a category path. */
+export function joinCategoryPath(segments: string[]): string {
+  return segments
+    .map(s => s.trim())
+    .filter(s => s.length > 0)
+    .join(SEPARATOR);
+}
+
+/** True if `child` is the exact same path or sits underneath `prefix`. */
+export function categoryHasPrefix(child: string, prefix: string): boolean {
+  const childSegs = parseCategoryPath(child);
+  const prefixSegs = parseCategoryPath(prefix);
+  if (prefixSegs.length === 0) return true;
+  if (prefixSegs.length > childSegs.length) return false;
+  for (let i = 0; i < prefixSegs.length; i++) {
+    if (childSegs[i] !== prefixSegs[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Given the set of all category strings under a scope and an optional
+ * parent path, return the immediate children: distinct next-segments
+ * keyed by their full path.
+ *
+ * Example: categories `Reference`, `Reference/Postgres`, `Reference/Networking`,
+ * with parent `Reference` → returns `[{name:'Postgres', path:'Reference/Postgres'},
+ * {name:'Networking', path:'Reference/Networking'}]`.
+ */
+export function childCategoriesAt(allCategories: string[], parent: string): CategoryNode[] {
+  const parentSegs = parseCategoryPath(parent);
+  const seen = new Map<string, CategoryNode>();
+  for (const cat of allCategories) {
+    const segs = parseCategoryPath(cat);
+    if (segs.length <= parentSegs.length) continue;
+    let matchesParent = true;
+    for (let i = 0; i < parentSegs.length; i++) {
+      if (segs[i] !== parentSegs[i]) {
+        matchesParent = false;
+        break;
+      }
+    }
+    if (!matchesParent) continue;
+    const childPath = joinCategoryPath(segs.slice(0, parentSegs.length + 1));
+    if (!seen.has(childPath)) {
+      seen.set(childPath, { name: segs[parentSegs.length], path: childPath });
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Top-level (root) categories: distinct first segments from the corpus.
+ */
+export function rootCategories(allCategories: string[]): CategoryNode[] {
+  return childCategoriesAt(allCategories, '');
+}
+
+/**
+ * True if a category value is rendered as a "leaf" — the user has notes
+ * directly at this path (rather than only inside its children).
+ */
+export function hasNotesAtPath(allCategories: string[], path: string): boolean {
+  return allCategories.includes(path);
+}

--- a/src/mcp/notesAdapter.ts
+++ b/src/mcp/notesAdapter.ts
@@ -22,11 +22,17 @@ const INDEX_FILENAME = '_mcp-index.json';
 export class NotesAdapter {
   constructor(private readonly notesDir: string) {}
 
-  async listNotes(filter: { category?: string; tag?: string } = {}): Promise<MdNote[]> {
+  async listNotes(
+    filter: { category?: string; categoryPrefix?: string; tag?: string } = {},
+  ): Promise<MdNote[]> {
     const idx = await this.readIndex();
     let out = idx.notes;
     const cat = filter.category?.trim();
     if (cat) out = out.filter(n => n.category === cat);
+    const prefix = filter.categoryPrefix?.trim().replace(/\/+$/, '');
+    if (prefix) {
+      out = out.filter(n => n.category === prefix || n.category.startsWith(prefix + '/'));
+    }
     const tag = filter.tag?.trim().toLowerCase();
     if (tag) out = out.filter(n => (n.tags ?? []).includes(tag));
     return out;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,14 +28,19 @@ const server = new McpServer(
 server.registerTool(
   'list_notes',
   {
-    description: 'List notes in the Mark It Down warehouse. Optionally filter by category and/or tag.',
+    description:
+      'List notes in the Mark It Down warehouse. Optionally filter by category (exact), categoryPrefix (matches the path or anything underneath), and/or tag.',
     inputSchema: {
-      category: z.string().optional().describe('Restrict to notes in this category'),
+      category: z.string().optional().describe('Restrict to notes whose category equals this exact path'),
+      categoryPrefix: z
+        .string()
+        .optional()
+        .describe('Restrict to notes whose category equals this path or sits underneath it (e.g. "Reference" matches "Reference/Postgres")'),
       tag: z.string().optional().describe('Restrict to notes carrying this tag (lowercase)'),
     },
   },
-  async ({ category, tag }) => {
-    const notes = await adapter.listNotes({ category, tag });
+  async ({ category, categoryPrefix, tag }) => {
+    const notes = await adapter.listNotes({ category, categoryPrefix, tag });
     return {
       content: [
         {

--- a/src/notes/notesTreeProvider.ts
+++ b/src/notes/notesTreeProvider.ts
@@ -1,11 +1,18 @@
 import * as vscode from 'vscode';
 import { NoteMetadata, NoteScope, NotesStore } from './notesStore';
+import {
+  childCategoriesAt,
+  hasNotesAtPath,
+  parseCategoryPath,
+  rootCategories,
+} from '../../packages/core/src/categories';
 
 type NodeKind = 'scope' | 'category' | 'note' | 'empty';
 
 export interface NoteTreeNode {
   kind: NodeKind;
   scope?: NoteScope;
+  /** Full category path from the root (e.g. `Reference/Postgres`). */
   category?: string;
   note?: NoteMetadata;
   emptyMessage?: string;
@@ -57,7 +64,7 @@ export class NotesTreeProvider implements vscode.TreeDataProvider<NoteTreeNode> 
       return this.childrenForScope(node.scope!);
     }
     if (node.kind === 'category') {
-      return this.notesIn(node.scope!, node.category!).map(note => ({ kind: 'note', note }));
+      return this.childrenForCategory(node.scope!, node.category!);
     }
     return [];
   }
@@ -67,21 +74,30 @@ export class NotesTreeProvider implements vscode.TreeDataProvider<NoteTreeNode> 
     this.subs.forEach(s => s.dispose());
   }
 
-  private childrenForScope(scope: NoteScope): NoteTreeNode[] {
-    const notes = this.store.listByScope(scope);
+  private allKnownCategories(scope: NoteScope): string[] {
     const configured = configuredCategories();
     const used = this.store.categoriesInUse(scope);
-    const all = [...new Set([...configured, ...used])];
+    return [...new Set([...configured, ...used])];
+  }
+
+  private childrenForScope(scope: NoteScope): NoteTreeNode[] {
+    const all = this.allKnownCategories(scope);
     if (all.length === 0) {
       return [{ kind: 'empty', scope, emptyMessage: 'No categories configured.' }];
     }
-    const nodes = all
-      .filter(cat => configured.includes(cat) || notes.some(n => n.category === cat))
-      .map<NoteTreeNode>(category => ({ kind: 'category', scope, category }));
-    if (nodes.length === 0) {
+    const roots = rootCategories(all);
+    if (roots.length === 0) {
       return [{ kind: 'empty', scope, emptyMessage: 'No categories configured.' }];
     }
-    return nodes;
+    return roots.map<NoteTreeNode>(node => ({ kind: 'category', scope, category: node.path }));
+  }
+
+  private childrenForCategory(scope: NoteScope, category: string): NoteTreeNode[] {
+    const all = this.allKnownCategories(scope);
+    const subCats = childCategoriesAt(all, category)
+      .map<NoteTreeNode>(node => ({ kind: 'category', scope, category: node.path }));
+    const notes = this.notesIn(scope, category).map<NoteTreeNode>(note => ({ kind: 'note', note }));
+    return [...subCats, ...notes];
   }
 
   private notesIn(scope: NoteScope, category: string): NoteMetadata[] {
@@ -124,12 +140,19 @@ function scopeItem(scope: NoteScope): vscode.TreeItem {
 }
 
 function categoryItem(scope: NoteScope, category: string): vscode.TreeItem {
-  const item = new vscode.TreeItem(category, vscode.TreeItemCollapsibleState.Collapsed);
+  const segments = parseCategoryPath(category);
+  const label = segments[segments.length - 1] ?? category;
+  const item = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.Collapsed);
   item.contextValue = `markItDown.notes.category.${scope}`;
   item.iconPath = new vscode.ThemeIcon('folder');
   item.id = `${scope}::${category}`;
+  if (segments.length > 1) {
+    item.tooltip = category;
+  }
   return item;
 }
+
+void hasNotesAtPath; // exported so the wikilinks panel can re-use it later
 
 function noteItem(note: NoteMetadata, store: NotesStore): vscode.TreeItem {
   const item = new vscode.TreeItem(note.title || 'Untitled note', vscode.TreeItemCollapsibleState.None);

--- a/tests/unit/categories/path.test.ts
+++ b/tests/unit/categories/path.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  categoryHasPrefix,
+  childCategoriesAt,
+  joinCategoryPath,
+  parseCategoryPath,
+  rootCategories,
+} from '../../../packages/core/src/categories';
+
+describe('parseCategoryPath', () => {
+  it('splits on slashes and trims', () => {
+    expect(parseCategoryPath('Reference/Postgres/Indexing')).toEqual(['Reference', 'Postgres', 'Indexing']);
+  });
+
+  it('drops empty + whitespace-only segments', () => {
+    expect(parseCategoryPath('Reference//Postgres/  ')).toEqual(['Reference', 'Postgres']);
+  });
+
+  it('handles a flat category', () => {
+    expect(parseCategoryPath('Drafts')).toEqual(['Drafts']);
+  });
+});
+
+describe('joinCategoryPath', () => {
+  it('joins segments with slash', () => {
+    expect(joinCategoryPath(['Reference', 'Postgres'])).toBe('Reference/Postgres');
+  });
+
+  it('drops empty segments', () => {
+    expect(joinCategoryPath(['Reference', '', 'Postgres'])).toBe('Reference/Postgres');
+  });
+});
+
+describe('categoryHasPrefix', () => {
+  it('matches exact', () => {
+    expect(categoryHasPrefix('Reference/Postgres', 'Reference/Postgres')).toBe(true);
+  });
+
+  it('matches strict descendants', () => {
+    expect(categoryHasPrefix('Reference/Postgres/Indexing', 'Reference')).toBe(true);
+    expect(categoryHasPrefix('Reference/Postgres/Indexing', 'Reference/Postgres')).toBe(true);
+  });
+
+  it('does not match siblings', () => {
+    expect(categoryHasPrefix('References/Foo', 'Reference')).toBe(false);
+  });
+
+  it('empty prefix matches everything', () => {
+    expect(categoryHasPrefix('Anything', '')).toBe(true);
+  });
+});
+
+describe('rootCategories', () => {
+  it('returns distinct first segments', () => {
+    const all = ['Reference/Postgres', 'Reference/Networking', 'Drafts', 'Daily/2026-04'];
+    expect(rootCategories(all).map(n => n.path)).toEqual(['Daily', 'Drafts', 'Reference']);
+  });
+});
+
+describe('childCategoriesAt', () => {
+  const all = [
+    'Reference',
+    'Reference/Postgres',
+    'Reference/Postgres/Indexing',
+    'Reference/Networking',
+    'Drafts',
+  ];
+
+  it('returns immediate children of a parent', () => {
+    expect(childCategoriesAt(all, 'Reference').map(n => n.path)).toEqual([
+      'Reference/Networking',
+      'Reference/Postgres',
+    ]);
+  });
+
+  it('returns immediate children at root when parent is empty', () => {
+    expect(childCategoriesAt(all, '').map(n => n.path)).toEqual(['Drafts', 'Reference']);
+  });
+
+  it('does not double-count grandchildren', () => {
+    const result = childCategoriesAt(all, 'Reference/Postgres');
+    expect(result.map(n => n.path)).toEqual(['Reference/Postgres/Indexing']);
+  });
+
+  it('skips the parent path itself even if listed', () => {
+    expect(childCategoriesAt(all, 'Reference').map(n => n.path)).not.toContain('Reference');
+  });
+});


### PR DESCRIPTION
Closes #45

## Summary

- Category names accept `/` as a hierarchy separator — `Reference/Postgres/Indexing` and friends
- Notes sidebar nests them: each scope shows root segments → child segments → notes at exact path
- New `packages/core/src/categories/` package with segment-aware traversal helpers
- MCP `list_notes` accepts `categoryPrefix` (matches the path or anything underneath, segment-aware)

## Test plan

- [x] `npx vitest run` — 141/141 (14 new path-helper tests)
- [x] `tsc -p ./` — clean
- [x] Webview + MCP bundles compile
- [x] Manual smoke: created `Reference/Postgres` notes, observed nested rendering

## Docs

- `docs/nested-categories.md` (new) + `docs/README.md` v2.0 row + `CHANGELOG.md` entry