### PR TITLE
feat(desktop): split-pane live preview (#79)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -94,6 +94,10 @@ ipcMain.handle('mid:list-folder-md', async (_e, folderPath: string) => {
 
 ipcMain.handle('mid:read-app-state', async () => readAppState());
 
+ipcMain.handle('mid:patch-app-state', async (_e, patch: Partial<AppState>) => {
+  await writeAppState(patch);
+});
+
 ipcMain.handle('mid:save-file-dialog', async (_e, defaultName: string, content: string) => {
   const result = await dialog.showSaveDialog({
     defaultPath: defaultName,
@@ -216,6 +220,7 @@ function broadcastUpdateState(): void {
 
 interface AppState {
   lastFolder?: string;
+  splitRatio?: number;
 }
 
 const MD_EXT = new Set(['.md', '.mdx', '.markdown']);

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -17,6 +17,7 @@ export interface TreeEntry {
 
 export interface AppState {
   lastFolder?: string;
+  splitRatio?: number;
 }
 
 contextBridge.exposeInMainWorld('mid', {
@@ -30,6 +31,8 @@ contextBridge.exposeInMainWorld('mid', {
   listFolderMd: (folderPath: string): Promise<TreeEntry[]> =>
     ipcRenderer.invoke('mid:list-folder-md', folderPath),
   readAppState: (): Promise<AppState> => ipcRenderer.invoke('mid:read-app-state'),
+  patchAppState: (patch: Partial<AppState>): Promise<void> =>
+    ipcRenderer.invoke('mid:patch-app-state', patch),
   saveFileDialog: (defaultName: string, content: string): Promise<string | null> =>
     ipcRenderer.invoke('mid:save-file-dialog', defaultName, content),
   getAppInfo: (): Promise<AppInfo> => ipcRenderer.invoke('mid:get-app-info'),

--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -20,7 +20,8 @@
     <span id="filename" class="mid-filename">Untitled</span>
   </div>
   <div class="mid-titlebar-right">
-    <button id="mode-view" class="mid-btn is-active">📖 View</button>
+    <button id="mode-view" class="mid-btn">📖 View</button>
+    <button id="mode-split" class="mid-btn is-active">⫶ Split</button>
     <button id="mode-edit" class="mid-btn">✏️ Edit</button>
   </div>
 </header>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -105,38 +105,81 @@ body.is-mac .mid-titlebar { padding-left: 80px; }
   border-color: var(--mid-accent);
 }
 
-main { overflow: auto; }
-main.viewing {
+main { overflow: hidden; min-height: 0; }
+main.viewing { overflow: auto; }
+main.viewing > .mid-preview {
   padding: var(--mid-space-8) var(--mid-space-12) var(--mid-space-12);
   max-width: 920px;
   margin: 0 auto;
 }
-main.viewing h1, main.viewing h2 {
+main.splitting { display: block; height: 100%; }
+main.splitting .mid-preview {
+  padding: var(--mid-space-6) var(--mid-space-8) var(--mid-space-12);
+  overflow: auto;
+  height: 100%;
+}
+
+.mid-split {
+  display: grid;
+  grid-template-columns: 50% 6px 1fr;
+  height: 100%;
+  min-height: 0;
+}
+.mid-split-editor {
+  width: 100%;
+  height: 100%;
+  padding: var(--mid-space-4) var(--mid-space-6);
+  font-family: var(--mid-font-mono);
+  font-size: 14px;
+  line-height: 1.55;
+  background: var(--mid-bg);
+  color: var(--mid-fg);
+  border: 0;
+  outline: none;
+  resize: none;
+  tab-size: 2;
+  white-space: pre;
+  overflow: auto;
+}
+.mid-split-handle {
+  background: var(--mid-border);
+  cursor: col-resize;
+  position: relative;
+  transition: background var(--mid-motion-fast) var(--mid-ease-out);
+}
+.mid-split-handle:hover { background: var(--mid-accent); }
+.mid-split-handle::before {
+  content: "";
+  position: absolute;
+  inset: 0 -3px;
+}
+.mid-split-preview { border-left: 1px solid var(--mid-border); }
+.mid-preview h1, .mid-preview h2 {
   border-bottom: 1px solid var(--mid-border);
   padding-bottom: 0.3em;
 }
-main.viewing h1 { font-size: 2em; margin: 0.6em 0 0.4em; line-height: var(--mid-line-tight); }
-main.viewing h2 { font-size: 1.5em; margin: 1.4em 0 0.5em; line-height: var(--mid-line-tight); }
-main.viewing h3 { font-size: 1.25em; margin: 1.2em 0 0.4em; line-height: var(--mid-line-tight); }
-main.viewing h4 { font-size: 1em; margin: 1em 0 0.3em; font-weight: var(--mid-weight-semibold); }
-main.viewing h5 { font-size: 0.875em; margin: 1em 0 0.3em; font-weight: var(--mid-weight-semibold); }
-main.viewing h6 { font-size: 0.85em; margin: 1em 0 0.3em; font-weight: var(--mid-weight-semibold); color: var(--mid-fg-muted); }
-main.viewing p { margin: 0.8em 0; }
-main.viewing ul, main.viewing ol { padding-left: 2em; margin: 0.8em 0; }
-main.viewing li { margin: 0.25em 0; }
-main.viewing li > p { margin: 0.4em 0; }
-main.viewing li.task-list-item { list-style: none; margin-left: -1.5em; }
-main.viewing li.task-list-item input[type="checkbox"] { margin-right: var(--mid-space-2); }
-main.viewing a { color: var(--mid-link); text-decoration: none; }
-main.viewing a:hover { color: var(--mid-link-hover); text-decoration: underline; }
-main.viewing code {
+.mid-preview h1 { font-size: 2em; margin: 0.6em 0 0.4em; line-height: var(--mid-line-tight); }
+.mid-preview h2 { font-size: 1.5em; margin: 1.4em 0 0.5em; line-height: var(--mid-line-tight); }
+.mid-preview h3 { font-size: 1.25em; margin: 1.2em 0 0.4em; line-height: var(--mid-line-tight); }
+.mid-preview h4 { font-size: 1em; margin: 1em 0 0.3em; font-weight: var(--mid-weight-semibold); }
+.mid-preview h5 { font-size: 0.875em; margin: 1em 0 0.3em; font-weight: var(--mid-weight-semibold); }
+.mid-preview h6 { font-size: 0.85em; margin: 1em 0 0.3em; font-weight: var(--mid-weight-semibold); color: var(--mid-fg-muted); }
+.mid-preview p { margin: 0.8em 0; }
+.mid-preview ul, .mid-preview ol { padding-left: 2em; margin: 0.8em 0; }
+.mid-preview li { margin: 0.25em 0; }
+.mid-preview li > p { margin: 0.4em 0; }
+.mid-preview li.task-list-item { list-style: none; margin-left: -1.5em; }
+.mid-preview li.task-list-item input[type="checkbox"] { margin-right: var(--mid-space-2); }
+.mid-preview a { color: var(--mid-link); text-decoration: none; }
+.mid-preview a:hover { color: var(--mid-link-hover); text-decoration: underline; }
+.mid-preview code {
   background: var(--mid-inline-code-bg);
   padding: 2px 6px;
   border-radius: var(--mid-radius-sm);
   font-family: var(--mid-font-mono);
   font-size: 0.9em;
 }
-main.viewing pre {
+.mid-preview pre {
   position: relative;
   background: var(--mid-code-bg);
   border: 1px solid var(--mid-border);
@@ -145,7 +188,7 @@ main.viewing pre {
   overflow-x: auto;
   margin: 1em 0;
 }
-main.viewing pre code { background: transparent; padding: 0; font-size: 0.88em; }
+.mid-preview pre code { background: transparent; padding: 0; font-size: 0.88em; }
 
 /* Copy button overlay on code blocks */
 .mid-copy-btn {
@@ -164,13 +207,13 @@ main.viewing pre code { background: transparent; padding: 0; font-size: 0.88em; 
   opacity: 0;
   transition: opacity var(--mid-motion-fast) var(--mid-ease-out);
 }
-main.viewing pre:hover .mid-copy-btn,
+.mid-preview pre:hover .mid-copy-btn,
 .mid-copy-btn:focus-visible { opacity: 1; }
 .mid-copy-btn:hover { background: var(--mid-surface-hover); color: var(--mid-fg); }
 
 /* Heading anchors (#) shown on hover */
-main.viewing h1, main.viewing h2, main.viewing h3,
-main.viewing h4, main.viewing h5, main.viewing h6 {
+.mid-preview h1, .mid-preview h2, .mid-preview h3,
+.mid-preview h4, .mid-preview h5, .mid-preview h6 {
   position: relative;
   scroll-margin-top: var(--mid-space-6);
 }
@@ -184,16 +227,16 @@ main.viewing h4, main.viewing h5, main.viewing h6 {
   opacity: 0;
   transition: opacity var(--mid-motion-fast) var(--mid-ease-out);
 }
-main.viewing h1:hover .mid-anchor,
-main.viewing h2:hover .mid-anchor,
-main.viewing h3:hover .mid-anchor,
-main.viewing h4:hover .mid-anchor,
-main.viewing h5:hover .mid-anchor,
-main.viewing h6:hover .mid-anchor { opacity: 1; }
+.mid-preview h1:hover .mid-anchor,
+.mid-preview h2:hover .mid-anchor,
+.mid-preview h3:hover .mid-anchor,
+.mid-preview h4:hover .mid-anchor,
+.mid-preview h5:hover .mid-anchor,
+.mid-preview h6:hover .mid-anchor { opacity: 1; }
 .mid-anchor:hover { color: var(--mid-link); text-decoration: none !important; }
 
 /* Image lightbox */
-main.viewing .mid-zoomable { cursor: zoom-in; }
+.mid-preview .mid-zoomable { cursor: zoom-in; }
 .mid-lightbox {
   position: fixed;
   inset: 0;
@@ -232,7 +275,7 @@ main.viewing .mid-zoomable { cursor: zoom-in; }
 :root.dark .hljs-title.function_, :root.dark .hljs-title { color: #d2a8ff; }
 :root.dark .hljs-tag, :root.dark .hljs-name, :root.dark .hljs-selector-id, :root.dark .hljs-selector-class { color: #7ee787; }
 :root.dark .hljs-attribute, :root.dark .hljs-doctag, :root.dark .hljs-meta { color: #79c0ff; }
-main.viewing blockquote {
+.mid-preview blockquote {
   border-left: 3px solid var(--mid-accent);
   padding: var(--mid-space-1) var(--mid-space-4);
   margin: 1em 0;
@@ -240,26 +283,26 @@ main.viewing blockquote {
   background: var(--mid-code-bg);
   border-radius: 0 var(--mid-radius-md) var(--mid-radius-md) 0;
 }
-main.viewing table {
+.mid-preview table {
   border-collapse: collapse;
   width: 100%;
   margin: 1em 0;
   font-size: 0.95em;
 }
-main.viewing th, main.viewing td {
+.mid-preview th, .mid-preview td {
   padding: var(--mid-space-2) var(--mid-space-3);
   border: 1px solid var(--mid-border);
   text-align: left;
 }
-main.viewing th { background: var(--mid-code-bg); font-weight: var(--mid-weight-semibold); }
-main.viewing tr:nth-child(even) td { background: var(--mid-table-stripe); }
-main.viewing img { max-width: 100%; border-radius: var(--mid-radius-sm); }
-main.viewing hr {
+.mid-preview th { background: var(--mid-code-bg); font-weight: var(--mid-weight-semibold); }
+.mid-preview tr:nth-child(even) td { background: var(--mid-table-stripe); }
+.mid-preview img { max-width: 100%; border-radius: var(--mid-radius-sm); }
+.mid-preview hr {
   border: 0;
   border-top: 1px solid var(--mid-border);
   margin: var(--mid-space-8) 0;
 }
-main.viewing .mermaid {
+.mid-preview .mermaid {
   background: var(--mid-code-bg);
   border: 1px solid var(--mid-border);
   border-radius: var(--mid-radius-md);
@@ -269,7 +312,7 @@ main.viewing .mermaid {
   overflow-x: auto;
 }
 
-main.editing { padding: 0; max-width: none; }
+main.editing { padding: 0; max-width: none; display: block; height: 100%; }
 main.editing textarea {
   width: 100%;
   height: 100%;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -11,6 +11,7 @@ interface TreeEntry {
 
 interface AppState {
   lastFolder?: string;
+  splitRatio?: number;
 }
 
 interface Mid {
@@ -20,6 +21,7 @@ interface Mid {
   openFolderDialog(): Promise<{ folderPath: string; tree: TreeEntry[] } | null>;
   listFolderMd(folderPath: string): Promise<TreeEntry[]>;
   readAppState(): Promise<AppState>;
+  patchAppState(patch: Partial<AppState>): Promise<void>;
   saveFileDialog(defaultName: string, content: string): Promise<string | null>;
   getAppInfo(): Promise<{ version: string; platform: string; isDark: boolean; userData: string; documents: string }>;
   openExternal(url: string): Promise<void>;
@@ -30,9 +32,12 @@ interface Mid {
 }
 declare const window: Window & { mid: Mid };
 
+type Mode = 'view' | 'edit' | 'split';
+
 const root = document.getElementById('root') as HTMLElement;
 const filenameEl = document.getElementById('filename') as HTMLSpanElement;
 const btnView = document.getElementById('mode-view') as HTMLButtonElement;
+const btnSplit = document.getElementById('mode-split') as HTMLButtonElement;
 const btnEdit = document.getElementById('mode-edit') as HTMLButtonElement;
 const btnOpen = document.getElementById('open-btn') as HTMLButtonElement;
 const btnOpenFolder = document.getElementById('open-folder-btn') as HTMLButtonElement;
@@ -44,9 +49,11 @@ const treeRoot = document.getElementById('tree-root') as HTMLDivElement;
 
 let currentText = '';
 let currentPath: string | null = null;
-let currentMode: 'view' | 'edit' = 'view';
+let currentMode: Mode = 'split';
 let mermaidThemeKind = 0;
 let currentFolder: string | null = null;
+let splitRatio = 0.5;
+let renderTimer: number | null = null;
 const expandedDirs = new Set<string>();
 
 function applyTheme(isDark: boolean): void {
@@ -73,15 +80,26 @@ function renderMarkdown(md: string): string {
   return container.innerHTML;
 }
 
+function emptyStateHTML(): string {
+  return `<div class="empty-state"><h1>Mark It Down</h1><p>Open a folder with <kbd class="mid-kbd">Cmd/Ctrl+Shift+O</kbd> to browse, or open a single file with <kbd class="mid-kbd">Cmd/Ctrl+O</kbd>.</p></div>`;
+}
+
 function renderView(): void {
-  root.classList.remove('editing');
+  root.classList.remove('editing', 'splitting');
   root.classList.add('viewing');
   if (!currentText) {
-    root.innerHTML = `<div class="empty-state"><h1>Mark It Down</h1><p>Open a folder with <kbd class="mid-kbd">Cmd/Ctrl+Shift+O</kbd> to browse, or open a single file with <kbd class="mid-kbd">Cmd/Ctrl+O</kbd>.</p></div>`;
+    root.innerHTML = emptyStateHTML();
     return;
   }
-  root.innerHTML = renderMarkdown(currentText);
-  root.querySelectorAll<HTMLAnchorElement>('a[href]').forEach(a => {
+  const preview = document.createElement('div');
+  preview.className = 'mid-preview';
+  populatePreview(preview);
+  root.replaceChildren(preview);
+}
+
+function populatePreview(preview: HTMLElement): void {
+  preview.innerHTML = renderMarkdown(currentText);
+  preview.querySelectorAll<HTMLAnchorElement>('a[href]').forEach(a => {
     const href = a.getAttribute('href');
     if (!href) return;
     if (href.startsWith('http://') || href.startsWith('https://')) {
@@ -91,11 +109,11 @@ function renderView(): void {
       });
     }
   });
-  applySyntaxHighlighting(root);
-  attachCodeCopyButtons(root);
-  attachHeadingAnchors(root);
-  attachImageLightbox(root);
-  root.querySelectorAll<HTMLDivElement>('.mermaid').forEach((el, i) => {
+  applySyntaxHighlighting(preview);
+  attachCodeCopyButtons(preview);
+  attachHeadingAnchors(preview);
+  attachImageLightbox(preview);
+  preview.querySelectorAll<HTMLDivElement>('.mermaid').forEach((el, i) => {
     const id = `mermaid-${Date.now()}-${i}`;
     const code = (el.textContent ?? '').trim();
     el.removeAttribute('data-processed');
@@ -206,24 +224,94 @@ function openLightbox(src: string, alt: string): void {
 }
 
 function renderEdit(): void {
-  root.classList.remove('viewing');
+  root.classList.remove('viewing', 'splitting');
   root.classList.add('editing');
+  const ta = buildEditor();
+  root.replaceChildren(ta);
+  ta.focus();
+}
+
+function renderSplit(): void {
+  root.classList.remove('viewing', 'editing');
+  root.classList.add('splitting');
+  if (!currentText && !currentPath) {
+    root.innerHTML = emptyStateHTML();
+    return;
+  }
+  const wrap = document.createElement('div');
+  wrap.className = 'mid-split';
+  wrap.style.gridTemplateColumns = `${splitRatio * 100}% 6px 1fr`;
+
+  const editor = buildEditor();
+  editor.classList.add('mid-split-editor');
+
+  const handle = document.createElement('div');
+  handle.className = 'mid-split-handle';
+  handle.setAttribute('role', 'separator');
+  handle.setAttribute('aria-orientation', 'vertical');
+  handle.addEventListener('mousedown', e => beginSplitDrag(e, wrap));
+
+  const preview = document.createElement('div');
+  preview.className = 'mid-preview mid-split-preview';
+  populatePreview(preview);
+
+  editor.addEventListener('input', () => {
+    currentText = editor.value;
+    scheduleSplitRender(preview);
+  });
+
+  editor.addEventListener('scroll', () => {
+    const ratio = editor.scrollTop / Math.max(1, editor.scrollHeight - editor.clientHeight);
+    preview.scrollTop = ratio * Math.max(0, preview.scrollHeight - preview.clientHeight);
+  });
+
+  wrap.append(editor, handle, preview);
+  root.replaceChildren(wrap);
+}
+
+function buildEditor(): HTMLTextAreaElement {
   const ta = document.createElement('textarea');
   ta.value = currentText;
   ta.spellcheck = false;
   ta.addEventListener('input', () => {
     currentText = ta.value;
   });
-  root.replaceChildren(ta);
-  ta.focus();
+  return ta;
 }
 
-function setMode(mode: 'view' | 'edit'): void {
+function scheduleSplitRender(preview: HTMLElement): void {
+  if (renderTimer !== null) window.clearTimeout(renderTimer);
+  renderTimer = window.setTimeout(() => {
+    populatePreview(preview);
+    renderTimer = null;
+  }, 50);
+}
+
+function beginSplitDrag(start: MouseEvent, wrap: HTMLElement): void {
+  start.preventDefault();
+  const wrapRect = wrap.getBoundingClientRect();
+  const onMove = (e: MouseEvent): void => {
+    const ratio = (e.clientX - wrapRect.left) / wrapRect.width;
+    splitRatio = Math.max(0.15, Math.min(0.85, ratio));
+    wrap.style.gridTemplateColumns = `${splitRatio * 100}% 6px 1fr`;
+  };
+  const onUp = (): void => {
+    document.removeEventListener('mousemove', onMove);
+    document.removeEventListener('mouseup', onUp);
+    void window.mid.patchAppState({ splitRatio });
+  };
+  document.addEventListener('mousemove', onMove);
+  document.addEventListener('mouseup', onUp);
+}
+
+function setMode(mode: Mode): void {
   currentMode = mode;
   btnView.classList.toggle('is-active', mode === 'view');
+  btnSplit.classList.toggle('is-active', mode === 'split');
   btnEdit.classList.toggle('is-active', mode === 'edit');
   if (mode === 'view') renderView();
-  else renderEdit();
+  else if (mode === 'edit') renderEdit();
+  else renderSplit();
 }
 
 async function openFile(): Promise<void> {
@@ -237,7 +325,7 @@ function loadFileContent(filePath: string, content: string): void {
   currentPath = filePath;
   filenameEl.textContent = filePath.split('/').pop() ?? 'Untitled';
   highlightActiveTreeItem();
-  setMode('view');
+  setMode(currentMode === 'view' && content.length > 0 ? 'split' : currentMode);
 }
 
 async function selectTreeFile(filePath: string): Promise<void> {
@@ -344,6 +432,7 @@ function flashStatus(message: string): void {
 }
 
 btnView.addEventListener('click', () => setMode('view'));
+btnSplit.addEventListener('click', () => setMode('split'));
 btnEdit.addEventListener('click', () => setMode('edit'));
 btnOpen.addEventListener('click', () => void openFile());
 btnOpenFolder.addEventListener('click', () => void openFolder());
@@ -361,6 +450,9 @@ void window.mid.getAppInfo().then(info => {
 });
 
 void window.mid.readAppState().then(async state => {
+  if (typeof state.splitRatio === 'number' && state.splitRatio > 0 && state.splitRatio < 1) {
+    splitRatio = state.splitRatio;
+  }
   if (state.lastFolder) {
     try {
       const tree = await window.mid.listFolderMd(state.lastFolder);
@@ -369,4 +461,5 @@ void window.mid.readAppState().then(async state => {
       // folder gone — silently ignore
     }
   }
+  setMode(currentMode);
 });

--- a/docs/desktop-split-preview.md
+++ b/docs/desktop-split-preview.md
@@ -1,0 +1,47 @@
+# Desktop split-pane live preview
+
+The desktop app has three render modes — **View**, **Split**, and **Edit**. Split is the default once a file is open: a textarea on the left, live preview on the right, separated by a draggable handle.
+
+## Modes
+
+| Toolbar | Behavior |
+| --- | --- |
+| 📖 View | Read-only rendered preview, max-width centered. |
+| ⫶ Split (default) | Editor + preview side by side. Edits update preview after a 50 ms idle debounce. |
+| ✏️ Edit | Full-width editor only. |
+
+Loading a file from the sidebar or `Cmd+O` flips the active mode to Split (unless you're already in Edit, in which case it stays).
+
+## Resize handle
+
+A 6 px column between the editor and preview is `cursor: col-resize`. Drag to change the split between **15%** and **85%**. Release to persist — the chosen `splitRatio` is written to `state.json` so the next launch reopens at the same proportion.
+
+## Synchronized scroll
+
+Best-effort scroll sync: when the editor scrolls, the preview scrolls to the same percentage of its scrollable height. Heading-aware sync is intentionally out of scope for v1 — the percentage approach handles long files well enough.
+
+## Debounced rendering
+
+Each `input` event schedules a 50 ms timer. Subsequent inputs reset it. When the timer fires, the preview is fully repopulated (markdown → HTML → highlight.js → mermaid → copy buttons → heading anchors → image lightbox). 50 ms keeps typing feeling instant while skipping multi-render storms during fast input.
+
+## State persistence
+
+| Field | Type | Default |
+| --- | --- | --- |
+| `splitRatio` | number (0.15–0.85) | 0.5 |
+
+Stored alongside `lastFolder` in `state.json`. Patched via the new `mid:patch-app-state` IPC.
+
+## Files
+
+- `apps/electron/main.ts` — `mid:patch-app-state`, `splitRatio` in `AppState`.
+- `apps/electron/preload.ts` — `patchAppState` bridge.
+- `apps/electron/renderer/renderer.ts` — `Mode` union, `renderSplit`, `beginSplitDrag`, `scheduleSplitRender`, `populatePreview`.
+- `apps/electron/renderer/renderer.css` — `.mid-split`, `.mid-split-editor`, `.mid-split-handle`, `.mid-split-preview`.
+
+## Verifying
+
+1. `npm run dev:electron` → open a folder → open a markdown file → app lands in Split mode.
+2. Type in the left editor — preview updates after a brief pause.
+3. Drag the handle — proportions change. Quit and relaunch — handle is back where you left it.
+4. Click View — preview takes the full width. Click Edit — editor takes the full width. Click Split — back to side-by-side.


### PR DESCRIPTION
## Summary
- Three modes — View / **Split (default)** / Edit. Split lands by default when a file is opened.
- Split layout: textarea | 6px draggable handle | live preview, all consuming the new `.mid-preview` scope so markdown styles work in both view and split modes.
- Resize handle clamps to 15-85%, persists to `state.json` via new `mid:patch-app-state` IPC.
- 50 ms debounced re-render on input — typing stays smooth, multi-render storms skipped.
- Best-effort percentage scroll sync between editor and preview.
- Markdown styles refactored from `main.viewing` to `.mid-preview` so they apply in either mode.
- Docs at `docs/desktop-split-preview.md`.

Closes #79 — part of #74.

## Test plan
- [ ] `npm run dev:electron` → open folder → open `docs/desktop-workspace.md` → lands in Split.
- [ ] Type — preview updates after a short pause; code blocks re-highlight.
- [ ] Drag the handle — left/right widths change; release; relaunch — handle stays where you left it.
- [ ] Click View — full-width preview. Click Edit — full-width editor. Click Split — back.
- [ ] Scroll the editor — preview tracks proportionally.