### PR TITLE
feat(publish): per-page slug overrides via YAML frontmatter (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — v2.0: Per-page slug overrides via frontmatter (#46)
+
+- Notes can declare a `slug:` in a YAML frontmatter block at the top of the body — published page goes to `notes/<slug>.html` instead of the default `notes/<slug-from-title>-<id>.html`
+- New `packages/core/src/frontmatter/index.ts` — tiny zero-dep parser for `---`-fenced blocks, supports scalars (string / number / boolean), inline lists, quoted strings, comment lines, BOM, missing-fence safety
+- `validateSlug` rules: `^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$` and ≤48 chars; anything else (uppercase, whitespace, slashes, leading/trailing dash, over-length) silently falls back to the title-derived id-suffixed URL
+- Slug collision detection in `PublishManager.collectAll`: first claimant keeps the clean URL, conflicting note(s) fall back to id-suffixed URL, warehouse log gets a `slug collision` entry, and a one-shot `showWarningMessage` surfaces it
+- `publishCurrent` (the per-file path) also strips frontmatter + honours slug override for arbitrary markdown files
+- 15 new unit tests across the parser (no-fence, fenced + stripped, scalar types, lists, comments, missing closing fence, BOM tolerance, leading blank line) and `validateSlug` (lowercase-dash, digits, rejected patterns, length cap, non-string input)
+
 ### Added — v2.0: Nested category hierarchies (#45)
 
 - Category names accept `/` as a hierarchy separator — `Reference/Postgres`, `Reference/Postgres/Indexing`, `Daily/2026-04` all coexist as plain category strings (no schema migration)

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,5 +33,6 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 | #43 — `[[wiki-link]]` references + backlink panel | shipped | [wiki-links.md](wiki-links.md) |
 | #44 — Note attachments (drag-drop + warehouse + publish) | shipped | [note-attachments.md](note-attachments.md) |
 | #45 — Nested category hierarchies | shipped | [nested-categories.md](nested-categories.md) |
+| #46 — Per-page slug overrides via frontmatter | shipped | [slug-overrides.md](slug-overrides.md) |
 
 Each feature gets its own page when it ships. New pages should follow the [notes-sidebar.md](notes-sidebar.md) shape: at-a-glance table, settings, workflows, edge cases, and a "what it unblocks" section.

--- a/docs/slug-overrides.md
+++ b/docs/slug-overrides.md
@@ -1,0 +1,90 @@
+# Per-Page Slug Overrides
+
+Default published-page URLs are `notes/<slug-from-title>-<id>.html` —
+guaranteed unique but ugly. A note can override that with a YAML
+frontmatter `slug:` field, dropping the id suffix entirely.
+
+## Author the override
+
+Add a frontmatter block at the very top of the note body:
+
+```markdown
+---
+slug: my-better-url
+---
+
+# My Better Title
+
+…
+```
+
+Result: the note publishes to `notes/my-better-url.html` instead of
+`notes/my-better-title-abc123def456.html`.
+
+## Validation rules
+
+The slug must match `^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$` and be ≤48
+characters. Anything else (uppercase, whitespace, slashes, leading or
+trailing dashes, over-length) is rejected silently and the note falls
+back to the title-derived slug + id suffix.
+
+This keeps the URL filesystem-safe and prevents `slug: ../../etc/passwd`
+shenanigans.
+
+## Collision handling
+
+Two notes resolving to the same slug would overwrite each other on the
+publish branch. The publisher detects this and:
+
+1. Logs a warning to the warehouse log: `slug collision: notes A and B both publish to notes/x.html`.
+2. Keeps the first claimant at the clean URL.
+3. Falls back to the id-suffixed URL (`notes/<slug>-<id>.html`) for the
+   loser, so neither note disappears.
+4. Surfaces a one-shot `showWarningMessage` so you notice and rename one
+   of them.
+
+The first-come-first-served order matches the iteration order over the
+notes index, which is unstable across runs — don't rely on which note
+"wins"; rename one of the conflicting slugs as soon as you see the
+warning.
+
+## Frontmatter parser
+
+The bundled parser lives in `packages/core/src/frontmatter/index.ts` and
+recognises:
+
+* simple `key: value` pairs (string, number, boolean)
+* quoted strings (`"hello"`, `'world'`)
+* inline lists (`tags: [a, "b c", d]`)
+* `null` / `~` (treated as empty string)
+* `# comment` lines and blank lines (skipped)
+* a single leading blank line after the closing fence is consumed so
+  bodies start where you'd expect
+
+Anything richer than that — nested objects, multi-line strings, anchors —
+is intentionally out of scope; pull a real YAML lib if you need it.
+
+## Other frontmatter fields
+
+Only `slug` is acted on today. The parser leaves the rest of the parsed
+data on `FrontmatterResult.data`, so future features (custom
+`description`, `og:image`, `published_at`, etc.) can plumb through
+without touching the parser again.
+
+## Implementation map
+
+| File | Role |
+| --- | --- |
+| `packages/core/src/frontmatter/index.ts` | Parser + `validateSlug` + `stripFrontmatter` |
+| `src/publish/publishManager.ts` | `collectAll` parses each note, picks slug, detects collisions, warns; `publishCurrent` strips frontmatter for arbitrary markdown files too |
+
+## Testing
+
+```bash
+npx vitest run tests/unit/frontmatter
+```
+
+15 tests cover parser branches (no-fence, fenced + stripped, scalar
+types, lists, comments, missing closing fence, BOM tolerance, leading
+blank line) and slug validation (lowercase-dash, digits, rejected
+patterns, length cap, non-string input).

--- a/packages/core/src/frontmatter/index.ts
+++ b/packages/core/src/frontmatter/index.ts
@@ -1,0 +1,136 @@
+/**
+ * Tiny zero-dep YAML-frontmatter parser. Recognises a `---`-delimited
+ * block at the very top of the document (optionally preceded by a UTF-8
+ * BOM) and pulls out simple `key: value` pairs.
+ *
+ * Supported value forms:
+ *   slug: my-page
+ *   title: "My Page"
+ *   draft: true
+ *   tags: [a, b, "c d"]
+ *
+ * Anything more elaborate (nested objects, multi-line strings, anchors)
+ * is intentionally not supported — pull a real YAML lib if that becomes a
+ * requirement. For our publish pipeline, the slug field is all that
+ * matters.
+ */
+
+export interface FrontmatterResult {
+  /** Parsed key→value map. Missing block ⇒ empty object. */
+  data: Record<string, string | number | boolean | string[]>;
+  /** Document body with the frontmatter block removed (and its trailing newlines collapsed). */
+  body: string;
+  /** True when a `---`-delimited block was found and parsed. */
+  found: boolean;
+}
+
+const FENCE = '---';
+
+export function parseFrontmatter(source: string): FrontmatterResult {
+  let src = source;
+  if (src.charCodeAt(0) === 0xFEFF) src = src.slice(1);
+
+  const head = src.split('\n', 1)[0];
+  if (head.trim() !== FENCE) {
+    return { data: {}, body: source, found: false };
+  }
+
+  // Find the closing fence.
+  const lines = src.split('\n');
+  let endIdx = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === FENCE) {
+      endIdx = i;
+      break;
+    }
+  }
+  if (endIdx < 0) {
+    return { data: {}, body: source, found: false };
+  }
+
+  const data: Record<string, string | number | boolean | string[]> = {};
+  for (let i = 1; i < endIdx; i++) {
+    const line = lines[i];
+    if (line.trim().length === 0 || line.trim().startsWith('#')) continue;
+    const colonIdx = line.indexOf(':');
+    if (colonIdx < 0) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const rawValue = line.slice(colonIdx + 1).trim();
+    if (key.length === 0) continue;
+    data[key] = parseScalar(rawValue);
+  }
+  const bodyLines = lines.slice(endIdx + 1);
+  // Drop a single leading blank line if present so users can typeset
+  // `---\n\n# Title` without picking up a stray newline.
+  if (bodyLines.length > 0 && bodyLines[0].trim().length === 0) {
+    bodyLines.shift();
+  }
+  return { data, body: bodyLines.join('\n'), found: true };
+}
+
+function parseScalar(raw: string): string | number | boolean | string[] {
+  if (raw.length === 0) return '';
+  // Inline list: [a, "b c", 'd']
+  if (raw.startsWith('[') && raw.endsWith(']')) {
+    return parseInlineList(raw.slice(1, -1));
+  }
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  if (raw === 'null' || raw === '~') return '';
+  // Quoted strings keep their inner content verbatim
+  if ((raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))) {
+    return raw.slice(1, -1);
+  }
+  if (/^-?\d+$/.test(raw)) return Number(raw);
+  if (/^-?\d+\.\d+$/.test(raw)) return Number(raw);
+  return raw;
+}
+
+function parseInlineList(inner: string): string[] {
+  const out: string[] = [];
+  let buf = '';
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < inner.length; i++) {
+    const c = inner[i];
+    if (quote) {
+      if (c === quote) quote = null;
+      else buf += c;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      quote = c;
+      continue;
+    }
+    if (c === ',') {
+      const trimmed = buf.trim();
+      if (trimmed.length > 0) out.push(trimmed);
+      buf = '';
+      continue;
+    }
+    buf += c;
+  }
+  const trimmed = buf.trim();
+  if (trimmed.length > 0) out.push(trimmed);
+  return out;
+}
+
+/**
+ * Convenience: returns just the body with frontmatter stripped, for
+ * pipelines that don't care about the parsed data.
+ */
+export function stripFrontmatter(source: string): string {
+  return parseFrontmatter(source).body;
+}
+
+/**
+ * Validate a slug value (lowercase letters/digits/dashes, ≤48 chars).
+ * Returns the cleaned slug, or undefined if it's invalid.
+ */
+export function validateSlug(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  if (trimmed.length > 48) return undefined;
+  if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(trimmed)) return undefined;
+  return trimmed;
+}

--- a/src/publish/publishManager.ts
+++ b/src/publish/publishManager.ts
@@ -8,6 +8,7 @@ import { findTheme } from '../themes/themes';
 import { PublishConfig, readPublishConfig } from './publishConfig';
 import { buildSiteAssets, PageInput, renderIndex, renderPage } from './staticGenerator';
 import { attachmentDirName } from '../../packages/core/src/attachments';
+import { parseFrontmatter, validateSlug } from '../../packages/core/src/frontmatter';
 import lunr from 'lunr';
 
 interface AttachmentToCopy {
@@ -65,12 +66,15 @@ export class PublishManager {
       return undefined;
     }
     const buf = await vscode.workspace.fs.readFile(uri);
-    const markdown = new TextDecoder().decode(buf);
+    const raw = new TextDecoder().decode(buf);
+    const fm = parseFrontmatter(raw);
+    const overrideSlug = fm.found ? validateSlug(fm.data.slug) : undefined;
     const baseName = (uri.path.split('/').pop() ?? 'page').replace(/\.[^.]+$/, '');
+    const slug = overrideSlug ?? baseName;
     const page: PageInput = {
       title: baseName,
-      pathFromRoot: `${baseName}.html`,
-      markdown,
+      pathFromRoot: `${slug}.html`,
+      markdown: fm.body,
     };
     return this.runBuildAndPush(wh, pub, [page], []);
   }
@@ -118,14 +122,40 @@ export class PublishManager {
     const notes = this.notesStore.listByScope('global');
     const pages: PageInput[] = [];
     const attachments: AttachmentToCopy[] = [];
+    const slugByPath = new Map<string, string>();
     for (const note of notes) {
-      const content = await this.notesStore.readContent(note);
-      const slug = slugify(note.title);
-      pages.push({
-        title: note.title,
-        pathFromRoot: `notes/${slug}-${note.id}.html`,
-        markdown: content,
-      });
+      const raw = await this.notesStore.readContent(note);
+      const fm = parseFrontmatter(raw);
+      const overrideSlug = fm.found ? validateSlug(fm.data.slug) : undefined;
+      const fallbackSlug = slugify(note.title);
+      const slug = overrideSlug ?? fallbackSlug;
+      const pathFromRoot = overrideSlug
+        ? `notes/${slug}.html`
+        : `notes/${slug}-${note.id}.html`;
+      const existing = slugByPath.get(pathFromRoot);
+      if (existing && existing !== note.id) {
+        log(
+          'warn',
+          `slug collision: notes ${existing} and ${note.id} both publish to ${pathFromRoot}; appending id to disambiguate.`,
+        );
+        const safePath = `notes/${slug}-${note.id}.html`;
+        pages.push({
+          title: note.title,
+          pathFromRoot: safePath,
+          markdown: fm.body,
+        });
+        slugByPath.set(safePath, note.id);
+        void vscode.window.showWarningMessage(
+          `Mark It Down: slug "${slug}" is used by another note — falling back to id-suffixed URL for "${note.title}".`,
+        );
+      } else {
+        pages.push({
+          title: note.title,
+          pathFromRoot,
+          markdown: fm.body,
+        });
+        slugByPath.set(pathFromRoot, note.id);
+      }
       const noteAttachments = await this.notesStore.listAttachments(note);
       for (const att of noteAttachments) {
         attachments.push({

--- a/tests/unit/frontmatter/parser.test.ts
+++ b/tests/unit/frontmatter/parser.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseFrontmatter,
+  stripFrontmatter,
+  validateSlug,
+} from '../../../packages/core/src/frontmatter';
+
+describe('parseFrontmatter', () => {
+  it('returns no data when there is no fence', () => {
+    const r = parseFrontmatter('# Just a heading\nbody');
+    expect(r.found).toBe(false);
+    expect(r.data).toEqual({});
+    expect(r.body).toBe('# Just a heading\nbody');
+  });
+
+  it('parses a fenced block + strips it from the body', () => {
+    const r = parseFrontmatter('---\nslug: my-page\ntitle: "Hello"\n---\n\n# Body');
+    expect(r.found).toBe(true);
+    expect(r.data).toEqual({ slug: 'my-page', title: 'Hello' });
+    expect(r.body).toBe('# Body');
+  });
+
+  it('supports booleans, numbers, lists', () => {
+    const r = parseFrontmatter(`---
+draft: true
+priority: 3
+score: 1.5
+tags: [one, "two three", four]
+---
+body`);
+    expect(r.data).toEqual({
+      draft: true,
+      priority: 3,
+      score: 1.5,
+      tags: ['one', 'two three', 'four'],
+    });
+  });
+
+  it('skips comments + blank lines inside the block', () => {
+    const r = parseFrontmatter('---\n# comment\nslug: a\n\nfoo: bar\n---\n');
+    expect(r.data).toEqual({ slug: 'a', foo: 'bar' });
+  });
+
+  it('handles a missing closing fence by treating the whole thing as body', () => {
+    const r = parseFrontmatter('---\nslug: nope\nstill no fence here\n# Body');
+    expect(r.found).toBe(false);
+    expect(r.data).toEqual({});
+  });
+
+  it('tolerates a UTF-8 BOM', () => {
+    const r = parseFrontmatter('﻿---\nslug: x\n---\nbody');
+    expect(r.found).toBe(true);
+    expect(r.data.slug).toBe('x');
+  });
+
+  it('drops a single leading blank line after the closing fence', () => {
+    const r = parseFrontmatter('---\nslug: a\n---\n\n\n# Body');
+    expect(r.body).toBe('\n# Body');
+  });
+});
+
+describe('stripFrontmatter', () => {
+  it('returns the body without the fenced block', () => {
+    expect(stripFrontmatter('---\nslug: a\n---\nbody')).toBe('body');
+  });
+
+  it('passes through bodies without frontmatter', () => {
+    expect(stripFrontmatter('hello world')).toBe('hello world');
+  });
+});
+
+describe('validateSlug', () => {
+  it('accepts a simple lowercase-dash slug', () => {
+    expect(validateSlug('my-better-url')).toBe('my-better-url');
+  });
+
+  it('accepts digits', () => {
+    expect(validateSlug('post-2026-01')).toBe('post-2026-01');
+  });
+
+  it('rejects uppercase, whitespace, and special chars', () => {
+    expect(validateSlug('My Slug')).toBeUndefined();
+    expect(validateSlug('slug!')).toBeUndefined();
+    expect(validateSlug('with/slash')).toBeUndefined();
+  });
+
+  it('rejects leading + trailing dashes', () => {
+    expect(validateSlug('-leading')).toBeUndefined();
+    expect(validateSlug('trailing-')).toBeUndefined();
+  });
+
+  it('rejects empty + over-length', () => {
+    expect(validateSlug('')).toBeUndefined();
+    expect(validateSlug('a'.repeat(50))).toBeUndefined();
+  });
+
+  it('rejects non-strings', () => {
+    expect(validateSlug(42)).toBeUndefined();
+    expect(validateSlug(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #46

## Summary

- New zero-dep frontmatter parser in `packages/core/src/frontmatter/`
- Notes with `slug: my-better-url` publish to `notes/my-better-url.html`
- Slug collisions: log warning + UI message + id-suffix fallback (no overwrites)

## Test plan

- [x] `npx vitest run` — 156/156 (15 new parser/validator tests)
- [x] `tsc -p ./` — clean
- [x] Manual smoke: clean slug → clean URL; collision → fallback + warning

## Docs

- `docs/slug-overrides.md` (new) + `docs/README.md` v2.0 row + `CHANGELOG.md` entry