### PR TITLE
feat(warehouse): multi-warehouse routing per category prefix (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — v2.0: Multi-warehouse routing (#47)
+
+- New `markItDown.warehouse.routes` setting accepts an array of `{categoryPrefix, repo, branch?, subdir?}` rules; notes whose category matches a prefix sync to that route's repo, everything else falls through to the default `markItDown.warehouse.repo`
+- Pure router lives in `packages/core/src/warehouse-routing/`: builds resolved routes from rules, validates inputs (rejects empty / malformed / duplicate-prefix rules with reasons logged), inherits branch + subdir from the default config, sorts routes by descending prefix specificity so deeper rules win, exposes a per-route predicate
+- `WarehouseSync.pull` / `planPush` / `push` accept an optional `predicate` so each call only handles its route's notes; `planPush` flags remote notes whose category no longer matches the route as deletes (so re-categorising a note from one route to another is handled gracefully — added on the new repo, deleted from the old)
+- `WarehouseManager` iterates every enabled route per `syncNow` / `pullCommand` / `runAutoPush`, with separate first-push confirmation per repo (`firstPushFlagKey` already keys on repo so each new warehouse gets its own one-time dialog)
+- Status bar collapses to `<repo>@<branch>` for a single route, `N warehouses` for multiple
+- `Open on GitHub` shows a Quick Pick when more than one route is enabled
+- 10 new unit tests covering route parsing (no-rules, no-default, every rejection branch, branch/subdir inheritance + override) and routing semantics (prefix match, default exclusion, sibling non-bleed)
+
 ### Added — v2.0: Per-page slug overrides via frontmatter (#46)
 
 - Notes can declare a `slug:` in a YAML frontmatter block at the top of the body — published page goes to `notes/<slug>.html` instead of the default `notes/<slug-from-title>-<id>.html`

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,5 +34,6 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 | #44 — Note attachments (drag-drop + warehouse + publish) | shipped | [note-attachments.md](note-attachments.md) |
 | #45 — Nested category hierarchies | shipped | [nested-categories.md](nested-categories.md) |
 | #46 — Per-page slug overrides via frontmatter | shipped | [slug-overrides.md](slug-overrides.md) |
+| #47 — Multi-warehouse routing per category | shipped | [multi-warehouse-routing.md](multi-warehouse-routing.md) |
 
 Each feature gets its own page when it ships. New pages should follow the [notes-sidebar.md](notes-sidebar.md) shape: at-a-glance table, settings, workflows, edge cases, and a "what it unblocks" section.

--- a/docs/multi-warehouse-routing.md
+++ b/docs/multi-warehouse-routing.md
@@ -1,0 +1,127 @@
+# Multi-Warehouse Routing
+
+Send personal notes to one repo, team notes to another. The warehouse
+sync engine partitions notes by category prefix and ships each route to
+its own GitHub repo independently.
+
+## Configure
+
+Default warehouse stays in `markItDown.warehouse.repo` — that's the
+"catch-all" route. Routing rules live in
+`markItDown.warehouse.routes` as an array of objects:
+
+```jsonc
+"markItDown.warehouse.repo": "fadymondy/personal-notes",
+"markItDown.warehouse.routes": [
+  {
+    "categoryPrefix": "Work",
+    "repo": "acme/team-notes",
+    "branch": "main"
+  },
+  {
+    "categoryPrefix": "Engineering/Outages",
+    "repo": "acme/outage-postmortems",
+    "subdir": "writeups"
+  }
+]
+```
+
+With this config:
+
+| Note category | Goes to |
+| --- | --- |
+| `Work/Q1 Roadmap` | acme/team-notes |
+| `Engineering/Outages/2026-01-12` | acme/outage-postmortems |
+| `Personal/Finance` | fadymondy/personal-notes (default) |
+| `Drafts` | fadymondy/personal-notes (default) |
+
+## Matching rules
+
+* Match is **segment-aware** via the same helper used for nested
+  categories — `Reference` matches `Reference` and `Reference/Postgres`
+  but **not** `References/Foo`.
+* Among routes, **longer prefixes win** (so `Engineering/Outages` claims
+  notes ahead of a more general `Engineering` rule).
+* Notes that match no rule fall through to the default repo. If you
+  haven't set `markItDown.warehouse.repo`, those notes have no home and
+  won't sync — there's no implicit local-only fallback.
+* Empty / malformed rules are logged to the warehouse channel and
+  ignored: missing `repo`, missing `categoryPrefix`, repo not in
+  `owner/repo` form, or a duplicate `categoryPrefix`.
+
+## What happens during sync
+
+For each route (default + each rule), the manager runs an independent
+clone + pull + plan + push cycle. That means:
+
+* Each route gets its own `_index.json` listing only the notes that
+  belong to it.
+* Conflict resolution still applies per-route — the existing conflict
+  panel surfaces conflicts from any repo into one list keyed by note id.
+* The `firstPushFlagKey` is per-repo, so each new warehouse gets its own
+  one-time confirmation dialog before the first push.
+* Status bar shows `2 warehouses` (or similar) when more than one route
+  is operating; click to open the conflicts panel as before.
+
+### Moving a note between routes
+
+Re-categorising a note (`Work/Plan` → `Personal/Plan`) is handled
+gracefully:
+
+1. The new route's planPush sees the note as `added` → uploads it to its
+   new repo.
+2. The old route's planPush sees the note as **predicate-mismatched** in
+   its remote index → marks it as `deleted` → removes it from its old
+   repo.
+
+The two pushes happen in sequence; for a brief window the note exists in
+both repos. Pull on either side reconciles to the new home.
+
+## Auto-push + manual sync
+
+`markItDown.warehouse.autoPush` (debounce ms) applies to every route. A
+single note save in `Work/X` triggers a debounced push to that route only;
+the others sit idle.
+
+`Mark It Down: Warehouse Sync Now` walks every route in declared order
+(longest-prefix-first per `buildRoutes`).
+
+## Status bar
+
+* No routes enabled → "Notes warehouse off"
+* One route → `<repo>@<branch>`
+* Multiple routes → `<N> warehouses`
+* Conflict on any route → `N note(s) diverged. Click to resolve.`
+
+## Implementation map
+
+| File | Role |
+| --- | --- |
+| `packages/core/src/warehouse-routing/index.ts` | Pure rule parser + `buildRoutes` + `routeForCategory` |
+| `src/warehouse/warehouseConfig.ts` | `readRoutes()` returns the resolved route configs |
+| `src/warehouse/warehouseSync.ts` | `pull` / `planPush` / `push` accept an optional `predicate` so each call only handles its route's subset |
+| `src/warehouse/warehouseManager.ts` | Iterates routes per sync action; aggregates summaries |
+
+## Limitations
+
+- A note must belong to exactly one route — there's no fan-out (mirror
+  the same note to two repos).
+- Workspace-id remains shared across routes; if you need per-route
+  workspace ids, override per route via a `workspaceId` field — that's a
+  natural follow-up but not in this first cut.
+- Rule changes that orphan a note (delete the rule for `Work/`) leave
+  the note in the old repo — the next sync of the default route picks
+  it up locally and pushes it to the default repo, but the old repo
+  will still hold it. Manually delete the file (or wait for the next
+  re-route to delete it via predicate-mismatch).
+
+## Testing
+
+```bash
+npx vitest run tests/unit/warehouse-routing
+```
+
+10 tests cover route parsing (no-rules default-only, no-default
+empty-set, every rejection branch, branch/subdir inheritance vs
+override) and routing semantics (prefix match, default exclusion,
+sibling non-bleed).

--- a/package.json
+++ b/package.json
@@ -598,6 +598,33 @@
           "default": "",
           "markdownDescription": "Override the workspace folder name used as a subfolder in the warehouse. Leave empty to derive from the workspace name."
         },
+        "markItDown.warehouse.routes": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "object",
+            "required": ["categoryPrefix", "repo"],
+            "properties": {
+              "categoryPrefix": {
+                "type": "string",
+                "description": "Category path prefix this route claims (segment-aware, e.g. \"Personal\" matches \"Personal/Finance\" but not \"PersonalNotes\")."
+              },
+              "repo": {
+                "type": "string",
+                "description": "GitHub repo for this route in `owner/repo` form."
+              },
+              "branch": {
+                "type": "string",
+                "description": "Optional branch override (defaults to markItDown.warehouse.branch)."
+              },
+              "subdir": {
+                "type": "string",
+                "description": "Optional subdir override (defaults to markItDown.warehouse.subdir)."
+              }
+            }
+          },
+          "markdownDescription": "Multi-warehouse routing. Each rule sends notes whose category matches `categoryPrefix` to a different repo. Notes that match no rule fall through to the default `markItDown.warehouse.repo`. First match wins; longer prefixes are preferred. Invalid rules are logged + ignored. See [docs/multi-warehouse-routing.md](https://github.com/fadymondy/mark-it-down/blob/main/docs/multi-warehouse-routing.md)."
+        },
         "markItDown.publish.enabled": {
           "type": "boolean",
           "default": false,

--- a/packages/core/src/warehouse-routing/index.ts
+++ b/packages/core/src/warehouse-routing/index.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure routing logic for the multi-warehouse feature.
+ *
+ * Users can declare rules like:
+ *   { categoryPrefix: "Personal", repo: "fadymondy/private-notes" }
+ *   { categoryPrefix: "Work",     repo: "acme/team-notes",       branch: "main" }
+ *
+ * The first matching rule wins. Notes whose category matches no rule
+ * fall through to the default warehouse repo (configured at the
+ * top-level `markItDown.warehouse.repo` setting).
+ */
+
+import { categoryHasPrefix } from '../categories/path';
+
+export interface RouteRule {
+  /** Category path prefix the rule matches; segment-aware (Reference matches Reference + Reference/Postgres but NOT References/Foo). */
+  categoryPrefix: string;
+  /** GitHub repo in `owner/repo` form. Empty / missing repo disables the rule. */
+  repo: string;
+  /** Optional branch override; falls back to the default config's branch. */
+  branch?: string;
+  /** Optional subdir override; falls back to the default config's subdir. */
+  subdir?: string;
+}
+
+export interface RouteMatch {
+  /** Stable identifier for telemetry / logs. `default` for the fallback route. */
+  routeId: string;
+  /** Repo for the route (default route uses the top-level repo). */
+  repo: string;
+  /** Branch (overridden by rule.branch when present). */
+  branch: string;
+  /** Subdir (overridden by rule.subdir when present). */
+  subdir: string;
+  /** Predicate over a note's category — true when the note belongs to this route. */
+  match: (category: string) => boolean;
+  /** Source rule index (0-based) or -1 for the default fallback. */
+  ruleIndex: number;
+}
+
+export interface RouteResolution {
+  routes: RouteMatch[];
+  /** Indices in `rules` that were dropped (no repo, duplicate, or invalid). Useful for warnings. */
+  rejected: { index: number; reason: string }[];
+}
+
+export function buildRoutes(
+  rules: RouteRule[] | undefined,
+  fallback: { repo: string; branch: string; subdir: string },
+): RouteResolution {
+  const routes: RouteMatch[] = [];
+  const rejected: { index: number; reason: string }[] = [];
+  const claimedPrefixes = new Set<string>();
+  const cleanedRules = (rules ?? []).map((r, i) => ({ rule: r, index: i }));
+
+  for (const { rule, index } of cleanedRules) {
+    const categoryPrefix = (rule.categoryPrefix ?? '').trim().replace(/\/+$/, '');
+    const repo = (rule.repo ?? '').trim();
+    if (categoryPrefix.length === 0 || repo.length === 0) {
+      rejected.push({ index, reason: 'rule must have non-empty categoryPrefix and repo' });
+      continue;
+    }
+    if (!/^[^\s/]+\/[^\s/]+$/.test(repo)) {
+      rejected.push({ index, reason: `repo "${repo}" must be in owner/repo form` });
+      continue;
+    }
+    if (claimedPrefixes.has(categoryPrefix)) {
+      rejected.push({ index, reason: `duplicate categoryPrefix "${categoryPrefix}"` });
+      continue;
+    }
+    claimedPrefixes.add(categoryPrefix);
+    const branch = rule.branch?.trim() || fallback.branch;
+    const subdir = (rule.subdir?.trim() || fallback.subdir).replace(/^\/+|\/+$/g, '');
+    routes.push({
+      routeId: `rule:${index}:${categoryPrefix}`,
+      repo,
+      branch,
+      subdir,
+      ruleIndex: index,
+      match: cat => categoryHasPrefix(cat, categoryPrefix),
+    });
+  }
+
+  // Sort by descending prefix specificity so deeper rules win over shallower ones
+  // when both are declared (e.g. Personal/Finance beats Personal).
+  routes.sort((a, b) => b.routeId.length - a.routeId.length);
+
+  // Default fallback route — matches anything no other route claimed.
+  if (fallback.repo.trim().length > 0) {
+    routes.push({
+      routeId: 'default',
+      repo: fallback.repo.trim(),
+      branch: fallback.branch,
+      subdir: fallback.subdir,
+      ruleIndex: -1,
+      match: cat => !routes.some(r => r.routeId !== 'default' && r.match(cat)),
+    });
+  }
+
+  return { routes, rejected };
+}
+
+/**
+ * Resolve the single route a note belongs to. Returns undefined when no
+ * route matches (e.g. no rules + no default repo configured).
+ */
+export function routeForCategory(
+  routes: RouteMatch[],
+  category: string,
+): RouteMatch | undefined {
+  return routes.find(r => r.match(category));
+}

--- a/src/warehouse/warehouseConfig.ts
+++ b/src/warehouse/warehouseConfig.ts
@@ -1,4 +1,8 @@
 import * as vscode from 'vscode';
+import {
+  buildRoutes,
+} from '../../packages/core/src/warehouse-routing';
+import type { RouteRule } from '../../packages/core/src/warehouse-routing';
 
 export type WarehouseTransport = 'gh' | 'git';
 
@@ -11,6 +15,20 @@ export interface WarehouseConfig {
   autoPush: boolean;
   autoPushDebounceMs: number;
   workspaceId: string;
+}
+
+export interface RoutedWarehouseConfig extends WarehouseConfig {
+  routeId: string;
+  /** True when this is the catch-all default route (no rule matched). */
+  isDefault: boolean;
+  /** Predicate over a note's category — true when the note belongs to this route. */
+  matches(category: string): boolean;
+}
+
+export interface WarehouseRoutes {
+  primary: WarehouseConfig;
+  routed: RoutedWarehouseConfig[];
+  rejectedRules: { index: number; reason: string }[];
 }
 
 export const PERSONAL_WORKSPACE_ID = '_personal';
@@ -44,6 +62,36 @@ export function readConfig(): WarehouseConfig {
 export function isAffected(event: vscode.ConfigurationChangeEvent): boolean {
   return event.affectsConfiguration('markItDown.warehouse');
 }
+
+export function readRoutes(): WarehouseRoutes {
+  const primary = readConfig();
+  const cfg = vscode.workspace.getConfiguration('markItDown.warehouse');
+  const rawRules = cfg.get<RouteRule[]>('routes') ?? [];
+  const resolution = buildRoutes(rawRules, {
+    repo: primary.repo,
+    branch: primary.branch,
+    subdir: primary.subdir,
+  });
+  const routed: RoutedWarehouseConfig[] = resolution.routes.map(route => ({
+    ...primary,
+    repo: route.repo,
+    branch: route.branch,
+    subdir: route.subdir,
+    enabled: route.repo.length > 0,
+    routeId: route.routeId,
+    isDefault: route.routeId === 'default',
+    matches: (cat: string) => route.match(cat),
+  }));
+  return { primary, routed, rejectedRules: resolution.rejected };
+}
+
+export function routeForNoteCategory(
+  routes: RoutedWarehouseConfig[],
+  category: string,
+): RoutedWarehouseConfig | undefined {
+  return routes.find(r => r.matches(category));
+}
+
 
 export function repoSlug(config: WarehouseConfig): string {
   return config.repo.replace(/[^A-Za-z0-9._-]+/g, '--');

--- a/src/warehouse/warehouseManager.ts
+++ b/src/warehouse/warehouseManager.ts
@@ -1,6 +1,14 @@
 import * as vscode from 'vscode';
 import { NotesStore } from '../notes/notesStore';
-import { isAffected, readConfig, repoWebUrl, WarehouseConfig } from './warehouseConfig';
+import {
+  isAffected,
+  readConfig,
+  readRoutes,
+  repoWebUrl,
+  RoutedWarehouseConfig,
+  WarehouseConfig,
+  WarehouseRoutes,
+} from './warehouseConfig';
 import { log } from './warehouseLog';
 import { WarehouseStatusBar } from './warehouseStatusBar';
 import { PushPlan, SecretsDetectedError, SyncSummary, WarehouseSync } from './warehouseSync';
@@ -17,6 +25,7 @@ export class WarehouseManager implements vscode.Disposable {
   private readonly subs: vscode.Disposable[] = [];
   private autoPushTimer: NodeJS.Timeout | undefined;
   private currentConfig: WarehouseConfig;
+  private currentRoutes: WarehouseRoutes;
   private busy = false;
 
   constructor(
@@ -29,6 +38,8 @@ export class WarehouseManager implements vscode.Disposable {
     this.statusBar = new WarehouseStatusBar();
     this.conflictPanel = new ConflictPanel(context, this.conflicts, store);
     this.currentConfig = readConfig();
+    this.currentRoutes = readRoutes();
+    this.warnRejectedRules();
 
     this.subs.push(
       this.conflicts,
@@ -36,6 +47,8 @@ export class WarehouseManager implements vscode.Disposable {
       vscode.workspace.onDidChangeConfiguration(e => {
         if (isAffected(e)) {
           this.currentConfig = readConfig();
+          this.currentRoutes = readRoutes();
+          this.warnRejectedRules();
           this.refreshStatusBar();
         }
       }),
@@ -45,8 +58,18 @@ export class WarehouseManager implements vscode.Disposable {
     this.refreshStatusBar();
   }
 
+  private warnRejectedRules(): void {
+    for (const r of this.currentRoutes.rejectedRules) {
+      log('warn', `route rule [${r.index}] ignored: ${r.reason}`);
+    }
+  }
+
+  private routesToOperate(): RoutedWarehouseConfig[] {
+    return this.currentRoutes.routed.filter(r => r.enabled);
+  }
+
   public start(): void {
-    if (this.currentConfig.enabled) {
+    if (this.routesToOperate().length > 0) {
       void this.pull({ silent: true }).catch(err => log('error', 'startup pull failed', err));
     }
   }
@@ -54,27 +77,49 @@ export class WarehouseManager implements vscode.Disposable {
   public async syncNow(): Promise<void> {
     if (!this.requireConfigured()) return;
     await this.guard(async () => {
-      this.statusBar.set('syncing', 'Pulling…');
-      const pulled = await this.sync.pull(this.currentConfig);
-      this.statusBar.set('syncing', 'Building push plan…');
-      const plan = await this.sync.planPush(this.currentConfig);
-      const pushed = await this.runPush(plan);
-      this.report({ pulled, pushed, warnings: [] });
+      const aggregate = emptySummary();
+      for (const route of this.routesToOperate()) {
+        this.statusBar.set('syncing', `Pulling ${route.repo}…`);
+        const pulled = await this.sync.pull(route, { predicate: c => route.matches(c) });
+        this.statusBar.set('syncing', `Plan push ${route.repo}…`);
+        const plan = await this.sync.planPush(route, { predicate: c => route.matches(c) });
+        const pushed = await this.runPush(plan, route);
+        accumulateSummary(aggregate, { pulled, pushed, warnings: [] });
+      }
+      this.report(aggregate);
     });
   }
 
   public async pullCommand(): Promise<void> {
     if (!this.requireConfigured()) return;
     await this.guard(async () => {
-      this.statusBar.set('syncing', 'Pulling…');
-      const pulled = await this.sync.pull(this.currentConfig);
-      this.report({ pulled, pushed: { added: 0, updated: 0, deleted: 0 }, warnings: [] });
+      const aggregate = emptySummary();
+      for (const route of this.routesToOperate()) {
+        this.statusBar.set('syncing', `Pulling ${route.repo}…`);
+        const pulled = await this.sync.pull(route, { predicate: c => route.matches(c) });
+        accumulateSummary(aggregate, { pulled, pushed: { added: 0, updated: 0, deleted: 0 }, warnings: [] });
+      }
+      this.report(aggregate);
     });
   }
 
   public async openOnGitHub(): Promise<void> {
     if (!this.requireConfigured()) return;
-    await vscode.env.openExternal(vscode.Uri.parse(repoWebUrl(this.currentConfig)));
+    const operating = this.routesToOperate();
+    let target = operating[0];
+    if (operating.length > 1) {
+      const picked = await vscode.window.showQuickPick(
+        operating.map(r => ({
+          label: r.repo,
+          description: r.isDefault ? 'default route' : `route: ${r.routeId}`,
+          value: r,
+        })),
+        { placeHolder: 'Open which warehouse on GitHub?' },
+      );
+      if (!picked) return;
+      target = picked.value;
+    }
+    await vscode.env.openExternal(vscode.Uri.parse(repoWebUrl(target)));
   }
 
   public openLog(): void {
@@ -92,18 +137,22 @@ export class WarehouseManager implements vscode.Disposable {
 
   private async pull(opts: { silent: boolean }): Promise<void> {
     await this.guard(async () => {
-      this.statusBar.set('syncing', 'Pulling…');
-      const pulled = await this.sync.pull(this.currentConfig);
+      const aggregate = emptySummary();
+      for (const route of this.routesToOperate()) {
+        this.statusBar.set('syncing', `Pulling ${route.repo}…`);
+        const pulled = await this.sync.pull(route, { predicate: c => route.matches(c) });
+        accumulateSummary(aggregate, { pulled, pushed: { added: 0, updated: 0, deleted: 0 }, warnings: [] });
+      }
       if (!opts.silent) {
-        this.report({ pulled, pushed: { added: 0, updated: 0, deleted: 0 }, warnings: [] });
-      } else if (pulled.added + pulled.updated > 0) {
-        log('info', `startup pull imported ${pulled.added} new + ${pulled.updated} updated notes`);
+        this.report(aggregate);
+      } else if (aggregate.pulled.added + aggregate.pulled.updated > 0) {
+        log('info', `startup pull imported ${aggregate.pulled.added} new + ${aggregate.pulled.updated} updated notes across ${this.routesToOperate().length} route(s)`);
       }
     });
   }
 
   private maybeSchedulePush(): void {
-    if (!this.currentConfig.enabled || !this.currentConfig.autoPush) return;
+    if (this.routesToOperate().length === 0 || !this.currentConfig.autoPush) return;
     if (this.autoPushTimer) clearTimeout(this.autoPushTimer);
     this.autoPushTimer = setTimeout(() => {
       this.autoPushTimer = undefined;
@@ -117,40 +166,46 @@ export class WarehouseManager implements vscode.Disposable {
       return;
     }
     await this.guard(async () => {
-      this.statusBar.set('syncing', 'Auto-push…');
-      const plan = await this.sync.planPush(this.currentConfig);
-      if (!this.sync.hasPushWork(plan)) {
-        return;
+      for (const route of this.routesToOperate()) {
+        this.statusBar.set('syncing', `Auto-push ${route.repo}…`);
+        const plan = await this.sync.planPush(route, { predicate: c => route.matches(c) });
+        if (!this.sync.hasPushWork(plan)) continue;
+        await this.runPush(plan, route);
       }
-      await this.runPush(plan);
     });
   }
 
-  private async runPush(plan: PushPlan): Promise<SyncSummary['pushed']> {
+  private async runPush(
+    plan: PushPlan,
+    route: RoutedWarehouseConfig,
+  ): Promise<SyncSummary['pushed']> {
     if (!this.sync.hasPushWork(plan)) {
       return { added: 0, updated: 0, deleted: 0 };
     }
-    if (!this.sync.hasConfirmedFirstPush(this.currentConfig)) {
-      const ok = await confirmFirstPush(plan, this.currentConfig);
+    if (!this.sync.hasConfirmedFirstPush(route)) {
+      const ok = await confirmFirstPush(plan, route);
       if (!ok) {
-        log('info', 'first push cancelled by user');
+        log('info', `first push to ${route.repo} cancelled by user`);
         return { added: 0, updated: 0, deleted: 0 };
       }
-      await this.sync.markFirstPushConfirmed(this.currentConfig);
+      await this.sync.markFirstPushConfirmed(route);
     }
     try {
-      const result = await this.sync.push(this.currentConfig, plan);
+      const result = await this.sync.push(route, plan, { predicate: c => route.matches(c) });
       return result;
     } catch (err) {
       if (err instanceof SecretsDetectedError) {
         const choice = await vscode.window.showWarningMessage(
-          'Mark It Down: secrets detected in notes about to push. Review the log and decide.',
+          `Mark It Down: secrets detected in notes about to push to ${route.repo}. Review the log and decide.`,
           { modal: true, detail: err.message },
           'Push anyway',
           'Cancel',
         );
         if (choice === 'Push anyway') {
-          return await this.sync.push(this.currentConfig, plan, { allowSecrets: true });
+          return await this.sync.push(route, plan, {
+            allowSecrets: true,
+            predicate: c => route.matches(c),
+          });
         }
         return { added: 0, updated: 0, deleted: 0 };
       }
@@ -177,10 +232,10 @@ export class WarehouseManager implements vscode.Disposable {
   }
 
   private requireConfigured(): boolean {
-    if (this.currentConfig.enabled) return true;
+    if (this.routesToOperate().length > 0) return true;
     void vscode.window
       .showInformationMessage(
-        'Notes warehouse is not configured. Set markItDown.warehouse.repo (e.g. "you/your-notes") to enable cloud sync.',
+        'Notes warehouse is not configured. Set markItDown.warehouse.repo or define routes in markItDown.warehouse.routes to enable cloud sync.',
         'Open Settings',
       )
       .then(choice => {
@@ -192,7 +247,8 @@ export class WarehouseManager implements vscode.Disposable {
   }
 
   private refreshStatusBar(): void {
-    if (!this.currentConfig.enabled) {
+    const operating = this.routesToOperate();
+    if (operating.length === 0) {
       this.statusBar.set('disabled');
       return;
     }
@@ -200,7 +256,12 @@ export class WarehouseManager implements vscode.Disposable {
       this.statusBar.set('conflict', `${this.conflicts.count()} note(s) diverged. Click to resolve.`);
       return;
     }
-    this.statusBar.set('idle', `${this.currentConfig.repo}@${this.currentConfig.branch}`);
+    if (operating.length === 1) {
+      const r = operating[0];
+      this.statusBar.set('idle', `${r.repo}@${r.branch}`);
+    } else {
+      this.statusBar.set('idle', `${operating.length} warehouses`);
+    }
   }
 
   private report(summary: SyncSummary): void {
@@ -225,6 +286,25 @@ export class WarehouseManager implements vscode.Disposable {
       this.statusBar.set('conflict', `${pulled.conflicts} note(s) diverged. Local copies kept.`);
     }
   }
+}
+
+function emptySummary(): SyncSummary {
+  return {
+    pulled: { added: 0, updated: 0, conflicts: 0 },
+    pushed: { added: 0, updated: 0, deleted: 0 },
+    warnings: [],
+  };
+}
+
+function accumulateSummary(into: SyncSummary, next: SyncSummary): void {
+  into.pulled.added += next.pulled.added;
+  into.pulled.updated += next.pulled.updated;
+  into.pulled.conflicts += next.pulled.conflicts;
+  into.pushed.added += next.pushed.added;
+  into.pushed.updated += next.pushed.updated;
+  into.pushed.deleted += next.pushed.deleted;
+  if (next.pushed.commit && !into.pushed.commit) into.pushed.commit = next.pushed.commit;
+  into.warnings.push(...next.warnings);
 }
 
 async function confirmFirstPush(plan: PushPlan, config: WarehouseConfig): Promise<boolean> {

--- a/src/warehouse/warehouseSync.ts
+++ b/src/warehouse/warehouseSync.ts
@@ -50,7 +50,11 @@ export class WarehouseSync {
     private readonly conflicts: ConflictRegistry,
   ) {}
 
-  public async pull(config: WarehouseConfig): Promise<SyncSummary['pulled']> {
+  public async pull(
+    config: WarehouseConfig,
+    opts: { predicate?: (category: string) => boolean } = {},
+  ): Promise<SyncSummary['pulled']> {
+    const predicate = opts.predicate ?? (() => true);
     const clone = await this.transport.ensureClone(config);
     if (!clone.freshlyCloned) {
       await this.transport.pull(config, clone);
@@ -68,6 +72,7 @@ export class WarehouseSync {
       if (!remote) continue;
       const localById = new Map(this.store.listByScope(scope).map(n => [n.id, n]));
       for (const entry of remote.notes) {
+        if (!predicate(entry.category)) continue;
         const local = localById.get(entry.id);
         if (!local) {
           const content = await this.readRemoteContent(config, clone, scope, entry.filename);
@@ -116,7 +121,11 @@ export class WarehouseSync {
     return { added, updated, conflicts };
   }
 
-  public async planPush(config: WarehouseConfig): Promise<PushPlan> {
+  public async planPush(
+    config: WarehouseConfig,
+    opts: { predicate?: (category: string) => boolean } = {},
+  ): Promise<PushPlan> {
+    const predicate = opts.predicate ?? (() => true);
     const clone = await this.transport.ensureClone(config);
     const plan: PushPlan = { added: [], updated: [], deleted: [], files: [] };
     const scopes: NoteScope[] = this.store.hasWorkspaceStorage()
@@ -124,7 +133,7 @@ export class WarehouseSync {
       : ['global'];
 
     for (const scope of scopes) {
-      const local = this.store.listByScope(scope);
+      const local = this.store.listByScope(scope).filter(n => predicate(n.category));
       const remote = (await this.readRemoteIndex(config, clone, scope))?.notes ?? [];
       const remoteById = new Map(remote.map(e => [e.id, e]));
       const localById = new Map(local.map(n => [n.id, n]));
@@ -138,7 +147,9 @@ export class WarehouseSync {
         }
       }
       for (const r of remote) {
-        if (!localById.has(r.id)) {
+        // Note disappeared locally OR moved to a category that no longer
+        // belongs to this route → mark for deletion in this repo.
+        if (!localById.has(r.id) || !predicate(r.category)) {
           plan.deleted.push(r);
         }
       }
@@ -169,8 +180,9 @@ export class WarehouseSync {
   public async push(
     config: WarehouseConfig,
     plan: PushPlan,
-    opts: { allowSecrets?: boolean } = {},
+    opts: { allowSecrets?: boolean; predicate?: (category: string) => boolean } = {},
   ): Promise<SyncSummary['pushed']> {
+    const predicate = opts.predicate ?? (() => true);
     const clone = await this.transport.ensureClone(config);
 
     if (!opts.allowSecrets) {
@@ -186,7 +198,7 @@ export class WarehouseSync {
       : ['global'];
 
     for (const scope of scopes) {
-      await this.materializeScope(config, clone, scope);
+      await this.materializeScope(config, clone, scope, predicate);
     }
     for (const entry of plan.deleted) {
       const abs = path.join(clone.root, scopeDir(config, entry.scope), entry.filename);
@@ -233,10 +245,11 @@ export class WarehouseSync {
     config: WarehouseConfig,
     clone: WarehouseClone,
     scope: NoteScope,
+    predicate: (category: string) => boolean = () => true,
   ): Promise<void> {
     const dir = path.join(clone.root, scopeDir(config, scope));
     await vscode.workspace.fs.createDirectory(vscode.Uri.file(dir));
-    const notes = this.store.listByScope(scope);
+    const notes = this.store.listByScope(scope).filter(n => predicate(n.category));
     const attachmentsByNote = new Map<string, string[]>();
     for (const note of notes) {
       const content = await this.store.readContent(note);

--- a/tests/unit/warehouse-routing/router.test.ts
+++ b/tests/unit/warehouse-routing/router.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildRoutes,
+  routeForCategory,
+} from '../../../packages/core/src/warehouse-routing';
+
+const FALLBACK = { repo: 'me/personal', branch: 'main', subdir: 'notes' };
+
+describe('buildRoutes', () => {
+  it('returns just the default route when no rules', () => {
+    const r = buildRoutes([], FALLBACK);
+    expect(r.routes).toHaveLength(1);
+    expect(r.routes[0].routeId).toBe('default');
+    expect(r.routes[0].repo).toBe('me/personal');
+  });
+
+  it('returns no routes when fallback repo is empty + no rules', () => {
+    const r = buildRoutes([], { ...FALLBACK, repo: '' });
+    expect(r.routes).toHaveLength(0);
+  });
+
+  it('rejects rules with empty categoryPrefix or repo', () => {
+    const r = buildRoutes(
+      [
+        { categoryPrefix: '', repo: 'a/b' },
+        { categoryPrefix: 'Foo', repo: '' },
+      ],
+      FALLBACK,
+    );
+    expect(r.rejected.map(x => x.index)).toEqual([0, 1]);
+    expect(r.routes.map(x => x.routeId)).toEqual(['default']);
+  });
+
+  it('rejects rules with malformed repo', () => {
+    const r = buildRoutes([{ categoryPrefix: 'Foo', repo: 'just-a-name' }], FALLBACK);
+    expect(r.rejected[0].reason).toMatch(/owner\/repo/);
+  });
+
+  it('rejects duplicate categoryPrefix', () => {
+    const r = buildRoutes(
+      [
+        { categoryPrefix: 'Foo', repo: 'a/b' },
+        { categoryPrefix: 'Foo', repo: 'c/d' },
+      ],
+      FALLBACK,
+    );
+    expect(r.rejected[0].reason).toMatch(/duplicate/);
+  });
+
+  it('inherits fallback branch / subdir when rule omits them', () => {
+    const r = buildRoutes([{ categoryPrefix: 'Work', repo: 'acme/team' }], FALLBACK);
+    const work = r.routes.find(x => x.routeId.startsWith('rule:'));
+    expect(work?.branch).toBe('main');
+    expect(work?.subdir).toBe('notes');
+  });
+
+  it('honours rule branch + subdir overrides', () => {
+    const r = buildRoutes(
+      [{ categoryPrefix: 'Work', repo: 'acme/team', branch: 'develop', subdir: 'docs' }],
+      FALLBACK,
+    );
+    const work = r.routes.find(x => x.routeId.startsWith('rule:'));
+    expect(work?.branch).toBe('develop');
+    expect(work?.subdir).toBe('docs');
+  });
+
+  it('routes notes via categoryPrefix match', () => {
+    const r = buildRoutes(
+      [
+        { categoryPrefix: 'Personal', repo: 'me/private' },
+        { categoryPrefix: 'Work', repo: 'acme/team' },
+      ],
+      FALLBACK,
+    );
+    expect(routeForCategory(r.routes, 'Personal/Finance')?.repo).toBe('me/private');
+    expect(routeForCategory(r.routes, 'Work/Outage')?.repo).toBe('acme/team');
+    expect(routeForCategory(r.routes, 'Drafts')?.repo).toBe('me/personal');
+  });
+
+  it('default route excludes notes claimed by any rule', () => {
+    const r = buildRoutes(
+      [{ categoryPrefix: 'Personal', repo: 'me/private' }],
+      FALLBACK,
+    );
+    const def = r.routes.find(x => x.routeId === 'default');
+    expect(def?.match('Personal/X')).toBe(false);
+    expect(def?.match('OtherCategory')).toBe(true);
+  });
+
+  it('does not bleed siblings into a prefix match', () => {
+    const r = buildRoutes(
+      [{ categoryPrefix: 'Reference', repo: 'me/refs' }],
+      FALLBACK,
+    );
+    expect(routeForCategory(r.routes, 'References/Foo')?.repo).toBe('me/personal');
+    expect(routeForCategory(r.routes, 'Reference/Postgres')?.repo).toBe('me/refs');
+  });
+});


### PR DESCRIPTION
Closes #47

## Summary

- New `markItDown.warehouse.routes` setting accepts `[{categoryPrefix, repo, branch?, subdir?}]`
- Pure router in `packages/core/src/warehouse-routing/` with first-match-wins + segment-aware prefix matching
- `WarehouseSync` accepts an optional predicate so each call only handles its route's notes
- Re-categorisation between routes deletes from the old repo + adds to the new

## Test plan

- [x] `npx vitest run` — 166/166 (10 new router tests)
- [x] `tsc -p ./` — clean
- [x] Manual: configured one rule + default, observed two repos receiving distinct subsets

## Docs

- `docs/multi-warehouse-routing.md` (new) + `docs/README.md` v2.0 row + `CHANGELOG.md` entry + `package.json` rule-schema markdownDescription