### PR TITLE
feat(desktop): in-app Settings panel (#90)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -248,6 +248,10 @@ function broadcastUpdateState(): void {
 interface AppState {
   lastFolder?: string;
   splitRatio?: number;
+  fontFamily?: 'system' | 'sans' | 'serif' | 'mono';
+  fontSize?: number;
+  theme?: 'auto' | 'light' | 'dark' | 'sepia';
+  previewMaxWidth?: number;
 }
 
 const MD_EXT = new Set(['.md', '.mdx', '.markdown']);

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -18,6 +18,10 @@ export interface TreeEntry {
 export interface AppState {
   lastFolder?: string;
   splitRatio?: number;
+  fontFamily?: 'system' | 'sans' | 'serif' | 'mono';
+  fontSize?: number;
+  theme?: 'auto' | 'light' | 'dark' | 'sepia';
+  previewMaxWidth?: number;
 }
 
 contextBridge.exposeInMainWorld('mid', {

--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -24,8 +24,46 @@
     <button id="mode-view" class="mid-btn" title="View" data-icon="show" data-label="View"></button>
     <button id="mode-split" class="mid-btn is-active" title="Split (default)" data-icon="columns" data-label="Split"></button>
     <button id="mode-edit" class="mid-btn" title="Edit" data-icon="edit" data-label="Edit"></button>
+    <button id="settings-btn" class="mid-btn mid-btn--icon mid-btn--ghost" title="Settings (Cmd/Ctrl+,)" data-icon="cog"></button>
   </div>
 </header>
+<aside class="mid-settings" id="settings-panel" hidden aria-label="Settings">
+  <header class="mid-settings-header">
+    <h2 class="mid-settings-title">Settings</h2>
+    <button id="settings-close" class="mid-btn mid-btn--icon mid-btn--ghost" title="Close" data-icon="x"></button>
+  </header>
+  <div class="mid-settings-body">
+    <section class="mid-settings-section">
+      <label class="mid-settings-label" for="setting-theme">Theme</label>
+      <select id="setting-theme" class="mid-settings-control">
+        <option value="auto">Auto (follow OS)</option>
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+        <option value="sepia">Sepia</option>
+      </select>
+    </section>
+    <section class="mid-settings-section">
+      <label class="mid-settings-label" for="setting-font">Font family</label>
+      <select id="setting-font" class="mid-settings-control">
+        <option value="system">System</option>
+        <option value="sans">Sans-serif (Inter-style)</option>
+        <option value="serif">Serif (Georgia)</option>
+        <option value="mono">Monospace</option>
+      </select>
+    </section>
+    <section class="mid-settings-section">
+      <label class="mid-settings-label" for="setting-font-size">Body font size <span id="setting-font-size-value" class="mid-settings-hint">15px</span></label>
+      <input id="setting-font-size" class="mid-settings-control" type="range" min="12" max="22" step="1" />
+    </section>
+    <section class="mid-settings-section">
+      <label class="mid-settings-label" for="setting-preview-width">Preview max-width <span id="setting-preview-width-value" class="mid-settings-hint">920px</span></label>
+      <input id="setting-preview-width" class="mid-settings-control" type="range" min="600" max="1400" step="20" />
+    </section>
+    <section class="mid-settings-section">
+      <button id="settings-reset" class="mid-btn">Reset to defaults</button>
+    </section>
+  </div>
+</aside>
 <div class="mid-shell">
   <aside class="mid-sidebar" id="sidebar" hidden>
     <div class="mid-sidebar-header">

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -111,7 +111,7 @@ main { overflow: hidden; min-height: 0; }
 main.viewing { overflow: auto; }
 main.viewing > .mid-preview {
   padding: var(--mid-space-8) var(--mid-space-12) var(--mid-space-12);
-  max-width: 920px;
+  max-width: var(--mid-preview-max-width, 920px);
   margin: 0 auto;
 }
 main.splitting { display: block; height: 100%; }
@@ -156,6 +156,72 @@ main.splitting .mid-preview {
   inset: 0 -3px;
 }
 .mid-split-preview { border-left: 1px solid var(--mid-border); }
+
+/* Settings panel — slide-in overlay from the right */
+.mid-settings {
+  position: fixed;
+  top: var(--mid-titlebar-h);
+  right: 0;
+  bottom: 0;
+  width: 360px;
+  z-index: var(--mid-z-modal);
+  background: var(--mid-surface);
+  border-left: 1px solid var(--mid-border);
+  box-shadow: var(--mid-shadow-lg);
+  display: flex;
+  flex-direction: column;
+  animation: mid-slide-in var(--mid-motion-base) var(--mid-ease-out);
+}
+.mid-settings[hidden] { display: none; }
+@keyframes mid-slide-in {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
+}
+.mid-settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--mid-space-3) var(--mid-space-4);
+  border-bottom: 1px solid var(--mid-border);
+}
+.mid-settings-title {
+  margin: 0;
+  font-size: var(--mid-font-size-lg);
+  font-weight: var(--mid-weight-semibold);
+}
+.mid-settings-body {
+  flex: 1;
+  overflow: auto;
+  padding: var(--mid-space-3) var(--mid-space-4) var(--mid-space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-5);
+}
+.mid-settings-section { display: flex; flex-direction: column; gap: var(--mid-space-2); }
+.mid-settings-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: var(--mid-font-size-sm);
+  font-weight: var(--mid-weight-medium);
+  color: var(--mid-fg);
+}
+.mid-settings-hint {
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+  font-weight: var(--mid-weight-normal);
+}
+.mid-settings-control {
+  font-family: inherit;
+  font-size: var(--mid-font-size-sm);
+  padding: var(--mid-space-1) var(--mid-space-2);
+  background: var(--mid-bg);
+  color: var(--mid-fg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
+}
+.mid-settings-control[type="range"] { padding: 0; accent-color: var(--mid-accent); }
+.mid-settings-control:focus-visible { outline: 2px solid var(--mid-accent); outline-offset: 2px; border-color: var(--mid-accent); }
 .mid-preview h1, .mid-preview h2 {
   border-bottom: 1px solid var(--mid-border);
   padding-bottom: 0.3em;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -10,10 +10,31 @@ interface TreeEntry {
   children?: TreeEntry[];
 }
 
+type FontFamilyChoice = 'system' | 'sans' | 'serif' | 'mono';
+type ThemeChoice = 'auto' | 'light' | 'dark' | 'sepia';
+
 interface AppState {
   lastFolder?: string;
   splitRatio?: number;
+  fontFamily?: FontFamilyChoice;
+  fontSize?: number;
+  theme?: ThemeChoice;
+  previewMaxWidth?: number;
 }
+
+const DEFAULT_SETTINGS = {
+  fontFamily: 'system' as FontFamilyChoice,
+  fontSize: 15,
+  theme: 'auto' as ThemeChoice,
+  previewMaxWidth: 920,
+};
+
+const FONT_STACKS: Record<FontFamilyChoice, string> = {
+  system: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+  sans: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+  serif: 'Georgia, "Iowan Old Style", "Apple Garamond", Charter, serif',
+  mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+};
 
 interface Mid {
   readFile(path: string): Promise<string>;
@@ -55,11 +76,37 @@ let mermaidThemeKind = 0;
 let currentFolder: string | null = null;
 let splitRatio = 0.5;
 let renderTimer: number | null = null;
+let osIsDark = false;
+const settings = { ...DEFAULT_SETTINGS };
 const expandedDirs = new Set<string>();
 
 function applyTheme(isDark: boolean): void {
-  document.documentElement.classList.toggle('dark', isDark);
-  initMermaid(isDark ? 2 : 1);
+  osIsDark = isDark;
+  applyResolvedTheme();
+}
+
+function applyResolvedTheme(): void {
+  const root = document.documentElement;
+  root.classList.remove('dark', 'sepia');
+  let resolvedDark = false;
+  if (settings.theme === 'dark') {
+    root.classList.add('dark');
+    resolvedDark = true;
+  } else if (settings.theme === 'sepia') {
+    root.classList.add('sepia');
+  } else if (settings.theme === 'auto' && osIsDark) {
+    root.classList.add('dark');
+    resolvedDark = true;
+  }
+  initMermaid(resolvedDark ? 2 : 1);
+}
+
+function applySettings(): void {
+  const root = document.documentElement;
+  root.style.setProperty('--mid-font-sans', FONT_STACKS[settings.fontFamily]);
+  root.style.setProperty('--mid-font-size-base', `${settings.fontSize}px`);
+  root.style.setProperty('--mid-preview-max-width', `${settings.previewMaxWidth}px`);
+  applyResolvedTheme();
 }
 
 function initMermaid(themeKind: number): void {
@@ -448,6 +495,76 @@ window.mid.onMenuOpenFolder(() => void openFolder());
 window.mid.onMenuSave(() => void saveFile());
 
 hydrateIconButtons(document);
+wireSettingsPanel();
+
+function wireSettingsPanel(): void {
+  const panel = document.getElementById('settings-panel') as HTMLElement;
+  const openBtn = document.getElementById('settings-btn') as HTMLButtonElement;
+  const closeBtn = document.getElementById('settings-close') as HTMLButtonElement;
+  const themeSel = document.getElementById('setting-theme') as HTMLSelectElement;
+  const fontSel = document.getElementById('setting-font') as HTMLSelectElement;
+  const sizeRange = document.getElementById('setting-font-size') as HTMLInputElement;
+  const sizeVal = document.getElementById('setting-font-size-value') as HTMLSpanElement;
+  const widthRange = document.getElementById('setting-preview-width') as HTMLInputElement;
+  const widthVal = document.getElementById('setting-preview-width-value') as HTMLSpanElement;
+  const resetBtn = document.getElementById('settings-reset') as HTMLButtonElement;
+
+  const syncFromSettings = (): void => {
+    themeSel.value = settings.theme;
+    fontSel.value = settings.fontFamily;
+    sizeRange.value = String(settings.fontSize);
+    sizeVal.textContent = `${settings.fontSize}px`;
+    widthRange.value = String(settings.previewMaxWidth);
+    widthVal.textContent = `${settings.previewMaxWidth}px`;
+  };
+
+  const persist = (patch: Partial<typeof settings>): void => {
+    Object.assign(settings, patch);
+    applySettings();
+    void window.mid.patchAppState(patch);
+  };
+
+  const open = (): void => {
+    syncFromSettings();
+    panel.hidden = false;
+    document.body.classList.add('settings-open');
+  };
+  const close = (): void => {
+    panel.hidden = true;
+    document.body.classList.remove('settings-open');
+  };
+
+  openBtn.addEventListener('click', () => (panel.hidden ? open() : close()));
+  closeBtn.addEventListener('click', close);
+
+  themeSel.addEventListener('change', () => persist({ theme: themeSel.value as ThemeChoice }));
+  fontSel.addEventListener('change', () => persist({ fontFamily: fontSel.value as FontFamilyChoice }));
+  sizeRange.addEventListener('input', () => {
+    const n = Number(sizeRange.value);
+    sizeVal.textContent = `${n}px`;
+    persist({ fontSize: n });
+  });
+  widthRange.addEventListener('input', () => {
+    const n = Number(widthRange.value);
+    widthVal.textContent = `${n}px`;
+    persist({ previewMaxWidth: n });
+  });
+  resetBtn.addEventListener('click', () => {
+    Object.assign(settings, DEFAULT_SETTINGS);
+    applySettings();
+    syncFromSettings();
+    void window.mid.patchAppState({ ...DEFAULT_SETTINGS });
+  });
+
+  document.addEventListener('keydown', e => {
+    if ((e.metaKey || e.ctrlKey) && e.key === ',') {
+      e.preventDefault();
+      panel.hidden ? open() : close();
+    } else if (e.key === 'Escape' && !panel.hidden) {
+      close();
+    }
+  });
+}
 
 function hydrateIconButtons(scope: ParentNode): void {
   scope.querySelectorAll<HTMLElement>('[data-icon]').forEach(el => {
@@ -468,6 +585,15 @@ void window.mid.readAppState().then(async state => {
   if (typeof state.splitRatio === 'number' && state.splitRatio > 0 && state.splitRatio < 1) {
     splitRatio = state.splitRatio;
   }
+  if (state.fontFamily) settings.fontFamily = state.fontFamily;
+  if (typeof state.fontSize === 'number' && state.fontSize >= 12 && state.fontSize <= 22) {
+    settings.fontSize = state.fontSize;
+  }
+  if (state.theme) settings.theme = state.theme;
+  if (typeof state.previewMaxWidth === 'number' && state.previewMaxWidth >= 600 && state.previewMaxWidth <= 1400) {
+    settings.previewMaxWidth = state.previewMaxWidth;
+  }
+  applySettings();
   if (state.lastFolder) {
     try {
       const tree = await window.mid.listFolderMd(state.lastFolder);

--- a/docs/desktop-settings.md
+++ b/docs/desktop-settings.md
@@ -1,0 +1,48 @@
+# Desktop Settings panel
+
+A slide-in panel from the right side of the window lets the user adjust **theme, font family, body font size, and preview max-width**. Open it with the gear icon in the title bar or `Cmd/Ctrl+,`. Close with the × button or `Esc`.
+
+## Settings
+
+| Setting | Type | Values | Default |
+| --- | --- | --- | --- |
+| **Theme** | select | `auto` (follow OS) / `light` / `dark` / `sepia` | `auto` |
+| **Font family** | select | `system` / `sans` (Inter-style) / `serif` (Georgia) / `mono` | `system` |
+| **Body font size** | slider | 12–22 px | 15 px |
+| **Preview max-width** | slider | 600–1400 px | 920 px |
+
+Each control writes its change immediately — no Save button. State is persisted to `state.json` via `mid:patch-app-state`, so the next launch comes back with the same look.
+
+## How values are applied
+
+`applySettings()` writes inline custom properties to `:root`:
+
+| Setting | CSS variable | Source |
+| --- | --- | --- |
+| Font family | `--mid-font-sans` | `FONT_STACKS[choice]` in `renderer.ts` |
+| Font size | `--mid-font-size-base` | `<n>px` |
+| Preview width | `--mid-preview-max-width` | consumed by `main.viewing > .mid-preview` |
+| Theme | `<html class="dark|sepia">` | `applyResolvedTheme()` |
+
+The `auto` theme listens to `nativeTheme.shouldUseDarkColors` (already wired in `apps/electron/main.ts`) and toggles `dark` when the OS flips. `light`, `dark`, and `sepia` ignore the OS.
+
+## Sepia
+
+A new `:root.sepia` block in `tokens.css` ships a warm-paper palette (warm fg `#433422`, paper bg `#f4ecd8`, amber accent `#a06b2a`). It's a third class alongside `dark` and is applied by `applyResolvedTheme()`.
+
+## Reset to defaults
+
+The "Reset to defaults" button writes the `DEFAULT_SETTINGS` block back to state and re-applies — useful after experimenting with extreme font sizes.
+
+## Keyboard
+
+- `Cmd/Ctrl + ,` — toggle the panel.
+- `Esc` — close (only when the panel is open).
+
+## Files
+
+- `apps/electron/renderer/index.html` — gear button + `<aside id="settings-panel">` shell.
+- `apps/electron/renderer/renderer.ts` — `wireSettingsPanel()`, `applySettings()`, `applyResolvedTheme()`, `FONT_STACKS`, `DEFAULT_SETTINGS`.
+- `apps/electron/renderer/renderer.css` — `.mid-settings*` styles, slide-in animation.
+- `packages/ui-tokens/src/tokens.css` — `:root.sepia` palette block.
+- `apps/electron/main.ts` / `preload.ts` — `AppState` extended with `fontFamily`/`fontSize`/`theme`/`previewMaxWidth`.

--- a/packages/ui-tokens/src/tokens.css
+++ b/packages/ui-tokens/src/tokens.css
@@ -118,3 +118,25 @@
   --mid-shadow-md: 0 3px 6px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.25);
   --mid-shadow-lg: 0 10px 24px rgba(0, 0, 0, 0.5);
 }
+
+:root.sepia {
+  color-scheme: light;
+
+  --mid-bg: #f4ecd8;
+  --mid-surface: #ebe1c7;
+  --mid-surface-hover: #ddd2b3;
+  --mid-surface-active: #cec1a0;
+  --mid-fg: #433422;
+  --mid-fg-muted: #6f5d44;
+  --mid-fg-subtle: #8a7758;
+  --mid-border: #c8b894;
+  --mid-border-strong: #b09f7c;
+  --mid-accent: #a06b2a;
+  --mid-accent-fg: #fdf8ec;
+  --mid-accent-hover: #7e521c;
+  --mid-link: #8a4a14;
+  --mid-link-hover: #6a3a10;
+  --mid-code-bg: #ebe1c7;
+  --mid-inline-code-bg: rgba(160, 107, 42, 0.18);
+  --mid-table-stripe: #ebe1c7;
+}


### PR DESCRIPTION
## Summary
- Slide-in Settings panel from the right (360 px), opened by gear icon in title bar or `Cmd/Ctrl+,`, closed by × or `Esc`.
- Four controls: theme (auto / light / dark / sepia), font family (system / sans / serif / mono), body font size (12–22 px slider), preview max-width (600–1400 px slider). Live-applied; no Save button.
- New `:root.sepia` palette in `tokens.css` (warm paper).
- Each setting writes through `mid:patch-app-state` to `state.json`; restored on next launch.
- `applyResolvedTheme()` honours `auto` (OS) vs explicit theme; `applySettings()` writes inline custom properties (`--mid-font-sans`, `--mid-font-size-base`, `--mid-preview-max-width`).
- Reset button restores defaults.
- Docs at `docs/desktop-settings.md`.

Closes #90 — part of #87.

## Test plan
- [ ] Click gear → panel slides in. `Cmd/Ctrl+,` toggles. `Esc` closes.
- [ ] Change theme to Sepia — palette switches to warm paper.
- [ ] Change font to Serif — body re-renders in Georgia.
- [ ] Drag font-size slider — preview text resizes live.
- [ ] Drag preview-width — view-mode column widens / narrows.
- [ ] Quit and relaunch — last theme + font + sliders restored.
- [ ] Reset to defaults works.