### PR TITLE
feat(ui-tokens): shared design tokens consumed by Electron renderer (#76)

### DIFF
--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -5,26 +5,28 @@
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self';" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Mark It Down</title>
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="primitives.css" />
 <link rel="stylesheet" href="renderer.css" />
 </head>
 <body>
 <header class="mid-titlebar" role="toolbar">
   <div class="mid-titlebar-left">
-    <button id="open-btn" title="Open markdown file">📂 Open</button>
-    <button id="save-btn" title="Save current file">💾 Save</button>
+    <button id="open-btn" class="mid-btn" title="Open markdown file">📂 Open</button>
+    <button id="save-btn" class="mid-btn" title="Save current file">💾 Save</button>
   </div>
   <div class="mid-titlebar-center">
     <span id="filename" class="mid-filename">Untitled</span>
   </div>
   <div class="mid-titlebar-right">
-    <button id="mode-view" class="active">📖 View</button>
-    <button id="mode-edit">✏️ Edit</button>
+    <button id="mode-view" class="mid-btn is-active">📖 View</button>
+    <button id="mode-edit" class="mid-btn">✏️ Edit</button>
   </div>
 </header>
 <main id="root" class="viewing">
   <div class="empty-state">
     <h1>Mark It Down</h1>
-    <p>Open a markdown file with <kbd>Cmd/Ctrl+O</kbd> to begin.</p>
+    <p>Open a markdown file with <kbd class="mid-kbd">Cmd/Ctrl+O</kbd> to begin.</p>
   </div>
 </main>
 <script src="renderer.js"></script>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -1,95 +1,129 @@
-:root {
-  color-scheme: light dark;
-  --bg: #ffffff;
-  --fg: #1f2328;
-  --fg-muted: #656d76;
-  --border: #d0d7de;
-  --link: #0969da;
-  --link-hover: #0550ae;
-  --code-bg: #f6f8fa;
-  --inline-code-bg: rgba(175,184,193,0.2);
-  --table-stripe: #f6f8fa;
-  --accent: #0969da;
-}
-:root.dark {
-  color-scheme: dark;
-  --bg: #0d1117;
-  --fg: #e6edf3;
-  --fg-muted: #7d8590;
-  --border: #30363d;
-  --link: #2f81f7;
-  --link-hover: #58a6ff;
-  --code-bg: #161b22;
-  --inline-code-bg: rgba(110,118,129,0.4);
-  --table-stripe: #161b22;
-  --accent: #2f81f7;
-}
-*, *::before, *::after { box-sizing: border-box; }
-html, body { margin: 0; padding: 0; height: 100%; }
+/* Electron renderer — layout + markdown styling.
+ * Design tokens live in packages/ui-tokens (tokens.css + primitives.css).
+ */
+
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-  font-size: 15px;
-  line-height: 1.65;
-  color: var(--fg);
-  background: var(--bg);
   display: grid;
-  grid-template-rows: 38px 1fr;
+  grid-template-rows: var(--mid-titlebar-h) 1fr;
 }
+
 .mid-titlebar {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  gap: 12px;
-  padding: 4px 12px;
-  background: var(--code-bg);
-  border-bottom: 1px solid var(--border);
+  gap: var(--mid-space-3);
+  padding: var(--mid-space-1) var(--mid-space-3);
+  background: var(--mid-surface);
+  border-bottom: 1px solid var(--mid-border);
   -webkit-app-region: drag;
 }
 body.is-mac .mid-titlebar { padding-left: 80px; }
-.mid-titlebar button { -webkit-app-region: no-drag; }
-.mid-titlebar-left, .mid-titlebar-right { display: flex; gap: 6px; }
+.mid-titlebar-left, .mid-titlebar-right { display: flex; gap: var(--mid-space-1); }
 .mid-titlebar-right { justify-self: end; }
-.mid-titlebar-center { text-align: center; color: var(--fg-muted); font-size: 0.92em; }
-.mid-titlebar button {
-  padding: 4px 10px;
-  font-size: 12px;
-  background: transparent;
-  color: var(--fg);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  cursor: pointer;
+.mid-titlebar-center {
+  text-align: center;
+  color: var(--mid-fg-muted);
+  font-size: var(--mid-font-size-sm);
 }
-.mid-titlebar button:hover { background: rgba(127,127,127,0.10); }
-.mid-titlebar button.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.mid-titlebar .mid-btn.is-active {
+  background: var(--mid-accent);
+  color: var(--mid-accent-fg);
+  border-color: var(--mid-accent);
+}
+
 main { overflow: auto; }
-main.viewing { padding: 32px 48px 96px; max-width: 920px; margin: 0 auto; }
-main.viewing h1, main.viewing h2 { border-bottom: 1px solid var(--border); padding-bottom: 0.3em; }
-main.viewing h1 { font-size: 2em; margin-top: 0.6em; }
-main.viewing h2 { font-size: 1.5em; margin-top: 1.4em; }
-main.viewing h3 { font-size: 1.25em; }
+main.viewing {
+  padding: var(--mid-space-8) var(--mid-space-12) var(--mid-space-12);
+  max-width: 920px;
+  margin: 0 auto;
+}
+main.viewing h1, main.viewing h2 {
+  border-bottom: 1px solid var(--mid-border);
+  padding-bottom: 0.3em;
+}
+main.viewing h1 { font-size: var(--mid-font-size-3xl); margin-top: 0.6em; }
+main.viewing h2 { font-size: var(--mid-font-size-2xl); margin-top: 1.4em; }
+main.viewing h3 { font-size: var(--mid-font-size-xl); }
 main.viewing p { margin: 0.8em 0; }
-main.viewing a { color: var(--link); text-decoration: none; }
-main.viewing a:hover { text-decoration: underline; }
-main.viewing code { background: var(--inline-code-bg); padding: 2px 6px; border-radius: 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.9em; }
-main.viewing pre { background: var(--code-bg); border: 1px solid var(--border); border-radius: 6px; padding: 14px 16px; overflow-x: auto; margin: 1em 0; }
+main.viewing a { color: var(--mid-link); text-decoration: none; }
+main.viewing a:hover { color: var(--mid-link-hover); text-decoration: underline; }
+main.viewing code {
+  background: var(--mid-inline-code-bg);
+  padding: 2px 6px;
+  border-radius: var(--mid-radius-sm);
+  font-family: var(--mid-font-mono);
+  font-size: 0.9em;
+}
+main.viewing pre {
+  background: var(--mid-code-bg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-md);
+  padding: var(--mid-space-3) var(--mid-space-4);
+  overflow-x: auto;
+  margin: 1em 0;
+}
 main.viewing pre code { background: transparent; padding: 0; font-size: 0.88em; }
-main.viewing blockquote { border-left: 3px solid var(--accent); padding: 4px 14px; margin: 1em 0; color: var(--fg-muted); background: var(--code-bg); border-radius: 0 6px 6px 0; }
-main.viewing table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.95em; }
-main.viewing th, main.viewing td { padding: 8px 12px; border: 1px solid var(--border); text-align: left; }
-main.viewing th { background: var(--code-bg); font-weight: 600; }
-main.viewing tr:nth-child(even) td { background: var(--table-stripe); }
-main.viewing img { max-width: 100%; border-radius: 4px; }
-main.viewing hr { border: 0; border-top: 1px solid var(--border); margin: 2em 0; }
-main.viewing .mermaid { background: var(--code-bg); border: 1px solid var(--border); border-radius: 6px; padding: 14px; margin: 1em 0; text-align: center; overflow-x: auto; }
+main.viewing blockquote {
+  border-left: 3px solid var(--mid-accent);
+  padding: var(--mid-space-1) var(--mid-space-4);
+  margin: 1em 0;
+  color: var(--mid-fg-muted);
+  background: var(--mid-code-bg);
+  border-radius: 0 var(--mid-radius-md) var(--mid-radius-md) 0;
+}
+main.viewing table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1em 0;
+  font-size: 0.95em;
+}
+main.viewing th, main.viewing td {
+  padding: var(--mid-space-2) var(--mid-space-3);
+  border: 1px solid var(--mid-border);
+  text-align: left;
+}
+main.viewing th { background: var(--mid-code-bg); font-weight: var(--mid-weight-semibold); }
+main.viewing tr:nth-child(even) td { background: var(--mid-table-stripe); }
+main.viewing img { max-width: 100%; border-radius: var(--mid-radius-sm); }
+main.viewing hr {
+  border: 0;
+  border-top: 1px solid var(--mid-border);
+  margin: var(--mid-space-8) 0;
+}
+main.viewing .mermaid {
+  background: var(--mid-code-bg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-md);
+  padding: var(--mid-space-3);
+  margin: 1em 0;
+  text-align: center;
+  overflow-x: auto;
+}
+
 main.editing { padding: 0; max-width: none; }
 main.editing textarea {
-  width: 100%; height: 100%; padding: 16px 24px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 14px; line-height: 1.55;
-  background: var(--bg); color: var(--fg);
-  border: 0; outline: none; resize: none; tab-size: 2;
+  width: 100%;
+  height: 100%;
+  padding: var(--mid-space-4) var(--mid-space-6);
+  font-family: var(--mid-font-mono);
+  font-size: 14px;
+  line-height: 1.55;
+  background: var(--mid-bg);
+  color: var(--mid-fg);
+  border: 0;
+  outline: none;
+  resize: none;
+  tab-size: 2;
   white-space: pre;
 }
-.empty-state { text-align: center; padding: 64px 16px; color: var(--fg-muted); }
-.empty-state h1 { font-size: 2.4em; color: var(--fg); border: 0; }
-.empty-state kbd { background: var(--inline-code-bg); padding: 2px 6px; border-radius: 4px; font-family: ui-monospace, monospace; font-size: 0.9em; }
+
+.empty-state {
+  text-align: center;
+  padding: var(--mid-space-12) var(--mid-space-4);
+  color: var(--mid-fg-muted);
+}
+.empty-state h1 {
+  font-size: var(--mid-font-size-3xl);
+  color: var(--mid-fg);
+  border: 0;
+}

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -98,8 +98,8 @@ function renderEdit(): void {
 
 function setMode(mode: 'view' | 'edit'): void {
   currentMode = mode;
-  btnView.classList.toggle('active', mode === 'view');
-  btnEdit.classList.toggle('active', mode === 'edit');
+  btnView.classList.toggle('is-active', mode === 'view');
+  btnEdit.classList.toggle('is-active', mode === 'edit');
   if (mode === 'view') renderView();
   else renderEdit();
 }

--- a/docs/ui-tokens.md
+++ b/docs/ui-tokens.md
@@ -1,0 +1,43 @@
+# ui-tokens — shared design system
+
+`packages/ui-tokens` is the single source of truth for color, spacing, typography, radius, shadow, and motion across the project. The Electron renderer, the VS Code webview, and the published-site stylesheet all consume it instead of redefining their own values.
+
+## What's in the package
+
+| File | Purpose |
+| --- | --- |
+| `src/tokens.css` | All CSS custom properties (`--mid-*`), light theme on `:root`, dark on `:root.dark`. |
+| `src/primitives.css` | Small reset + reusable components (`.mid-btn`, `.mid-list-row`, `.mid-surface`, `.mid-kbd`). Imports tokens implicitly via the cascade — load `tokens.css` first. |
+| `src/index.ts` | Programmatic mirror of the values for JS consumers (e.g., Mermaid theme init that takes a JS color). |
+
+## Token namespace
+
+All custom properties are prefixed `--mid-*` to avoid collisions with libraries (Highlight.js, Mermaid) and host environments (VS Code, GitHub Pages).
+
+Categories: `color` (light + dark), `space-*` (4px base, 0..12), `radius-*` (xs..xl + pill), `font-sans/mono`, `font-size-*`, `line-*`, `weight-*`, `shadow-*`, `motion-*`, `ease-*`, `titlebar-h`, `sidebar-w`, `z-*`.
+
+## Wiring a consumer
+
+The Electron renderer wires it like this:
+
+```html
+<link rel="stylesheet" href="tokens.css" />
+<link rel="stylesheet" href="primitives.css" />
+<link rel="stylesheet" href="renderer.css" />
+```
+
+Order matters: tokens first (defines variables), primitives next (uses variables), renderer last (consumer-specific layout + overrides).
+
+Build glue in `scripts/copy-electron-assets.mjs` copies the four files into `out/electron/renderer/` so Electron's same-origin CSP can load them.
+
+## Adding a token
+
+1. Add the property to both light and dark blocks in `tokens.css`.
+2. If JS needs the value too, mirror it in `src/index.ts`.
+3. Use it as `var(--mid-foo)` from any consumer stylesheet.
+
+Don't introduce one-off colors in consumer stylesheets — extend the token set instead, so a future theme switch only edits one file.
+
+## Dark mode
+
+Toggle by adding the `dark` class on `<html>`. The Electron renderer does this from `nativeTheme.shouldUseDarkColors` in `apps/electron/renderer/renderer.ts`.

--- a/package.json
+++ b/package.json
@@ -751,7 +751,7 @@
     "compile:extension": "tsc -p ./",
     "compile:webview": "esbuild src/webview/main.ts --bundle --outfile=out/webview/main.js --format=iife --target=es2020 --platform=browser",
     "compile:mcp": "esbuild src/mcp/server.ts --bundle --outfile=out/mcp/server.js --format=cjs --platform=node --target=node18 --external:vscode",
-    "compile:electron": "tsc -p apps/electron/tsconfig.json && esbuild apps/electron/renderer/renderer.ts --bundle --outfile=out/electron/renderer/renderer.js --format=iife --target=es2020 --platform=browser && node -e \"const fs=require('fs'),p=require('path');fs.mkdirSync('out/electron/renderer',{recursive:true});['index.html','renderer.css'].forEach(f=>fs.copyFileSync(p.join('apps/electron/renderer',f),p.join('out/electron/renderer',f)));\"",
+    "compile:electron": "tsc -p apps/electron/tsconfig.json && esbuild apps/electron/renderer/renderer.ts --bundle --outfile=out/electron/renderer/renderer.js --format=iife --target=es2020 --platform=browser && node scripts/copy-electron-assets.mjs",
     "build:claude-plugin": "npm run compile:mcp && node -e \"const fs=require('fs'),p=require('path');fs.mkdirSync('plugins/mark-it-down-claude/bin',{recursive:true});fs.copyFileSync('out/mcp/server.js','plugins/mark-it-down-claude/bin/server.js');console.log('mark-it-down-claude plugin: bin/server.js refreshed');\"",
     "watch": "tsc -watch -p ./",
     "package": "vsce package",

--- a/packages/ui-tokens/src/index.ts
+++ b/packages/ui-tokens/src/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Programmatic access to design-token values for JS consumers.
+ * The CSS files (`tokens.css`, `primitives.css`) are the runtime source of
+ * truth — this map mirrors the values for cases where JS needs them
+ * (e.g., initializing a third-party renderer like Mermaid that takes a
+ * color in JS, not CSS).
+ */
+
+export const tokens = {
+  color: {
+    light: {
+      bg: '#ffffff',
+      surface: '#f6f8fa',
+      fg: '#1f2328',
+      fgMuted: '#656d76',
+      border: '#d0d7de',
+      accent: '#0969da',
+      link: '#0969da',
+      codeBg: '#f6f8fa',
+    },
+    dark: {
+      bg: '#0d1117',
+      surface: '#161b22',
+      fg: '#e6edf3',
+      fgMuted: '#7d8590',
+      border: '#30363d',
+      accent: '#2f81f7',
+      link: '#2f81f7',
+      codeBg: '#161b22',
+    },
+  },
+  font: {
+    sans: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Helvetica Neue", Arial, sans-serif',
+    mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+  },
+  layout: {
+    titlebarHeight: 38,
+    sidebarWidth: 240,
+  },
+  motion: {
+    fast: 120,
+    base: 200,
+    slow: 320,
+  },
+} as const;
+
+export type ColorScheme = keyof typeof tokens.color;

--- a/packages/ui-tokens/src/primitives.css
+++ b/packages/ui-tokens/src/primitives.css
@@ -1,0 +1,97 @@
+/* Mark It Down — primitives
+ * Small reset + reusable components consuming ui-tokens.
+ * Importers must include tokens.css first.
+ */
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; height: 100%; }
+body {
+  font-family: var(--mid-font-sans);
+  font-size: var(--mid-font-size-base);
+  line-height: var(--mid-line-relaxed);
+  color: var(--mid-fg);
+  background: var(--mid-bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+button { font-family: inherit; }
+
+.mid-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--mid-space-1);
+  padding: var(--mid-space-1) var(--mid-space-3);
+  font-size: var(--mid-font-size-sm);
+  font-weight: var(--mid-weight-medium);
+  line-height: 1.4;
+  background: transparent;
+  color: var(--mid-fg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
+  cursor: pointer;
+  transition:
+    background var(--mid-motion-fast) var(--mid-ease-out),
+    border-color var(--mid-motion-fast) var(--mid-ease-out),
+    color var(--mid-motion-fast) var(--mid-ease-out);
+  -webkit-app-region: no-drag;
+}
+.mid-btn:hover { background: var(--mid-surface-hover); border-color: var(--mid-border-strong); }
+.mid-btn:active { background: var(--mid-surface-active); }
+.mid-btn:focus-visible { outline: 2px solid var(--mid-accent); outline-offset: 2px; }
+.mid-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.mid-btn--primary {
+  background: var(--mid-accent);
+  color: var(--mid-accent-fg);
+  border-color: var(--mid-accent);
+}
+.mid-btn--primary:hover {
+  background: var(--mid-accent-hover);
+  border-color: var(--mid-accent-hover);
+}
+.mid-btn--ghost { border-color: transparent; }
+.mid-btn--icon { padding: var(--mid-space-1); width: 28px; height: 28px; }
+
+.mid-surface {
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-md);
+}
+
+.mid-list-row {
+  display: flex;
+  align-items: center;
+  gap: var(--mid-space-2);
+  padding: var(--mid-space-1) var(--mid-space-3);
+  font-size: var(--mid-font-size-sm);
+  color: var(--mid-fg);
+  border-radius: var(--mid-radius-sm);
+  cursor: pointer;
+  user-select: none;
+  transition: background var(--mid-motion-fast) var(--mid-ease-out);
+}
+.mid-list-row:hover { background: var(--mid-surface-hover); }
+.mid-list-row.is-active {
+  background: var(--mid-accent);
+  color: var(--mid-accent-fg);
+}
+
+.mid-kbd {
+  display: inline-block;
+  padding: 1px var(--mid-space-1);
+  font-family: var(--mid-font-mono);
+  font-size: var(--mid-font-size-xs);
+  background: var(--mid-inline-code-bg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-xs);
+}
+
+.mid-divider {
+  height: 1px;
+  background: var(--mid-border);
+  border: 0;
+  margin: var(--mid-space-3) 0;
+}
+
+::selection { background: var(--mid-accent); color: var(--mid-accent-fg); }

--- a/packages/ui-tokens/src/tokens.css
+++ b/packages/ui-tokens/src/tokens.css
@@ -1,0 +1,120 @@
+/* Mark It Down — design tokens
+ * Single source of truth for color / spacing / type / radius / shadow / motion.
+ * Consumed by the Electron renderer, the VS Code webview, and the published site.
+ */
+
+:root {
+  color-scheme: light dark;
+
+  /* Color — light */
+  --mid-bg: #ffffff;
+  --mid-surface: #f6f8fa;
+  --mid-surface-hover: #eaeef2;
+  --mid-surface-active: #d8dee4;
+  --mid-fg: #1f2328;
+  --mid-fg-muted: #656d76;
+  --mid-fg-subtle: #8b949e;
+  --mid-border: #d0d7de;
+  --mid-border-strong: #afb8c1;
+  --mid-accent: #0969da;
+  --mid-accent-fg: #ffffff;
+  --mid-accent-hover: #0550ae;
+  --mid-link: #0969da;
+  --mid-link-hover: #0550ae;
+  --mid-code-bg: #f6f8fa;
+  --mid-inline-code-bg: rgba(175, 184, 193, 0.2);
+  --mid-table-stripe: #f6f8fa;
+  --mid-danger: #d1242f;
+  --mid-warning: #9a6700;
+  --mid-success: #1a7f37;
+
+  /* Spacing — 4px base */
+  --mid-space-0: 0;
+  --mid-space-1: 4px;
+  --mid-space-2: 8px;
+  --mid-space-3: 12px;
+  --mid-space-4: 16px;
+  --mid-space-5: 20px;
+  --mid-space-6: 24px;
+  --mid-space-8: 32px;
+  --mid-space-10: 40px;
+  --mid-space-12: 48px;
+
+  /* Radius */
+  --mid-radius-xs: 2px;
+  --mid-radius-sm: 4px;
+  --mid-radius-md: 6px;
+  --mid-radius-lg: 8px;
+  --mid-radius-xl: 12px;
+  --mid-radius-pill: 9999px;
+
+  /* Typography */
+  --mid-font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, "Helvetica Neue", Arial, sans-serif;
+  --mid-font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --mid-font-size-xs: 11px;
+  --mid-font-size-sm: 12px;
+  --mid-font-size-base: 15px;
+  --mid-font-size-lg: 17px;
+  --mid-font-size-xl: 20px;
+  --mid-font-size-2xl: 24px;
+  --mid-font-size-3xl: 32px;
+  --mid-line-tight: 1.25;
+  --mid-line-normal: 1.5;
+  --mid-line-relaxed: 1.65;
+  --mid-weight-normal: 400;
+  --mid-weight-medium: 500;
+  --mid-weight-semibold: 600;
+  --mid-weight-bold: 700;
+
+  /* Shadow */
+  --mid-shadow-sm: 0 1px 2px rgba(31, 35, 40, 0.06);
+  --mid-shadow-md: 0 3px 6px rgba(31, 35, 40, 0.10), 0 1px 2px rgba(31, 35, 40, 0.06);
+  --mid-shadow-lg: 0 10px 24px rgba(31, 35, 40, 0.14);
+
+  /* Motion */
+  --mid-motion-fast: 120ms;
+  --mid-motion-base: 200ms;
+  --mid-motion-slow: 320ms;
+  --mid-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --mid-ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+
+  /* Layout */
+  --mid-titlebar-h: 38px;
+  --mid-sidebar-w: 240px;
+
+  /* Z-index */
+  --mid-z-base: 1;
+  --mid-z-sticky: 100;
+  --mid-z-dropdown: 200;
+  --mid-z-modal: 1000;
+  --mid-z-toast: 2000;
+}
+
+:root.dark {
+  color-scheme: dark;
+
+  --mid-bg: #0d1117;
+  --mid-surface: #161b22;
+  --mid-surface-hover: #1f242c;
+  --mid-surface-active: #2a313c;
+  --mid-fg: #e6edf3;
+  --mid-fg-muted: #7d8590;
+  --mid-fg-subtle: #6e7681;
+  --mid-border: #30363d;
+  --mid-border-strong: #484f58;
+  --mid-accent: #2f81f7;
+  --mid-accent-fg: #ffffff;
+  --mid-accent-hover: #58a6ff;
+  --mid-link: #2f81f7;
+  --mid-link-hover: #58a6ff;
+  --mid-code-bg: #161b22;
+  --mid-inline-code-bg: rgba(110, 118, 129, 0.4);
+  --mid-table-stripe: #161b22;
+  --mid-danger: #f85149;
+  --mid-warning: #d29922;
+  --mid-success: #3fb950;
+
+  --mid-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --mid-shadow-md: 0 3px 6px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.25);
+  --mid-shadow-lg: 0 10px 24px rgba(0, 0, 0, 0.5);
+}

--- a/scripts/copy-electron-assets.mjs
+++ b/scripts/copy-electron-assets.mjs
@@ -1,0 +1,13 @@
+import { mkdirSync, copyFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const out = 'out/electron/renderer';
+mkdirSync(out, { recursive: true });
+
+const copies = [
+  ['apps/electron/renderer/index.html', join(out, 'index.html')],
+  ['apps/electron/renderer/renderer.css', join(out, 'renderer.css')],
+  ['packages/ui-tokens/src/tokens.css', join(out, 'tokens.css')],
+  ['packages/ui-tokens/src/primitives.css', join(out, 'primitives.css')],
+];
+for (const [src, dest] of copies) copyFileSync(src, dest);


### PR DESCRIPTION
## Summary
- New `packages/ui-tokens/src/{tokens.css, primitives.css, index.ts}` — single source of truth for color/spacing/type/radius/shadow/motion under the `--mid-*` namespace.
- `scripts/copy-electron-assets.mjs` replaces the inline node `-e` in `compile:electron`; copies tokens + primitives next to renderer.css so Electron's same-origin CSP can load them.
- Electron renderer now `<link>`s tokens.css and primitives.css before its own CSS; all `--bg`/`--fg`/etc. references migrated to the namespaced `--mid-*` tokens.
- Toolbar buttons now use `.mid-btn`; active state uses `.is-active` class.
- Docs at `docs/ui-tokens.md` (token contract + wiring guide).

Closes #76 — part of #74.

## Test plan
- [ ] `npm run dev:electron` — app renders with identical visuals (regression-free) but driven by tokens.
- [ ] Toggle macOS dark mode → light/dark themes still flip correctly.
- [ ] Open/Save/View/Edit buttons keep hover + active styling.