### PR TITLE
feat(desktop): folder workspace + file tree sidebar (#77)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -78,6 +78,22 @@ ipcMain.handle('mid:open-file-dialog', async () => {
   return { filePath, content: await fs.readFile(filePath, 'utf8') };
 });
 
+ipcMain.handle('mid:open-folder-dialog', async () => {
+  const result = await dialog.showOpenDialog({
+    properties: ['openDirectory'],
+  });
+  if (result.canceled || result.filePaths.length === 0) return null;
+  const folderPath = result.filePaths[0];
+  await writeAppState({ lastFolder: folderPath });
+  return { folderPath, tree: await listMarkdownTree(folderPath) };
+});
+
+ipcMain.handle('mid:list-folder-md', async (_e, folderPath: string) => {
+  return listMarkdownTree(folderPath);
+});
+
+ipcMain.handle('mid:read-app-state', async () => readAppState());
+
 ipcMain.handle('mid:save-file-dialog', async (_e, defaultName: string, content: string) => {
   const result = await dialog.showSaveDialog({
     defaultPath: defaultName,
@@ -198,6 +214,61 @@ function broadcastUpdateState(): void {
   }
 }
 
+interface AppState {
+  lastFolder?: string;
+}
+
+const MD_EXT = new Set(['.md', '.mdx', '.markdown']);
+const SKIP_DIRS = new Set(['node_modules', '.git', '.next', 'dist', 'out', '.cache', '.DS_Store']);
+
+interface TreeEntry {
+  name: string;
+  path: string;
+  kind: 'file' | 'dir';
+  children?: TreeEntry[];
+}
+
+async function listMarkdownTree(folderPath: string): Promise<TreeEntry[]> {
+  const entries = await fs.readdir(folderPath, { withFileTypes: true });
+  const out: TreeEntry[] = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('.') && entry.name !== '.github') continue;
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = path.join(folderPath, entry.name);
+    if (entry.isDirectory()) {
+      const children = await listMarkdownTree(full);
+      if (children.length > 0) {
+        out.push({ name: entry.name, path: full, kind: 'dir', children });
+      }
+    } else if (entry.isFile() && MD_EXT.has(path.extname(entry.name).toLowerCase())) {
+      out.push({ name: entry.name, path: full, kind: 'file' });
+    }
+  }
+  out.sort((a, b) => {
+    if (a.kind !== b.kind) return a.kind === 'dir' ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+  return out;
+}
+
+async function readAppState(): Promise<AppState> {
+  const file = path.join(app.getPath('userData'), 'state.json');
+  try {
+    const raw = await fs.readFile(file, 'utf8');
+    return JSON.parse(raw) as AppState;
+  } catch {
+    return {};
+  }
+}
+
+async function writeAppState(patch: Partial<AppState>): Promise<void> {
+  const file = path.join(app.getPath('userData'), 'state.json');
+  const current = await readAppState();
+  const next = { ...current, ...patch };
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, JSON.stringify(next, null, 2), 'utf8');
+}
+
 function buildMenu(): Menu {
   const isMac = process.platform === 'darwin';
   const template: MenuItemConstructorOptions[] = [
@@ -226,6 +297,11 @@ function buildMenu(): Menu {
           label: 'Open Markdown…',
           accelerator: 'CmdOrCtrl+O',
           click: () => mainWindow?.webContents.send('mid:menu-open'),
+        },
+        {
+          label: 'Open Folder…',
+          accelerator: 'CmdOrCtrl+Shift+O',
+          click: () => mainWindow?.webContents.send('mid:menu-open-folder'),
         },
         {
           label: 'Save',

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -8,12 +8,28 @@ export interface AppInfo {
   documents: string;
 }
 
+export interface TreeEntry {
+  name: string;
+  path: string;
+  kind: 'file' | 'dir';
+  children?: TreeEntry[];
+}
+
+export interface AppState {
+  lastFolder?: string;
+}
+
 contextBridge.exposeInMainWorld('mid', {
   readFile: (path: string): Promise<string> => ipcRenderer.invoke('mid:read-file', path),
   writeFile: (path: string, content: string): Promise<boolean> =>
     ipcRenderer.invoke('mid:write-file', path, content),
   openFileDialog: (): Promise<{ filePath: string; content: string } | null> =>
     ipcRenderer.invoke('mid:open-file-dialog'),
+  openFolderDialog: (): Promise<{ folderPath: string; tree: TreeEntry[] } | null> =>
+    ipcRenderer.invoke('mid:open-folder-dialog'),
+  listFolderMd: (folderPath: string): Promise<TreeEntry[]> =>
+    ipcRenderer.invoke('mid:list-folder-md', folderPath),
+  readAppState: (): Promise<AppState> => ipcRenderer.invoke('mid:read-app-state'),
   saveFileDialog: (defaultName: string, content: string): Promise<string | null> =>
     ipcRenderer.invoke('mid:save-file-dialog', defaultName, content),
   getAppInfo: (): Promise<AppInfo> => ipcRenderer.invoke('mid:get-app-info'),
@@ -27,6 +43,11 @@ contextBridge.exposeInMainWorld('mid', {
     const handler = () => cb();
     ipcRenderer.on('mid:menu-open', handler);
     return () => ipcRenderer.removeListener('mid:menu-open', handler);
+  },
+  onMenuOpenFolder: (cb: () => void): (() => void) => {
+    const handler = () => cb();
+    ipcRenderer.on('mid:menu-open-folder', handler);
+    return () => ipcRenderer.removeListener('mid:menu-open-folder', handler);
   },
   onMenuSave: (cb: () => void): (() => void) => {
     const handler = () => cb();

--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -12,8 +12,9 @@
 <body>
 <header class="mid-titlebar" role="toolbar">
   <div class="mid-titlebar-left">
-    <button id="open-btn" class="mid-btn" title="Open markdown file">📂 Open</button>
-    <button id="save-btn" class="mid-btn" title="Save current file">💾 Save</button>
+    <button id="open-folder-btn" class="mid-btn" title="Open folder (Cmd/Ctrl+Shift+O)">📁 Folder</button>
+    <button id="open-btn" class="mid-btn" title="Open markdown file (Cmd/Ctrl+O)">📂 Open</button>
+    <button id="save-btn" class="mid-btn" title="Save current file (Cmd/Ctrl+S)">💾 Save</button>
   </div>
   <div class="mid-titlebar-center">
     <span id="filename" class="mid-filename">Untitled</span>
@@ -23,12 +24,21 @@
     <button id="mode-edit" class="mid-btn">✏️ Edit</button>
   </div>
 </header>
-<main id="root" class="viewing">
-  <div class="empty-state">
-    <h1>Mark It Down</h1>
-    <p>Open a markdown file with <kbd class="mid-kbd">Cmd/Ctrl+O</kbd> to begin.</p>
-  </div>
-</main>
+<div class="mid-shell">
+  <aside class="mid-sidebar" id="sidebar" hidden>
+    <div class="mid-sidebar-header">
+      <span class="mid-sidebar-title" id="sidebar-folder-name">Files</span>
+      <button id="sidebar-refresh" class="mid-btn mid-btn--icon mid-btn--ghost" title="Refresh">↻</button>
+    </div>
+    <div class="mid-sidebar-tree" id="tree-root"></div>
+  </aside>
+  <main id="root" class="viewing">
+    <div class="empty-state">
+      <h1>Mark It Down</h1>
+      <p>Open a folder with <kbd class="mid-kbd">Cmd/Ctrl+Shift+O</kbd> to browse, or open a single file with <kbd class="mid-kbd">Cmd/Ctrl+O</kbd>.</p>
+    </div>
+  </main>
+</div>
 <script src="renderer.js"></script>
 </body>
 </html>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -7,6 +7,80 @@ body {
   grid-template-rows: var(--mid-titlebar-h) 1fr;
 }
 
+.mid-shell {
+  display: grid;
+  grid-template-columns: 1fr;
+  min-height: 0;
+  overflow: hidden;
+}
+body.has-sidebar .mid-shell {
+  grid-template-columns: var(--mid-sidebar-w) 1fr;
+}
+
+.mid-sidebar {
+  display: flex;
+  flex-direction: column;
+  background: var(--mid-surface);
+  border-right: 1px solid var(--mid-border);
+  overflow: hidden;
+}
+.mid-sidebar[hidden] { display: none; }
+.mid-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--mid-space-2) var(--mid-space-3);
+  border-bottom: 1px solid var(--mid-border);
+  font-size: var(--mid-font-size-sm);
+  font-weight: var(--mid-weight-semibold);
+  color: var(--mid-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.mid-sidebar-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+.mid-sidebar-tree {
+  flex: 1;
+  overflow: auto;
+  padding: var(--mid-space-2) var(--mid-space-1);
+}
+.mid-tree-item {
+  display: flex;
+  align-items: center;
+  gap: var(--mid-space-1);
+  padding: 2px var(--mid-space-2);
+  font-size: var(--mid-font-size-sm);
+  color: var(--mid-fg);
+  cursor: pointer;
+  user-select: none;
+  border-radius: var(--mid-radius-sm);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.mid-tree-item:hover { background: var(--mid-surface-hover); }
+.mid-tree-item.is-active { background: var(--mid-accent); color: var(--mid-accent-fg); }
+.mid-tree-chevron {
+  display: inline-block;
+  width: 12px;
+  text-align: center;
+  color: var(--mid-fg-muted);
+  transition: transform var(--mid-motion-fast) var(--mid-ease-out);
+}
+.mid-tree-chevron.is-open { transform: rotate(90deg); }
+.mid-tree-children { padding-left: var(--mid-space-3); }
+.mid-tree-empty {
+  padding: var(--mid-space-4);
+  text-align: center;
+  color: var(--mid-fg-muted);
+  font-size: var(--mid-font-size-sm);
+}
+
 .mid-titlebar {
   display: grid;
   grid-template-columns: 1fr auto 1fr;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -1,15 +1,30 @@
 import { renderMarkdown as coreRenderMarkdown, applyMermaidPlaceholders } from '../../../packages/core/src/markdown/renderer';
 import mermaid from 'mermaid';
 
+interface TreeEntry {
+  name: string;
+  path: string;
+  kind: 'file' | 'dir';
+  children?: TreeEntry[];
+}
+
+interface AppState {
+  lastFolder?: string;
+}
+
 interface Mid {
   readFile(path: string): Promise<string>;
   writeFile(path: string, content: string): Promise<boolean>;
   openFileDialog(): Promise<{ filePath: string; content: string } | null>;
+  openFolderDialog(): Promise<{ folderPath: string; tree: TreeEntry[] } | null>;
+  listFolderMd(folderPath: string): Promise<TreeEntry[]>;
+  readAppState(): Promise<AppState>;
   saveFileDialog(defaultName: string, content: string): Promise<string | null>;
   getAppInfo(): Promise<{ version: string; platform: string; isDark: boolean; userData: string; documents: string }>;
   openExternal(url: string): Promise<void>;
   onThemeChanged(cb: (isDark: boolean) => void): () => void;
   onMenuOpen(cb: () => void): () => void;
+  onMenuOpenFolder(cb: () => void): () => void;
   onMenuSave(cb: () => void): () => void;
 }
 declare const window: Window & { mid: Mid };
@@ -19,12 +34,19 @@ const filenameEl = document.getElementById('filename') as HTMLSpanElement;
 const btnView = document.getElementById('mode-view') as HTMLButtonElement;
 const btnEdit = document.getElementById('mode-edit') as HTMLButtonElement;
 const btnOpen = document.getElementById('open-btn') as HTMLButtonElement;
+const btnOpenFolder = document.getElementById('open-folder-btn') as HTMLButtonElement;
 const btnSave = document.getElementById('save-btn') as HTMLButtonElement;
+const sidebar = document.getElementById('sidebar') as HTMLElement;
+const sidebarFolderName = document.getElementById('sidebar-folder-name') as HTMLSpanElement;
+const sidebarRefresh = document.getElementById('sidebar-refresh') as HTMLButtonElement;
+const treeRoot = document.getElementById('tree-root') as HTMLDivElement;
 
 let currentText = '';
 let currentPath: string | null = null;
 let currentMode: 'view' | 'edit' = 'view';
 let mermaidThemeKind = 0;
+let currentFolder: string | null = null;
+const expandedDirs = new Set<string>();
 
 function applyTheme(isDark: boolean): void {
   document.documentElement.classList.toggle('dark', isDark);
@@ -54,7 +76,7 @@ function renderView(): void {
   root.classList.remove('editing');
   root.classList.add('viewing');
   if (!currentText) {
-    root.innerHTML = `<div class="empty-state"><h1>Mark It Down</h1><p>Open a markdown file with <kbd>Cmd/Ctrl+O</kbd> to begin.</p></div>`;
+    root.innerHTML = `<div class="empty-state"><h1>Mark It Down</h1><p>Open a folder with <kbd class="mid-kbd">Cmd/Ctrl+Shift+O</kbd> to browse, or open a single file with <kbd class="mid-kbd">Cmd/Ctrl+O</kbd>.</p></div>`;
     return;
   }
   root.innerHTML = renderMarkdown(currentText);
@@ -107,10 +129,96 @@ function setMode(mode: 'view' | 'edit'): void {
 async function openFile(): Promise<void> {
   const result = await window.mid.openFileDialog();
   if (!result) return;
-  currentText = result.content;
-  currentPath = result.filePath;
-  filenameEl.textContent = currentPath.split('/').pop() ?? 'Untitled';
+  loadFileContent(result.filePath, result.content);
+}
+
+function loadFileContent(filePath: string, content: string): void {
+  currentText = content;
+  currentPath = filePath;
+  filenameEl.textContent = filePath.split('/').pop() ?? 'Untitled';
+  highlightActiveTreeItem();
   setMode('view');
+}
+
+async function selectTreeFile(filePath: string): Promise<void> {
+  const content = await window.mid.readFile(filePath);
+  loadFileContent(filePath, content);
+}
+
+async function openFolder(): Promise<void> {
+  const result = await window.mid.openFolderDialog();
+  if (!result) return;
+  applyFolder(result.folderPath, result.tree);
+}
+
+function applyFolder(folderPath: string, tree: TreeEntry[]): void {
+  currentFolder = folderPath;
+  document.body.classList.add('has-sidebar');
+  sidebar.hidden = false;
+  sidebarFolderName.textContent = folderPath.split('/').pop() ?? folderPath;
+  sidebarFolderName.title = folderPath;
+  treeRoot.replaceChildren(...renderTree(tree));
+  if (tree.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'mid-tree-empty';
+    empty.textContent = 'No markdown files in this folder.';
+    treeRoot.appendChild(empty);
+  }
+}
+
+function renderTree(entries: TreeEntry[]): HTMLElement[] {
+  return entries.map(entry => renderTreeEntry(entry));
+}
+
+function renderTreeEntry(entry: TreeEntry): HTMLElement {
+  const wrapper = document.createElement('div');
+  const item = document.createElement('div');
+  item.className = 'mid-tree-item';
+  item.dataset.path = entry.path;
+  item.dataset.kind = entry.kind;
+
+  if (entry.kind === 'dir') {
+    const isOpen = expandedDirs.has(entry.path);
+    const chevron = document.createElement('span');
+    chevron.className = `mid-tree-chevron${isOpen ? ' is-open' : ''}`;
+    chevron.textContent = '▸';
+    item.appendChild(chevron);
+    item.appendChild(document.createTextNode(`📁 ${entry.name}`));
+    item.addEventListener('click', () => {
+      if (expandedDirs.has(entry.path)) expandedDirs.delete(entry.path);
+      else expandedDirs.add(entry.path);
+      const fresh = renderTreeEntry(entry);
+      wrapper.replaceWith(fresh);
+    });
+    wrapper.appendChild(item);
+    if (isOpen && entry.children) {
+      const children = document.createElement('div');
+      children.className = 'mid-tree-children';
+      children.append(...renderTree(entry.children));
+      wrapper.appendChild(children);
+    }
+  } else {
+    const spacer = document.createElement('span');
+    spacer.className = 'mid-tree-chevron';
+    item.appendChild(spacer);
+    item.appendChild(document.createTextNode(`📄 ${entry.name}`));
+    if (currentPath === entry.path) item.classList.add('is-active');
+    item.addEventListener('click', () => void selectTreeFile(entry.path));
+    wrapper.appendChild(item);
+  }
+  return wrapper;
+}
+
+function highlightActiveTreeItem(): void {
+  treeRoot.querySelectorAll<HTMLElement>('.mid-tree-item').forEach(el => {
+    el.classList.toggle('is-active', el.dataset.path === currentPath && el.dataset.kind === 'file');
+  });
+}
+
+async function refreshFolder(): Promise<void> {
+  if (!currentFolder) return;
+  const tree = await window.mid.listFolderMd(currentFolder);
+  treeRoot.replaceChildren(...renderTree(tree));
 }
 
 async function saveFile(): Promise<void> {
@@ -138,13 +246,27 @@ function flashStatus(message: string): void {
 btnView.addEventListener('click', () => setMode('view'));
 btnEdit.addEventListener('click', () => setMode('edit'));
 btnOpen.addEventListener('click', () => void openFile());
+btnOpenFolder.addEventListener('click', () => void openFolder());
 btnSave.addEventListener('click', () => void saveFile());
+sidebarRefresh.addEventListener('click', () => void refreshFolder());
 
 window.mid.onThemeChanged(applyTheme);
 window.mid.onMenuOpen(() => void openFile());
+window.mid.onMenuOpenFolder(() => void openFolder());
 window.mid.onMenuSave(() => void saveFile());
 
 void window.mid.getAppInfo().then(info => {
   document.body.classList.toggle('is-mac', info.platform === 'darwin');
   applyTheme(info.isDark);
+});
+
+void window.mid.readAppState().then(async state => {
+  if (state.lastFolder) {
+    try {
+      const tree = await window.mid.listFolderMd(state.lastFolder);
+      applyFolder(state.lastFolder, tree);
+    } catch {
+      // folder gone — silently ignore
+    }
+  }
 });

--- a/docs/desktop-workspace.md
+++ b/docs/desktop-workspace.md
@@ -1,0 +1,48 @@
+# Desktop workspace — folder mode + file tree sidebar
+
+The desktop app supports a **folder workspace** in addition to the single-file flow. Open a folder once and every `.md` / `.mdx` / `.markdown` file inside is browsable in the sidebar; the choice is persisted across launches so the workspace reopens automatically next time.
+
+## Opening a folder
+
+- **Menu**: File → Open Folder…
+- **Shortcut**: `Cmd/Ctrl+Shift+O`
+- **Toolbar**: 📁 Folder
+
+Single-file open (`Cmd/Ctrl+O`) still works and is independent — it doesn't change the active folder.
+
+## What the sidebar shows
+
+- A recursive tree of markdown files. Folders that contain no markdown (anywhere in their subtree) are hidden so you don't drown in `node_modules` clones.
+- Hidden folders (anything starting with `.`) are skipped, with one exception: `.github` is included for repo workspaces.
+- Standard build / dependency directories are pruned: `node_modules`, `.git`, `.next`, `dist`, `out`, `.cache`.
+- Files are sorted alphabetically; folders sort before files at every level.
+- Click a folder row to expand / collapse; click a file row to load it into the main view.
+- The **↻ Refresh** button in the sidebar header re-reads the folder tree (use it after creating/renaming files outside the app).
+
+## Persistence
+
+The last opened folder is written to `state.json` in the OS user-data dir:
+
+| Platform | Path |
+| --- | --- |
+| macOS | `~/Library/Application Support/Mark It Down/state.json` |
+| Windows | `%APPDATA%/Mark It Down/state.json` |
+| Linux | `~/.config/Mark It Down/state.json` |
+
+On launch, the renderer calls `mid:read-app-state` and re-lists the folder tree. If the folder no longer exists, the workspace silently falls back to single-file mode.
+
+## IPC surface (preload)
+
+| Channel | Signature | Notes |
+| --- | --- | --- |
+| `mid:open-folder-dialog` | `() → { folderPath, tree } \| null` | Shows OS folder picker, persists `lastFolder`, returns initial tree. |
+| `mid:list-folder-md` | `(folderPath) → TreeEntry[]` | Re-list a folder without showing a dialog (used by Refresh and on relaunch). |
+| `mid:read-app-state` | `() → AppState` | Returns `{ lastFolder? }`. |
+
+`TreeEntry` shape: `{ name, path, kind: 'file' | 'dir', children?: TreeEntry[] }`.
+
+## Verifying
+
+1. `npm run dev:electron`, then File → Open Folder… → pick this repo.
+2. Sidebar lists `docs/`, `README.md`, `CHANGELOG.md`, etc. Click `docs/ui-tokens.md` — preview loads.
+3. Quit and relaunch. The sidebar reopens with the same folder selected.


### PR DESCRIPTION
## Summary
- New IPC channels: `mid:open-folder-dialog`, `mid:list-folder-md`, `mid:read-app-state`. State persisted in `userData/state.json`.
- Menu item **File → Open Folder…** with `Cmd/Ctrl+Shift+O` accelerator + a 📁 toolbar button.
- Recursive markdown tree with collapsible folders, prune list (`node_modules`, `.git`, `.next`, etc.), and folder-before-file sort.
- Sidebar shell driven by `body.has-sidebar`, styled with ui-tokens (`.mid-tree-item`, `.mid-tree-chevron`, `.mid-tree-children`).
- Last folder reopens automatically on launch; missing folder falls back gracefully.
- Docs at `docs/desktop-workspace.md`.

Closes #77 — part of #74.

## Test plan
- [ ] `npm run dev:electron` → File → Open Folder… → repo root. Sidebar lists `docs/`, `README.md`, etc.
- [ ] Click a markdown file — loads in the main view; row highlights as active.
- [ ] Refresh button re-reads the tree.
- [ ] Quit and relaunch → sidebar reopens with same folder.
- [ ] `Cmd+O` still opens single files independently of the folder.