### PR TITLE
fix(desktop): reserve macOS traffic-light inset in titlebar (#75)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -45,6 +45,7 @@ body {
   border-bottom: 1px solid var(--border);
   -webkit-app-region: drag;
 }
+body.is-mac .mid-titlebar { padding-left: 80px; }
 .mid-titlebar button { -webkit-app-region: no-drag; }
 .mid-titlebar-left, .mid-titlebar-right { display: flex; gap: 6px; }
 .mid-titlebar-right { justify-self: end; }

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -144,4 +144,7 @@ window.mid.onThemeChanged(applyTheme);
 window.mid.onMenuOpen(() => void openFile());
 window.mid.onMenuSave(() => void saveFile());
 
-void window.mid.getAppInfo().then(info => applyTheme(info.isDark));
+void window.mid.getAppInfo().then(info => {
+  document.body.classList.toggle('is-mac', info.platform === 'darwin');
+  applyTheme(info.isDark);
+});

--- a/docs/desktop-titlebar.md
+++ b/docs/desktop-titlebar.md
@@ -1,0 +1,16 @@
+# Desktop titlebar — macOS traffic-light inset
+
+The Electron window uses `titleBarStyle: 'hiddenInset'` on macOS so the standard close/minimize/maximize controls render over a custom toolbar. Without explicit padding, our left-aligned toolbar buttons collide with the traffic lights.
+
+## Behavior
+
+- **macOS** (`platform === 'darwin'`): the renderer adds `is-mac` to `<body>`, which adds `padding-left: 80px` to `.mid-titlebar`. 80px clears all three traffic-light controls plus a small gutter.
+- **Windows / Linux**: no inset is applied — the toolbar starts at the window edge.
+
+## How it's wired
+
+`apps/electron/renderer/renderer.ts` reads `platform` from the `getAppInfo()` IPC response and toggles the body class on first paint. `apps/electron/renderer/renderer.css` reserves the inset only when that class is present, so no platform-specific styles run for non-mac users.
+
+## Verifying
+
+Run `npm run dev:electron` on macOS and confirm the Open / Save buttons sit ~80px from the left edge. On Windows or Linux, confirm the buttons sit flush at the left padding (12px).


### PR DESCRIPTION
## Summary
- macOS-only inset of 80px on `.mid-titlebar` so Open/Save buttons clear the traffic-light controls
- Body class `is-mac` toggled from `getAppInfo().platform === 'darwin'` — no inset on Windows/Linux
- Docs at `docs/desktop-titlebar.md`

Closes #75 — part of #74

## Test plan
- [ ] `npm run dev:electron` on macOS — Open/Save sit ~80px from left edge, no overlap with traffic lights
- [ ] Confirm Windows/Linux still flush at 12px padding (no inset)