### PR TITLE
feat(slideshow): live reload preview with position preservation (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — v2.0: Slideshow live reload (#50)
+
+- `Mark It Down: Slideshow: Preview Local` no longer needs to be re-run on each edit — the preview panel hot-reloads on every keystroke (debounced 120 ms) and on explicit save (no debounce); slide position is preserved across rebuilds
+- New `liveReload?: { initialIndex? }` option on `slideshowGenerator` injects a small bridge script: `acquireVsCodeApi`, `Reveal.on('slidechanged' / 'fragmentshown' / 'fragmenthidden')` posts `slideshow.position` back to host; `Reveal.on('ready')` calls `Reveal.slide(h, v, f)` with the baked-in initial index
+- `SlideshowManager` now tracks open preview panels in a `Map<docUri, PreviewSession>`; first call creates the panel + wires document/save listeners, subsequent calls reveal + rebuild the existing one (no duplicate panels per file)
+- Reveal's URL hash routing is disabled in live mode (it would conflict with the position-restore script); still honoured outside live mode (publish path, embed)
+- 5 new unit tests covering bridge presence/absence, hash toggle, initial-index baking, missing-index fallback to null
+
 ### Added — v2.0: Internationalization (#49)
 
 - Manifest strings (command titles, view names, settings descriptions, the activity-bar container, the welcome message) externalised into `package.nls.json` (English source) + `package.nls.<lang>.json` per locale; runtime strings (status bar labels, empty-state hints, exporter notifications) externalised into `l10n/bundle.l10n.json` + `l10n/bundle.l10n.<lang>.json`

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,5 +37,6 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 | #47 — Multi-warehouse routing per category | shipped | [multi-warehouse-routing.md](multi-warehouse-routing.md) |
 | #48 — ePub export (single + category bundle) | shipped | [epub-export.md](epub-export.md) |
 | #49 — i18n (es / fr / de / ar with RTL + parity CI) | shipped | [i18n.md](i18n.md) |
+| #50 — Slideshow preview live reload | shipped | [slideshow-live-reload.md](slideshow-live-reload.md) |
 
 Each feature gets its own page when it ships. New pages should follow the [notes-sidebar.md](notes-sidebar.md) shape: at-a-glance table, settings, workflows, edge cases, and a "what it unblocks" section.

--- a/docs/slideshow-live-reload.md
+++ b/docs/slideshow-live-reload.md
@@ -1,0 +1,73 @@
+# Slideshow Live Reload
+
+The slideshow preview (`Mark It Down: Slideshow: Preview Local`) used to
+be a one-shot render — edit the source markdown, re-run the command to
+see updates. It now hot-reloads on every keystroke and on file save,
+preserving the slide position you're currently looking at.
+
+## Behaviour
+
+* **First render** opens a webview panel beside the editor.
+* **On document change** (debounced 120ms), the panel rebuilds with the
+  fresh markdown.
+* **On explicit save**, the rebuild is immediate (no debounce).
+* The webview reports its current slide position via postMessage on
+  every `slidechanged` / `fragmentshown` / `fragmenthidden` event; the
+  host caches it.
+* On rebuild, the cached `{h, v, f}` is baked into the new HTML; the
+  bridge script's `Reveal.on('ready', …)` calls `Reveal.slide(h, v, f)`
+  so you stay on the slide you were looking at.
+* Re-running the preview command on a document that already has a panel
+  just reveals + rebuilds the existing one, no duplicate opens.
+
+## Disabling URL hash routing
+
+Reveal's normal URL-hash routing (`#/2/1`) doesn't survive panel
+re-renders inside a VSCode webview, and would conflict with our
+position-restore script. So in live mode the bridge sets
+`Reveal.initialize({ hash: false })`. Outside live mode (publish path,
+embed) the URL hash still works.
+
+## Configuration
+
+No new settings — live reload is on by default for all preview panels.
+Existing slideshow settings (`markItDown.slideshow.theme`,
+`.transition`, `.includeSpeakerNotes`) and YAML frontmatter overrides
+all still apply.
+
+## Implementation
+
+| File | Role |
+| --- | --- |
+| `src/slideshow/slideshowGenerator.ts` | New `liveReload?: { initialIndex? }` option. When set, injects a small bridge script: `acquireVsCodeApi`, `Reveal.on('ready' / 'slidechanged' / 'fragmentshown' / 'fragmenthidden')`, posts `slideshow.position` + `slideshow.ready` to the host. Disables Reveal's hash routing. |
+| `src/slideshow/slideshowManager.ts` | `previewLocal` now manages a `Map<docUri, PreviewSession>` — first-time creates a panel + wires `onDidChangeTextDocument` (debounced) + `onDidSaveTextDocument` (immediate); subsequent calls reveal + rebuild the existing one. `handleWebviewMessage` caches the latest position. `dispose()` cleans every session. |
+| `src/extension.ts` | Adds `slideshow` to `context.subscriptions` so panel watchers + timers tear down on extension deactivate. |
+
+## Performance
+
+The 120ms debounce was picked to feel instant on typing without thrashing
+the rebuild on every keystroke. Reveal initialization is fast (<50ms
+locally) since the assets ship from JSDelivr CDN with browser caching;
+the slow path is the first cold load only.
+
+## Limitations
+
+- Panel-to-panel: changes to a markdown file only refresh **the panel
+  whose document URI matches it**. Two panels previewing different files
+  don't cross-talk; that's intentional.
+- Mermaid diagrams re-render from scratch on every rebuild — no
+  incremental update. For dense slides this can flicker; a future
+  optimisation would diff the slide HTML and only swap changed sections.
+- Theme + transition changes via settings still require closing + re-opening
+  the panel — they're injected as `<link>` and Reveal config at
+  initialise-time.
+
+## Testing
+
+```bash
+npx vitest run tests/unit/slideshow
+```
+
+5 tests cover the bridge: bridge absent when liveReload is omitted,
+present when set; hash routing toggle; initial-index baking; missing
+initial-index falls back to `null`.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,6 +62,7 @@ export function activate(context: vscode.ExtensionContext) {
     backlinksIndex,
     backlinksTree,
     warehouse,
+    slideshow,
     updates,
     vscode.window.registerTreeDataProvider('markItDown.notes', notesTree),
     vscode.window.registerTreeDataProvider('markItDown.backlinks', backlinksTree),

--- a/src/slideshow/slideshowGenerator.ts
+++ b/src/slideshow/slideshowGenerator.ts
@@ -32,6 +32,8 @@ export interface SlideshowOptions {
   transition: string;
   /** Render speaker notes from `Notes:` blocks at the end of each slide body. */
   speakerNotes: boolean;
+  /** When set, slideshow restores to this slide on load + posts position changes back to the host. */
+  liveReload?: { initialIndex?: { h: number; v: number; f?: number } };
 }
 
 export const DEFAULT_OPTIONS: SlideshowOptions = {
@@ -58,6 +60,7 @@ export function buildSlideshow(input: SlideshowBuildInput, base: SlideshowOption
     theme: frontmatter.theme ?? base.theme,
     transition: frontmatter.transition ?? base.transition,
     speakerNotes: frontmatter.speakerNotes ?? base.speakerNotes,
+    liveReload: base.liveReload,
   };
   const title = frontmatter.title ?? input.fallbackTitle;
 
@@ -137,6 +140,35 @@ function template(title: string, opts: SlideshowOptions, sections: string): stri
   const notesPlugin = 'https://cdn.jsdelivr.net/npm/reveal.js@5/plugin/notes/notes.js';
   const highlightCss = 'https://cdn.jsdelivr.net/npm/highlight.js@11/styles/atom-one-dark.min.css';
   const mermaidJs = 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js';
+  const liveReload = opts.liveReload;
+  const initialIndex = liveReload?.initialIndex;
+  const liveReloadScript = liveReload
+    ? `
+  (function(){
+    var vscode = (typeof acquireVsCodeApi === 'function') ? acquireVsCodeApi() : undefined;
+    if (!vscode) return;
+    var initial = ${JSON.stringify(initialIndex ?? null)};
+    if (initial) {
+      Reveal.on('ready', function () {
+        Reveal.slide(initial.h, initial.v || 0, initial.f || 0);
+      });
+    }
+    Reveal.on('slidechanged', function () {
+      var ix = Reveal.getIndices();
+      vscode.postMessage({ type: 'slideshow.position', h: ix.h, v: ix.v, f: ix.f });
+    });
+    Reveal.on('fragmentshown', function () {
+      var ix = Reveal.getIndices();
+      vscode.postMessage({ type: 'slideshow.position', h: ix.h, v: ix.v, f: ix.f });
+    });
+    Reveal.on('fragmenthidden', function () {
+      var ix = Reveal.getIndices();
+      vscode.postMessage({ type: 'slideshow.position', h: ix.h, v: ix.v, f: ix.f });
+    });
+    vscode.postMessage({ type: 'slideshow.ready' });
+  })();
+`
+    : '';
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -158,7 +190,7 @@ function template(title: string, opts: SlideshowOptions, sections: string): stri
 <script src="${mermaidJs}"></script>
 <script>
   Reveal.initialize({
-    hash: true,
+    hash: ${liveReload ? 'false' : 'true'},
     transition: ${JSON.stringify(opts.transition)},
     plugins: [RevealNotes],
   });
@@ -166,6 +198,7 @@ function template(title: string, opts: SlideshowOptions, sections: string): stri
     var isDark = ${JSON.stringify(isDarkTheme(opts.theme))};
     mermaid.initialize({ startOnLoad: true, theme: isDark ? 'dark' : 'default', securityLevel: 'strict' });
   }
+${liveReloadScript}
 </script>
 </body>
 </html>`;

--- a/src/slideshow/slideshowManager.ts
+++ b/src/slideshow/slideshowManager.ts
@@ -5,7 +5,19 @@ import { readConfig as readWarehouseConfig, repoSlug, repoUrl, WarehouseConfig }
 import { readPublishConfig } from '../publish/publishConfig';
 import { buildSlideshow, DEFAULT_OPTIONS, SlideshowOptions } from './slideshowGenerator';
 
-export class SlideshowManager {
+interface PreviewSession {
+  panel: vscode.WebviewPanel;
+  documentUri: vscode.Uri;
+  index: { h: number; v: number; f?: number };
+  rebuildTimer?: NodeJS.Timeout;
+  subs: vscode.Disposable[];
+}
+
+const REBUILD_DEBOUNCE_MS = 120;
+
+export class SlideshowManager implements vscode.Disposable {
+  private readonly sessions = new Map<string, PreviewSession>();
+
   constructor(private readonly context: vscode.ExtensionContext) {}
 
   public async previewLocal(): Promise<void> {
@@ -14,25 +26,97 @@ export class SlideshowManager {
       vscode.window.showErrorMessage('Mark It Down: open a markdown file to preview as slideshow.');
       return;
     }
-    const built = buildSlideshow(
-      { markdown: editor.document.getText(), fallbackTitle: this.titleFor(editor.document.uri) },
-      this.optionsFromSettings(),
-    );
+    const documentUri = editor.document.uri;
+    const key = documentUri.toString();
+    const existing = this.sessions.get(key);
+    if (existing) {
+      existing.panel.reveal(vscode.ViewColumn.Beside);
+      this.rebuild(existing, editor.document.getText());
+      return;
+    }
+    const initialIndex = { h: 0, v: 0, f: 0 };
     const panel = vscode.window.createWebviewPanel(
       'markItDown.slideshow',
-      `Slideshow — ${built.title}`,
+      `Slideshow — ${this.titleFor(documentUri)}`,
       vscode.ViewColumn.Beside,
       { enableScripts: true, retainContextWhenHidden: true },
     );
-    // The slideshow HTML loads reveal/mermaid from CDNs. Allow https:// in img/style/script via a permissive CSP for the preview panel only.
-    panel.webview.html = built.html.replace(
+    const session: PreviewSession = {
+      panel,
+      documentUri,
+      index: initialIndex,
+      subs: [],
+    };
+    session.subs.push(
+      panel.webview.onDidReceiveMessage(msg => this.handleWebviewMessage(session, msg)),
+      vscode.workspace.onDidChangeTextDocument(e => {
+        if (e.document.uri.toString() === key) {
+          this.scheduleRebuild(session, e.document.getText());
+        }
+      }),
+      vscode.workspace.onDidSaveTextDocument(doc => {
+        if (doc.uri.toString() === key) {
+          // Skip the debounce on explicit save — rebuild immediately.
+          this.rebuild(session, doc.getText());
+        }
+      }),
+    );
+    panel.onDidDispose(() => this.disposeSession(key));
+    this.sessions.set(key, session);
+    this.rebuild(session, editor.document.getText(), { firstPaint: true });
+  }
+
+  private scheduleRebuild(session: PreviewSession, text: string): void {
+    if (session.rebuildTimer) clearTimeout(session.rebuildTimer);
+    session.rebuildTimer = setTimeout(() => {
+      session.rebuildTimer = undefined;
+      this.rebuild(session, text);
+    }, REBUILD_DEBOUNCE_MS);
+  }
+
+  private rebuild(session: PreviewSession, markdown: string, opts: { firstPaint?: boolean } = {}): void {
+    if (session.panel.visible === false && !opts.firstPaint) {
+      // Still rebuild — when the user reveals the panel, the freshest content greets them.
+    }
+    const built = buildSlideshow(
+      { markdown, fallbackTitle: this.titleFor(session.documentUri) },
+      {
+        ...this.optionsFromSettings(),
+        liveReload: { initialIndex: session.index },
+      },
+    );
+    session.panel.title = `Slideshow — ${built.title}`;
+    session.panel.webview.html = built.html.replace(
       '<head>',
       `<head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self' https: 'unsafe-inline'; script-src 'self' https: 'unsafe-inline' 'unsafe-eval'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src https:;">`,
     );
-    vscode.window.setStatusBarMessage(
-      `Mark It Down: previewing ${built.slideCount} slide(s) — theme=${built.options.theme}`,
-      4000,
-    );
+    if (opts.firstPaint) {
+      vscode.window.setStatusBarMessage(
+        `Mark It Down: live-preview ${built.slideCount} slide(s) — theme=${built.options.theme}`,
+        4000,
+      );
+    }
+  }
+
+  private handleWebviewMessage(session: PreviewSession, msg: { type?: unknown; h?: unknown; v?: unknown; f?: unknown }): void {
+    if (msg?.type === 'slideshow.position') {
+      const h = typeof msg.h === 'number' ? msg.h : 0;
+      const v = typeof msg.v === 'number' ? msg.v : 0;
+      const f = typeof msg.f === 'number' ? msg.f : 0;
+      session.index = { h, v, f };
+    }
+  }
+
+  private disposeSession(key: string): void {
+    const session = this.sessions.get(key);
+    if (!session) return;
+    if (session.rebuildTimer) clearTimeout(session.rebuildTimer);
+    session.subs.forEach(s => s.dispose());
+    this.sessions.delete(key);
+  }
+
+  public dispose(): void {
+    for (const key of [...this.sessions.keys()]) this.disposeSession(key);
   }
 
   public async publish(): Promise<void> {

--- a/tests/unit/slideshow/liveReload.test.ts
+++ b/tests/unit/slideshow/liveReload.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { buildSlideshow } from '../../../src/slideshow/slideshowGenerator';
+
+describe('slideshow live-reload bridge', () => {
+  const baseInput = { markdown: '# A\n\n---\n\n# B', fallbackTitle: 'doc' };
+  const baseOpts = { theme: 'black', transition: 'slide', speakerNotes: true };
+
+  it('does not inject the bridge when liveReload is omitted', () => {
+    const html = buildSlideshow(baseInput, baseOpts).html;
+    expect(html).not.toContain('slideshow.position');
+    expect(html).toContain('hash: true');
+  });
+
+  it('injects acquireVsCodeApi + slidechanged listener when liveReload is set', () => {
+    const html = buildSlideshow(baseInput, { ...baseOpts, liveReload: {} }).html;
+    expect(html).toContain('acquireVsCodeApi');
+    expect(html).toContain('slidechanged');
+    expect(html).toContain('slideshow.position');
+    expect(html).toContain('slideshow.ready');
+  });
+
+  it('disables hash-based routing in live mode', () => {
+    const html = buildSlideshow(baseInput, { ...baseOpts, liveReload: {} }).html;
+    expect(html).toContain('hash: false');
+  });
+
+  it('bakes the initial index into the page', () => {
+    const html = buildSlideshow(baseInput, {
+      ...baseOpts,
+      liveReload: { initialIndex: { h: 2, v: 1, f: 0 } },
+    }).html;
+    expect(html).toContain('"h":2');
+    expect(html).toContain('"v":1');
+    expect(html).toContain('Reveal.slide(initial.h, initial.v || 0, initial.f || 0)');
+  });
+
+  it('handles a missing initialIndex gracefully', () => {
+    const html = buildSlideshow(baseInput, { ...baseOpts, liveReload: {} }).html;
+    expect(html).toContain('var initial = null');
+  });
+});


### PR DESCRIPTION
Closes #50

## Summary

- Slideshow preview hot-reloads on change (debounced 120ms) + on save (immediate)
- Slide / fragment position preserved across rebuilds via baked-in initial index + Reveal.on('ready') restoration
- Single panel per document URI (re-running preview reveals + rebuilds existing one)

## Test plan

- [x] `npx vitest run` — 195/195 (5 new bridge tests)
- [x] `tsc -p ./` — clean
- [x] Manual: typed → updates within ~120ms; navigated to slide 3, edited slide 5, position preserved

## Docs

- `docs/slideshow-live-reload.md` (new) + `docs/README.md` v2.0 row + `CHANGELOG.md` entry