### PR TITLE
feat(themes): per-token highlight.js mapping for the 25 themes (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+### Added — v2.0: Per-token highlight.js theme mapping (#51)
+
+- All 25 bundled themes now ship with a coherent code-highlight palette tuned against their chrome (keyword, built-in, string, number, comment, fn, type, variable, operator, params, meta, regex, title, tag, attribute)
+- New `packages/core/src/themes/hljsCss.ts`: pure helpers `deriveHljsTokens` (algorithmic mapping from chrome palette → token colours), `hljsTokensFor` (curated overrides + derived fallback), `hljsCssFor` (emits the CSS rules)
+- Curated palettes for the marquee themes: github-light/dark, dracula, one-dark/light, monokai, solarized-light/dark, tokyo-night, nord, gruvbox-light/dark, rose-pine, cobalt2 — using each ecosystem's canonical token colours
+- Algorithmic mapping for the rest (Ayu, Material, Night Owl, Oceanic Next, Snazzy, Palenight, Tokyo Night Light, Nord Light) — derived from the theme's own link / accent / fgMuted so the highlight palette never fights the chrome
+- Webview pipeline (`webviewBuilder.ts`) emits the per-theme hljs CSS right after the existing `:root[data-theme=…]` chrome override
+- Published static site (`buildSiteAssets`) appends the same per-theme rules after the bundled hljs base stylesheet so deployed sites match local rendering
+- Updated `docs/themes.md` with a new "Per-token highlight.js palette (#51)" section explaining derivation, curation, where it lands, and what's still up for grabs
+- 9 new unit tests across `deriveHljsTokens` (link → keyword, accent → built-in, fgMuted → comment), `hljsTokensFor` (curated overrides for github-light + dracula, derived fallback), `hljsCssFor` (every standard hljs class present, .hljs base color uses fg, every bundled theme emits valid CSS), and parity (every theme resolves to a fully-populated HljsTokens object)
+
 ### Added — v2.0: Slideshow live reload (#50)
 
 - `Mark It Down: Slideshow: Preview Local` no longer needs to be re-run on each edit — the preview panel hot-reloads on every keystroke (debounced 120 ms) and on explicit save (no debounce); slide position is preserved across rebuilds

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,5 +38,6 @@ Per-feature documentation for the v1.0 roadmap. Each page covers what the featur
 | #48 — ePub export (single + category bundle) | shipped | [epub-export.md](epub-export.md) |
 | #49 — i18n (es / fr / de / ar with RTL + parity CI) | shipped | [i18n.md](i18n.md) |
 | #50 — Slideshow preview live reload | shipped | [slideshow-live-reload.md](slideshow-live-reload.md) |
+| #51 — Per-token highlight.js theme mapping for the 25 themes | shipped | [themes.md](themes.md#per-token-highlightjs-palette-51) |
 
 Each feature gets its own page when it ships. New pages should follow the [notes-sidebar.md](notes-sidebar.md) shape: at-a-glance table, settings, workflows, edge cases, and a "what it unblocks" section.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -116,7 +116,48 @@ When `auto` is selected, mermaid follows the VSCode color theme directly via the
 - **Theme switch resets cursor**: changing the theme reloads the webview HTML, which destroys the CodeMirror EditorView. Cursor and selection in Edit mode are reset to position 0. Future work: live-swap CSS variables without rebuilding the HTML.
 - **High-contrast themes**: not yet bundled — VSCode's high-contrast modes are followed in `auto`. Adding `hc-light` / `hc-dark` palettes is a future addition.
 - **Mermaid in light themes**: mermaid's `default` theme looks fine on most light backgrounds; if a specific light bundled theme has poor contrast with mermaid edges, it's tracked as polish (not a blocker).
-- **Theme syntax-highlighting tokens**: the bundled themes only define the renderer palette, not highlight.js token colors. highlight.js uses its own dark/light common stylesheet; per-theme highlight tokens are a future addition.
+- **Theme syntax-highlighting tokens**: as of #51, every theme also gets a per-token highlight.js palette. See the section below for how it's wired.
+
+## Per-token highlight.js palette (#51)
+
+Every bundled theme gets a coherent code-highlight palette tuned against
+its chrome — keywords, strings, comments, types, fn names, regex, etc.
+all match the surrounding theme rather than sitting on top of a generic
+`atom-one-dark` base.
+
+### How it's derived
+
+- Default mapping from `packages/core/src/themes/hljsCss.ts`:
+  `keyword → palette.link`, `built-in → palette.accent`,
+  `comment → palette.fgMuted`, `fn → palette.link`,
+  `string → palette.linkHover`, `variable → palette.fg`, etc.
+- Curated overrides per theme — github-light/dark, dracula, one-dark/light,
+  monokai, solarized-light/dark, tokyo-night, nord, gruvbox-light/dark,
+  rose-pine, cobalt2 — use the well-known community palettes for those
+  ecosystems instead of the derived defaults.
+- All 25 themes resolve to a fully-populated `HljsTokens` object via
+  `hljsTokensFor(theme)`; `hljsCssFor(theme)` emits the matching CSS.
+
+### Where it lands
+
+- **Webview**: `webviewBuilder.ts` emits the per-theme block right after
+  the existing chrome `:root[data-theme=…]` override. Marked still
+  produces `<span class="hljs-keyword">` etc.; our CSS overrides paint
+  them.
+- **Published site**: `buildSiteAssets(palette, kindIsDark, theme)`
+  appends the same per-theme rules after the bundled hljs base
+  stylesheet, so deployed sites match local rendering.
+
+### Tradeoffs
+
+- 25 themes ship hand-tuned for the marquee ones + algorithmic for the
+  rest. The algorithmic mapping is correct but conservative — PRs to
+  curate Ayu, Material, Night Owl, Oceanic Next, Snazzy, Palenight,
+  Tokyo Night Light, Nord Light against their canonical token palettes
+  are welcome.
+- The bundled hljs stylesheet (`atom-one-dark` for dark-kind, `github`
+  for light-kind) still loads as a base; our per-theme rules override
+  it. This costs ~2KB extra CSS but keeps the load path simple.
 
 ## Why not `@orchestra-mcp/theme`?
 

--- a/packages/core/src/themes/hljsCss.ts
+++ b/packages/core/src/themes/hljsCss.ts
@@ -1,0 +1,349 @@
+/**
+ * Per-theme highlight.js token colour mapping.
+ *
+ * Each of the 25 bundled themes gets a coherent code-highlight palette
+ * tuned against its chrome. We derive the colours from the existing
+ * palette by default (link → keyword, accent → string, fgMuted → comment,
+ * etc.) and let curated themes override individual buckets.
+ */
+
+import { ThemeDefinition, ThemePalette } from './themes';
+
+export interface HljsTokens {
+  /** keywords (`if`, `return`, `class`, `def`) */
+  keyword: string;
+  /** built-ins (`console`, `len`, `True`) */
+  builtIn: string;
+  /** strings ("hello", template literals) */
+  string: string;
+  /** numeric literals */
+  number: string;
+  /** comments — usually muted */
+  comment: string;
+  /** function / method names at definition + call sites */
+  fn: string;
+  /** types / classes (capitalised tokens, type annotations) */
+  type: string;
+  /** identifiers and properties */
+  variable: string;
+  /** operators, punctuation */
+  operator: string;
+  /** params inside function signatures */
+  params: string;
+  /** preprocessor / meta directives (#include, @decorator) */
+  meta: string;
+  /** regex literals */
+  regex: string;
+  /** color marker for `<title>` and `<doctag>` */
+  title: string;
+  /** color marker for `<tag>` (HTML elements) + `<name>` */
+  tag: string;
+  /** color marker for `<attribute>` */
+  attribute: string;
+}
+
+/**
+ * Map a chrome palette into a code-highlight palette using sensible
+ * defaults that stay readable against the background. Themes that need
+ * sharper choices override individual buckets via THEME_HLJS below.
+ */
+export function deriveHljsTokens(palette: ThemePalette): HljsTokens {
+  return {
+    keyword: palette.link,
+    builtIn: palette.accent,
+    string: palette.linkHover,
+    number: palette.accent,
+    comment: palette.fgMuted,
+    fn: palette.link,
+    type: palette.accent,
+    variable: palette.fg,
+    operator: palette.fgMuted,
+    params: palette.fg,
+    meta: palette.linkHover,
+    regex: palette.accent,
+    title: palette.link,
+    tag: palette.link,
+    attribute: palette.accent,
+  };
+}
+
+/**
+ * Curated overrides for themes whose community-known token palette would
+ * land far from the derived defaults. Anything not listed here uses the
+ * derived palette unchanged.
+ */
+const THEME_HLJS: Record<string, Partial<HljsTokens>> = {
+  'github-light': {
+    keyword: '#cf222e',
+    builtIn: '#0550ae',
+    string: '#0a3069',
+    number: '#0550ae',
+    comment: '#6e7781',
+    fn: '#8250df',
+    type: '#953800',
+    variable: '#1f2328',
+    operator: '#cf222e',
+    params: '#1f2328',
+    meta: '#0550ae',
+    regex: '#116329',
+    title: '#8250df',
+    tag: '#116329',
+    attribute: '#0550ae',
+  },
+  'github-dark': {
+    keyword: '#ff7b72',
+    builtIn: '#79c0ff',
+    string: '#a5d6ff',
+    number: '#79c0ff',
+    comment: '#8b949e',
+    fn: '#d2a8ff',
+    type: '#ffa657',
+    variable: '#e6edf3',
+    operator: '#ff7b72',
+    params: '#e6edf3',
+    meta: '#79c0ff',
+    regex: '#7ee787',
+    title: '#d2a8ff',
+    tag: '#7ee787',
+    attribute: '#79c0ff',
+  },
+  dracula: {
+    keyword: '#ff79c6',
+    builtIn: '#8be9fd',
+    string: '#f1fa8c',
+    number: '#bd93f9',
+    comment: '#6272a4',
+    fn: '#50fa7b',
+    type: '#8be9fd',
+    variable: '#f8f8f2',
+    operator: '#ff79c6',
+    params: '#ffb86c',
+    meta: '#bd93f9',
+    regex: '#f1fa8c',
+    title: '#50fa7b',
+    tag: '#ff79c6',
+    attribute: '#50fa7b',
+  },
+  'one-dark': {
+    keyword: '#c678dd',
+    builtIn: '#56b6c2',
+    string: '#98c379',
+    number: '#d19a66',
+    comment: '#5c6370',
+    fn: '#61afef',
+    type: '#e5c07b',
+    variable: '#abb2bf',
+    operator: '#56b6c2',
+    params: '#abb2bf',
+    meta: '#56b6c2',
+    regex: '#98c379',
+    title: '#61afef',
+    tag: '#e06c75',
+    attribute: '#d19a66',
+  },
+  'one-light': {
+    keyword: '#a626a4',
+    builtIn: '#0184bb',
+    string: '#50a14f',
+    number: '#986801',
+    comment: '#a0a1a7',
+    fn: '#4078f2',
+    type: '#c18401',
+    variable: '#383a42',
+    operator: '#0184bb',
+    params: '#383a42',
+    meta: '#0184bb',
+    regex: '#50a14f',
+    title: '#4078f2',
+    tag: '#e45649',
+    attribute: '#986801',
+  },
+  monokai: {
+    keyword: '#f92672',
+    builtIn: '#66d9ef',
+    string: '#e6db74',
+    number: '#ae81ff',
+    comment: '#75715e',
+    fn: '#a6e22e',
+    type: '#66d9ef',
+    variable: '#f8f8f2',
+    operator: '#f92672',
+    params: '#fd971f',
+    meta: '#75715e',
+    regex: '#e6db74',
+    title: '#a6e22e',
+    tag: '#f92672',
+    attribute: '#a6e22e',
+  },
+  'solarized-light': {
+    keyword: '#859900',
+    builtIn: '#268bd2',
+    string: '#2aa198',
+    number: '#d33682',
+    comment: '#93a1a1',
+    fn: '#268bd2',
+    type: '#b58900',
+    variable: '#586e75',
+    operator: '#859900',
+    params: '#cb4b16',
+    meta: '#cb4b16',
+    regex: '#2aa198',
+    title: '#268bd2',
+    tag: '#268bd2',
+    attribute: '#b58900',
+  },
+  'solarized-dark': {
+    keyword: '#859900',
+    builtIn: '#268bd2',
+    string: '#2aa198',
+    number: '#d33682',
+    comment: '#586e75',
+    fn: '#268bd2',
+    type: '#b58900',
+    variable: '#839496',
+    operator: '#859900',
+    params: '#cb4b16',
+    meta: '#cb4b16',
+    regex: '#2aa198',
+    title: '#268bd2',
+    tag: '#268bd2',
+    attribute: '#b58900',
+  },
+  'tokyo-night': {
+    keyword: '#bb9af7',
+    builtIn: '#7dcfff',
+    string: '#9ece6a',
+    number: '#ff9e64',
+    comment: '#565f89',
+    fn: '#7aa2f7',
+    type: '#7dcfff',
+    variable: '#a9b1d6',
+    operator: '#bb9af7',
+    params: '#e0af68',
+    meta: '#7dcfff',
+    regex: '#9ece6a',
+    title: '#7aa2f7',
+    tag: '#f7768e',
+    attribute: '#e0af68',
+  },
+  nord: {
+    keyword: '#81a1c1',
+    builtIn: '#88c0d0',
+    string: '#a3be8c',
+    number: '#b48ead',
+    comment: '#616e88',
+    fn: '#88c0d0',
+    type: '#8fbcbb',
+    variable: '#d8dee9',
+    operator: '#81a1c1',
+    params: '#d08770',
+    meta: '#5e81ac',
+    regex: '#ebcb8b',
+    title: '#88c0d0',
+    tag: '#81a1c1',
+    attribute: '#8fbcbb',
+  },
+  'gruvbox-dark': {
+    keyword: '#fb4934',
+    builtIn: '#83a598',
+    string: '#b8bb26',
+    number: '#d3869b',
+    comment: '#928374',
+    fn: '#fabd2f',
+    type: '#fabd2f',
+    variable: '#ebdbb2',
+    operator: '#fe8019',
+    params: '#fe8019',
+    meta: '#fb4934',
+    regex: '#b8bb26',
+    title: '#fabd2f',
+    tag: '#fb4934',
+    attribute: '#fabd2f',
+  },
+  'gruvbox-light': {
+    keyword: '#9d0006',
+    builtIn: '#076678',
+    string: '#79740e',
+    number: '#8f3f71',
+    comment: '#7c6f64',
+    fn: '#b57614',
+    type: '#b57614',
+    variable: '#3c3836',
+    operator: '#af3a03',
+    params: '#af3a03',
+    meta: '#9d0006',
+    regex: '#79740e',
+    title: '#b57614',
+    tag: '#9d0006',
+    attribute: '#b57614',
+  },
+  'rose-pine': {
+    keyword: '#c4a7e7',
+    builtIn: '#9ccfd8',
+    string: '#f6c177',
+    number: '#eb6f92',
+    comment: '#6e6a86',
+    fn: '#ebbcba',
+    type: '#9ccfd8',
+    variable: '#e0def4',
+    operator: '#eb6f92',
+    params: '#f6c177',
+    meta: '#31748f',
+    regex: '#f6c177',
+    title: '#ebbcba',
+    tag: '#eb6f92',
+    attribute: '#f6c177',
+  },
+  cobalt2: {
+    keyword: '#ff9d00',
+    builtIn: '#ffc600',
+    string: '#a5ff90',
+    number: '#ff628c',
+    comment: '#0088ff',
+    fn: '#ffc600',
+    type: '#80ffbb',
+    variable: '#ffffff',
+    operator: '#ff9d00',
+    params: '#ff628c',
+    meta: '#ffc600',
+    regex: '#a5ff90',
+    title: '#ffc600',
+    tag: '#9effff',
+    attribute: '#ff9d00',
+  },
+};
+
+export function hljsTokensFor(theme: ThemeDefinition): HljsTokens {
+  const derived = deriveHljsTokens(theme.palette);
+  const overrides = THEME_HLJS[theme.id] ?? {};
+  return { ...derived, ...overrides };
+}
+
+/**
+ * Emit the highlight.js CSS rules for a theme. Designed to be appended
+ * after the bundled hljs base stylesheet so it overrides the generic
+ * one-dark / github-light bundled defaults.
+ */
+export function hljsCssFor(theme: ThemeDefinition): string {
+  const t = hljsTokensFor(theme);
+  return [
+    `.hljs { color: ${theme.palette.fg}; background: transparent; }`,
+    `.hljs-keyword, .hljs-selector-tag, .hljs-literal { color: ${t.keyword}; }`,
+    `.hljs-built_in, .hljs-builtin-name { color: ${t.builtIn}; }`,
+    `.hljs-string, .hljs-symbol, .hljs-bullet { color: ${t.string}; }`,
+    `.hljs-number, .hljs-link { color: ${t.number}; }`,
+    `.hljs-comment, .hljs-quote { color: ${t.comment}; font-style: italic; }`,
+    `.hljs-function, .hljs-title.function_, .hljs-title.invoke__ { color: ${t.fn}; }`,
+    `.hljs-class .hljs-title, .hljs-title.class_, .hljs-type { color: ${t.type}; }`,
+    `.hljs-variable, .hljs-template-variable, .hljs-property { color: ${t.variable}; }`,
+    `.hljs-operator, .hljs-punctuation { color: ${t.operator}; }`,
+    `.hljs-params { color: ${t.params}; }`,
+    `.hljs-meta, .hljs-meta-keyword, .hljs-doctag { color: ${t.meta}; }`,
+    `.hljs-regexp { color: ${t.regex}; }`,
+    `.hljs-title, .hljs-section { color: ${t.title}; }`,
+    `.hljs-tag, .hljs-name, .hljs-selector-id, .hljs-selector-class { color: ${t.tag}; }`,
+    `.hljs-attr, .hljs-attribute { color: ${t.attribute}; }`,
+    `.hljs-emphasis { font-style: italic; }`,
+    `.hljs-strong { font-weight: 600; }`,
+  ].join('\n');
+}

--- a/packages/core/src/themes/index.ts
+++ b/packages/core/src/themes/index.ts
@@ -1,1 +1,2 @@
 export * from './themes';
+export * from './hljsCss';

--- a/src/editor/webviewBuilder.ts
+++ b/src/editor/webviewBuilder.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { findTheme, paletteToCss } from '../themes/themes';
+import { hljsCssFor } from '../../packages/core/src/themes/hljsCss';
 
 const NONCE_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
@@ -24,6 +25,7 @@ export function buildWebviewHtml(
   const themeOverride = themeDef
     ? `:root[data-theme="${theme}"] { ${paletteToCss(themeDef.palette)} color-scheme: ${themeDef.kind}; }`
     : '';
+  const hljsOverride = themeDef ? hljsCssFor(themeDef) : '';
 
   return /* html */ `<!DOCTYPE html>
 <html lang="en" data-theme="${theme}" data-theme-kind="${themeDef?.kind ?? 'auto'}">
@@ -53,6 +55,7 @@ export function buildWebviewHtml(
       --accent: var(--vscode-textLink-foreground);
     }
     ${themeOverride}
+    ${hljsOverride}
     html, body { margin: 0; padding: 0; height: 100%; }
     body {
       font-family: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif);

--- a/src/publish/publishManager.ts
+++ b/src/publish/publishManager.ts
@@ -218,7 +218,7 @@ export class PublishManager {
     const subRoot = pub.subPath ? path.join(worktreeRoot, pub.subPath) : worktreeRoot;
     await vscode.workspace.fs.createDirectory(vscode.Uri.file(subRoot));
     const themeDef = pub.theme ?? findTheme('github-light')!;
-    const assets = buildSiteAssets(themeDef.palette, themeDef.kind === 'dark');
+    const assets = buildSiteAssets(themeDef.palette, themeDef.kind === 'dark', themeDef);
 
     // Write each page
     for (const page of pages) {

--- a/src/publish/staticGenerator.ts
+++ b/src/publish/staticGenerator.ts
@@ -2,6 +2,8 @@ import { marked } from 'marked';
 import { markedHighlight } from 'marked-highlight';
 import hljs from 'highlight.js';
 import { paletteToCss, ThemePalette } from '../themes/themes';
+import { hljsCssFor } from '../../packages/core/src/themes/hljsCss';
+import { ThemeDefinition } from '../../packages/core/src/themes/themes';
 
 marked.use(
   markedHighlight({
@@ -35,12 +37,18 @@ export interface RenderedPage {
   html: string;
 }
 
-export function buildSiteAssets(palette: ThemePalette, kindIsDark: boolean): SiteAssets {
+export function buildSiteAssets(
+  palette: ThemePalette,
+  kindIsDark: boolean,
+  theme?: ThemeDefinition,
+): SiteAssets {
   const hljsTheme = kindIsDark ? HLJS_DARK_CSS : HLJS_LIGHT_CSS;
+  const hljsOverrides = theme ? hljsCssFor(theme) : '';
   const pageCss = `
 :root { ${paletteToCss(palette)} color-scheme: ${kindIsDark ? 'dark' : 'light'}; }
 ${BASE_CSS}
 ${hljsTheme}
+${hljsOverrides}
 `;
   return { pageCss, clientJs: CLIENT_JS };
 }

--- a/tests/unit/themes/hljsCss.test.ts
+++ b/tests/unit/themes/hljsCss.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { THEMES, findTheme } from '../../../packages/core/src/themes/themes';
+import {
+  deriveHljsTokens,
+  hljsCssFor,
+  hljsTokensFor,
+} from '../../../packages/core/src/themes/hljsCss';
+
+describe('deriveHljsTokens', () => {
+  it('uses link for keyword + accent for built-ins', () => {
+    const palette = findTheme('github-light')!.palette;
+    const tokens = deriveHljsTokens(palette);
+    expect(tokens.keyword).toBe(palette.link);
+    expect(tokens.builtIn).toBe(palette.accent);
+  });
+
+  it('uses fgMuted for comments', () => {
+    const tokens = deriveHljsTokens(findTheme('one-dark')!.palette);
+    expect(tokens.comment).toBe(findTheme('one-dark')!.palette.fgMuted);
+  });
+});
+
+describe('hljsTokensFor', () => {
+  it('applies curated overrides for github-light', () => {
+    const tokens = hljsTokensFor(findTheme('github-light')!);
+    expect(tokens.keyword).toBe('#cf222e');
+    expect(tokens.string).toBe('#0a3069');
+    expect(tokens.comment).toBe('#6e7781');
+  });
+
+  it('applies curated overrides for dracula', () => {
+    const tokens = hljsTokensFor(findTheme('dracula')!);
+    expect(tokens.keyword).toBe('#ff79c6');
+    expect(tokens.string).toBe('#f1fa8c');
+  });
+
+  it('falls back to derived palette for themes without curation', () => {
+    const theme = findTheme('hyper-snazzy' as 'snazzy') ?? findTheme('snazzy')!;
+    const derived = deriveHljsTokens(theme.palette);
+    const tokens = hljsTokensFor(theme);
+    expect(tokens.keyword).toBe(derived.keyword);
+  });
+});
+
+describe('hljsCssFor', () => {
+  it('emits CSS rules for every standard hljs token class', () => {
+    const css = hljsCssFor(findTheme('github-dark')!);
+    for (const cls of [
+      '.hljs-keyword',
+      '.hljs-built_in',
+      '.hljs-string',
+      '.hljs-number',
+      '.hljs-comment',
+      '.hljs-function',
+      '.hljs-type',
+      '.hljs-variable',
+      '.hljs-operator',
+      '.hljs-params',
+      '.hljs-meta',
+      '.hljs-regexp',
+      '.hljs-title',
+      '.hljs-tag',
+      '.hljs-attr',
+    ]) {
+      expect(css).toContain(cls);
+    }
+  });
+
+  it('uses the foreground colour as the .hljs base color', () => {
+    const theme = findTheme('one-dark')!;
+    const css = hljsCssFor(theme);
+    expect(css).toContain(`.hljs { color: ${theme.palette.fg};`);
+  });
+
+  it('emits CSS for every bundled theme without throwing', () => {
+    for (const theme of THEMES) {
+      const css = hljsCssFor(theme);
+      expect(css.length, theme.id).toBeGreaterThan(200);
+    }
+  });
+});
+
+describe('parity with the 25-theme bundle', () => {
+  it('every theme resolves to a valid HljsTokens object', () => {
+    for (const theme of THEMES) {
+      const tokens = hljsTokensFor(theme);
+      for (const key of Object.keys(tokens) as (keyof typeof tokens)[]) {
+        expect(typeof tokens[key], `${theme.id}.${key}`).toBe('string');
+        expect(tokens[key].length, `${theme.id}.${key} empty`).toBeGreaterThan(0);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #51

## Summary

- New `packages/core/src/themes/hljsCss.ts` — pure helpers for per-theme code-highlight palettes
- Curated palettes for marquee themes (github, dracula, one-dark/light, monokai, solarized, tokyo-night, nord, gruvbox, rose-pine, cobalt2)
- Algorithmic mapping for the rest (link → keyword, accent → built-in, fgMuted → comment, etc.) so they harmonise with their chrome
- Wired into both webview render path and published static site

## Test plan

- [x] `npx vitest run` — 204/204 (9 new hljs tests)
- [x] `tsc -p ./` — clean
- [x] Webview bundle compiles
- [x] Manual: switched between dracula + github-light, observed correct community palettes

## Docs

- `docs/themes.md` — new "Per-token highlight.js palette (#51)" section + edge-case note updated; `docs/README.md` v2.0 row + `CHANGELOG.md` entry