### PR TITLE
feat(desktop): markdown polish — highlight.js, copy buttons, heading anchors (#78)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -115,10 +115,18 @@ main.viewing h1, main.viewing h2 {
   border-bottom: 1px solid var(--mid-border);
   padding-bottom: 0.3em;
 }
-main.viewing h1 { font-size: var(--mid-font-size-3xl); margin-top: 0.6em; }
-main.viewing h2 { font-size: var(--mid-font-size-2xl); margin-top: 1.4em; }
-main.viewing h3 { font-size: var(--mid-font-size-xl); }
+main.viewing h1 { font-size: 2em; margin: 0.6em 0 0.4em; line-height: var(--mid-line-tight); }
+main.viewing h2 { font-size: 1.5em; margin: 1.4em 0 0.5em; line-height: var(--mid-line-tight); }
+main.viewing h3 { font-size: 1.25em; margin: 1.2em 0 0.4em; line-height: var(--mid-line-tight); }
+main.viewing h4 { font-size: 1em; margin: 1em 0 0.3em; font-weight: var(--mid-weight-semibold); }
+main.viewing h5 { font-size: 0.875em; margin: 1em 0 0.3em; font-weight: var(--mid-weight-semibold); }
+main.viewing h6 { font-size: 0.85em; margin: 1em 0 0.3em; font-weight: var(--mid-weight-semibold); color: var(--mid-fg-muted); }
 main.viewing p { margin: 0.8em 0; }
+main.viewing ul, main.viewing ol { padding-left: 2em; margin: 0.8em 0; }
+main.viewing li { margin: 0.25em 0; }
+main.viewing li > p { margin: 0.4em 0; }
+main.viewing li.task-list-item { list-style: none; margin-left: -1.5em; }
+main.viewing li.task-list-item input[type="checkbox"] { margin-right: var(--mid-space-2); }
 main.viewing a { color: var(--mid-link); text-decoration: none; }
 main.viewing a:hover { color: var(--mid-link-hover); text-decoration: underline; }
 main.viewing code {
@@ -129,6 +137,7 @@ main.viewing code {
   font-size: 0.9em;
 }
 main.viewing pre {
+  position: relative;
   background: var(--mid-code-bg);
   border: 1px solid var(--mid-border);
   border-radius: var(--mid-radius-md);
@@ -137,6 +146,92 @@ main.viewing pre {
   margin: 1em 0;
 }
 main.viewing pre code { background: transparent; padding: 0; font-size: 0.88em; }
+
+/* Copy button overlay on code blocks */
+.mid-copy-btn {
+  position: absolute;
+  top: var(--mid-space-2);
+  right: var(--mid-space-2);
+  padding: 2px var(--mid-space-2);
+  font-family: var(--mid-font-sans);
+  font-size: var(--mid-font-size-xs);
+  font-weight: var(--mid-weight-medium);
+  color: var(--mid-fg-muted);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--mid-motion-fast) var(--mid-ease-out);
+}
+main.viewing pre:hover .mid-copy-btn,
+.mid-copy-btn:focus-visible { opacity: 1; }
+.mid-copy-btn:hover { background: var(--mid-surface-hover); color: var(--mid-fg); }
+
+/* Heading anchors (#) shown on hover */
+main.viewing h1, main.viewing h2, main.viewing h3,
+main.viewing h4, main.viewing h5, main.viewing h6 {
+  position: relative;
+  scroll-margin-top: var(--mid-space-6);
+}
+.mid-anchor {
+  display: inline-block;
+  margin-left: var(--mid-space-2);
+  padding: 0 var(--mid-space-1);
+  font-weight: var(--mid-weight-normal);
+  color: var(--mid-fg-subtle);
+  text-decoration: none;
+  opacity: 0;
+  transition: opacity var(--mid-motion-fast) var(--mid-ease-out);
+}
+main.viewing h1:hover .mid-anchor,
+main.viewing h2:hover .mid-anchor,
+main.viewing h3:hover .mid-anchor,
+main.viewing h4:hover .mid-anchor,
+main.viewing h5:hover .mid-anchor,
+main.viewing h6:hover .mid-anchor { opacity: 1; }
+.mid-anchor:hover { color: var(--mid-link); text-decoration: none !important; }
+
+/* Image lightbox */
+main.viewing .mid-zoomable { cursor: zoom-in; }
+.mid-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: var(--mid-z-modal);
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.78);
+  cursor: zoom-out;
+  animation: mid-fade-in var(--mid-motion-base) var(--mid-ease-out);
+}
+.mid-lightbox img {
+  max-width: 92%;
+  max-height: 92%;
+  border-radius: var(--mid-radius-md);
+  box-shadow: var(--mid-shadow-lg);
+}
+@keyframes mid-fade-in { from { opacity: 0; } to { opacity: 1; } }
+
+/* Highlight.js theme tied to ui-tokens. Colors mirror GH-light/dark roughly. */
+.hljs { color: var(--mid-fg); background: transparent; }
+.hljs-comment, .hljs-quote { color: var(--mid-fg-muted); font-style: italic; }
+.hljs-keyword, .hljs-selector-tag, .hljs-meta .hljs-keyword { color: #cf222e; font-weight: var(--mid-weight-semibold); }
+.hljs-string, .hljs-attr, .hljs-template-variable, .hljs-regexp { color: #0a3069; }
+.hljs-number, .hljs-literal, .hljs-variable, .hljs-link { color: #0550ae; }
+.hljs-built_in, .hljs-type, .hljs-class .hljs-title { color: #953800; }
+.hljs-title.function_, .hljs-title { color: #8250df; }
+.hljs-tag, .hljs-name, .hljs-selector-id, .hljs-selector-class { color: #116329; }
+.hljs-attribute, .hljs-doctag, .hljs-meta { color: #0550ae; }
+.hljs-emphasis { font-style: italic; }
+.hljs-strong { font-weight: var(--mid-weight-bold); }
+
+:root.dark .hljs-keyword, :root.dark .hljs-selector-tag, :root.dark .hljs-meta .hljs-keyword { color: #ff7b72; }
+:root.dark .hljs-string, :root.dark .hljs-attr, :root.dark .hljs-template-variable, :root.dark .hljs-regexp { color: #a5d6ff; }
+:root.dark .hljs-number, :root.dark .hljs-literal, :root.dark .hljs-variable, :root.dark .hljs-link { color: #79c0ff; }
+:root.dark .hljs-built_in, :root.dark .hljs-type, :root.dark .hljs-class .hljs-title { color: #ffa657; }
+:root.dark .hljs-title.function_, :root.dark .hljs-title { color: #d2a8ff; }
+:root.dark .hljs-tag, :root.dark .hljs-name, :root.dark .hljs-selector-id, :root.dark .hljs-selector-class { color: #7ee787; }
+:root.dark .hljs-attribute, :root.dark .hljs-doctag, :root.dark .hljs-meta { color: #79c0ff; }
 main.viewing blockquote {
   border-left: 3px solid var(--mid-accent);
   padding: var(--mid-space-1) var(--mid-space-4);

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -1,5 +1,6 @@
 import { renderMarkdown as coreRenderMarkdown, applyMermaidPlaceholders } from '../../../packages/core/src/markdown/renderer';
 import mermaid from 'mermaid';
+import hljs from 'highlight.js/lib/common';
 
 interface TreeEntry {
   name: string;
@@ -90,6 +91,10 @@ function renderView(): void {
       });
     }
   });
+  applySyntaxHighlighting(root);
+  attachCodeCopyButtons(root);
+  attachHeadingAnchors(root);
+  attachImageLightbox(root);
   root.querySelectorAll<HTMLDivElement>('.mermaid').forEach((el, i) => {
     const id = `mermaid-${Date.now()}-${i}`;
     const code = (el.textContent ?? '').trim();
@@ -103,6 +108,101 @@ function renderView(): void {
         el.innerHTML = `<pre style="color: #d04444">Mermaid error: ${String((err as Error)?.message ?? err)}</pre>`;
       });
   });
+}
+
+function applySyntaxHighlighting(scope: HTMLElement): void {
+  scope.querySelectorAll<HTMLElement>('pre > code').forEach(block => {
+    if (block.classList.contains('mermaid')) return;
+    try {
+      hljs.highlightElement(block);
+    } catch {
+      // unsupported language — leave plain
+    }
+  });
+}
+
+function attachCodeCopyButtons(scope: HTMLElement): void {
+  scope.querySelectorAll<HTMLPreElement>('pre').forEach(pre => {
+    if (pre.querySelector('.mid-copy-btn')) return;
+    if (pre.classList.contains('mermaid')) return;
+    pre.classList.add('has-copy');
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'mid-copy-btn';
+    btn.textContent = 'Copy';
+    btn.addEventListener('click', async () => {
+      const code = pre.querySelector('code')?.innerText ?? pre.innerText;
+      try {
+        await navigator.clipboard.writeText(code);
+        btn.textContent = 'Copied';
+        setTimeout(() => { btn.textContent = 'Copy'; }, 1200);
+      } catch {
+        btn.textContent = 'Failed';
+        setTimeout(() => { btn.textContent = 'Copy'; }, 1200);
+      }
+    });
+    pre.appendChild(btn);
+  });
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+function attachHeadingAnchors(scope: HTMLElement): void {
+  const seen = new Map<string, number>();
+  scope.querySelectorAll<HTMLHeadingElement>('h1, h2, h3, h4, h5, h6').forEach(h => {
+    const baseSlug = slugify(h.textContent ?? '');
+    if (!baseSlug) return;
+    const count = seen.get(baseSlug) ?? 0;
+    seen.set(baseSlug, count + 1);
+    const slug = count === 0 ? baseSlug : `${baseSlug}-${count}`;
+    h.id = slug;
+    const anchor = document.createElement('a');
+    anchor.className = 'mid-anchor';
+    anchor.href = `#${slug}`;
+    anchor.setAttribute('aria-label', `Anchor link to ${slug}`);
+    anchor.textContent = '#';
+    anchor.addEventListener('click', e => {
+      e.preventDefault();
+      h.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+    h.appendChild(anchor);
+  });
+}
+
+function attachImageLightbox(scope: HTMLElement): void {
+  scope.querySelectorAll<HTMLImageElement>('img').forEach(img => {
+    img.classList.add('mid-zoomable');
+    img.addEventListener('click', () => openLightbox(img.src, img.alt));
+  });
+}
+
+function openLightbox(src: string, alt: string): void {
+  const existing = document.getElementById('mid-lightbox');
+  existing?.remove();
+  const overlay = document.createElement('div');
+  overlay.id = 'mid-lightbox';
+  overlay.className = 'mid-lightbox';
+  const img = document.createElement('img');
+  img.src = src;
+  img.alt = alt;
+  overlay.appendChild(img);
+  const close = (): void => {
+    overlay.remove();
+    document.removeEventListener('keydown', onKey);
+  };
+  const onKey = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') close();
+  };
+  overlay.addEventListener('click', close);
+  document.addEventListener('keydown', onKey);
+  document.body.appendChild(overlay);
 }
 
 function renderEdit(): void {

--- a/docs/desktop-markdown.md
+++ b/docs/desktop-markdown.md
@@ -1,0 +1,33 @@
+# Desktop markdown rendering
+
+Polished GitHub-flavored rendering for the desktop view. Built on top of the core renderer in `packages/core/src/markdown` with desktop-only post-processors.
+
+## What's enabled
+
+| Feature | How |
+| --- | --- |
+| **Syntax highlighting** | `highlight.js/lib/common` (~30 languages, tree-shaken). After `renderMarkdown`, walks every `pre > code` and runs `hljs.highlightElement`. Mermaid blocks are skipped. |
+| **Copy buttons** | A `Copy` button is appended to every `<pre>` (top-right, fades in on hover). Uses the Clipboard API; falls back to `Failed` if denied. |
+| **Heading anchors** | Each heading gets a slug `id`; a `#` link appears next to the heading on hover and scrolls to it. Duplicate slugs in the same doc get `-1`, `-2` suffixes. |
+| **Image lightbox** | All `<img>` get a `cursor: zoom-in` and click into a fixed overlay (Esc or click-anywhere closes). |
+| **GitHub typography** | h1–h6 sized like `github.com/.../README`; tighter line-height on headings; task-list checkboxes flush-left. |
+
+## Theme integration
+
+The hljs token colors are embedded directly in `renderer.css`, keyed off `:root` and `:root.dark`. They mirror GitHub's dark/light palettes loosely — close enough that the effect feels native without pulling a 30 KB hljs theme stylesheet into the bundle.
+
+A future pass can wire the per-theme `hljsCss.ts` map (already used by the published-site themes) to let users pick their code palette in the desktop too.
+
+## Files
+
+- `apps/electron/renderer/renderer.ts` — `applySyntaxHighlighting`, `attachCodeCopyButtons`, `attachHeadingAnchors`, `attachImageLightbox`, `openLightbox`.
+- `apps/electron/renderer/renderer.css` — copy-button overlay, anchor link, lightbox overlay, hljs token colors, GH-style headings + task lists.
+
+## Verifying
+
+Open any markdown file with code blocks (e.g., `docs/desktop-workspace.md`):
+
+- Code blocks have colored tokens and a Copy button on hover.
+- Hover a heading → `#` appears; click it → scrolls + URL hash updates.
+- Click an image → lightbox; Esc to close.
+- Toggle macOS dark mode → both the markdown chrome and the hljs palette flip together.


### PR DESCRIPTION
## Summary
- Wired `highlight.js/lib/common` for syntax highlighting in code blocks (mermaid skipped). Tree-shaken bundle ~30 langs.
- Copy button overlay on every `<pre>`, fades in on hover, uses Clipboard API with failure feedback.
- Heading anchors: every h1-h6 gets a slug `id` + a `#` link that appears on hover. Duplicate slugs disambiguated with `-1`, `-2`.
- Image lightbox: `<img>` becomes zoom-in cursor; click opens a full-screen overlay; Esc or click-anywhere closes.
- GitHub-style typography: tighter heading line-heights, task-list checkboxes flush-left, list spacing tuned.
- Embedded hljs theme uses light/dark palettes inline (no extra stylesheet to ship).
- Docs at `docs/desktop-markdown.md`.

Closes #78 — part of #74.

## Test plan
- [ ] Open `docs/desktop-workspace.md` (or any md with code) — code blocks have colored tokens.
- [ ] Hover a code block — Copy button appears top-right; click it copies the code.
- [ ] Hover a heading — `#` link appears; click scrolls and updates URL hash.
- [ ] Click an image — lightbox opens; Esc closes.
- [ ] Toggle macOS dark mode — token colors flip with the chrome.