### PR TITLE
feat(markdown): YAML frontmatter, GH alerts, KaTeX math (#91)

### DIFF
--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="tokens.css" />
 <link rel="stylesheet" href="icons.css" />
 <link rel="stylesheet" href="primitives.css" />
+<link rel="stylesheet" href="katex.css" />
 <link rel="stylesheet" href="renderer.css" />
 </head>
 <body>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -222,6 +222,68 @@ main.splitting .mid-preview {
 }
 .mid-settings-control[type="range"] { padding: 0; accent-color: var(--mid-accent); }
 .mid-settings-control:focus-visible { outline: 2px solid var(--mid-accent); outline-offset: 2px; border-color: var(--mid-accent); }
+
+/* Frontmatter meta block */
+.mid-frontmatter {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: var(--mid-space-1) var(--mid-space-4);
+  padding: var(--mid-space-3) var(--mid-space-4);
+  margin: 0 0 var(--mid-space-6);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-left: 3px solid var(--mid-accent);
+  border-radius: var(--mid-radius-md);
+  font-size: var(--mid-font-size-sm);
+}
+.mid-fm-row { display: contents; }
+.mid-fm-key {
+  font-weight: var(--mid-weight-semibold);
+  color: var(--mid-fg-muted);
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}
+.mid-fm-val { color: var(--mid-fg); word-break: break-word; }
+
+/* GH-flavored alerts */
+.mid-alert {
+  border-left-width: 4px;
+  border-radius: 0 var(--mid-radius-md) var(--mid-radius-md) 0;
+  background: var(--mid-surface);
+  color: var(--mid-fg);
+}
+.mid-alert .mid-alert-header {
+  display: flex;
+  align-items: center;
+  gap: var(--mid-space-1);
+  font-weight: var(--mid-weight-semibold);
+  font-size: var(--mid-font-size-sm);
+  margin-bottom: var(--mid-space-1);
+}
+.mid-alert--note { border-left-color: #0969da; }
+.mid-alert--note .mid-alert-header { color: #0969da; }
+.mid-alert--tip { border-left-color: #1a7f37; }
+.mid-alert--tip .mid-alert-header { color: #1a7f37; }
+.mid-alert--important { border-left-color: #8250df; }
+.mid-alert--important .mid-alert-header { color: #8250df; }
+.mid-alert--warning { border-left-color: #9a6700; }
+.mid-alert--warning .mid-alert-header { color: #9a6700; }
+.mid-alert--caution { border-left-color: #d1242f; }
+.mid-alert--caution .mid-alert-header { color: #d1242f; }
+:root.dark .mid-alert--note { border-left-color: #2f81f7; }
+:root.dark .mid-alert--note .mid-alert-header { color: #2f81f7; }
+:root.dark .mid-alert--tip { border-left-color: #3fb950; }
+:root.dark .mid-alert--tip .mid-alert-header { color: #3fb950; }
+:root.dark .mid-alert--important { border-left-color: #a371f7; }
+:root.dark .mid-alert--important .mid-alert-header { color: #a371f7; }
+:root.dark .mid-alert--warning { border-left-color: #d29922; }
+:root.dark .mid-alert--warning .mid-alert-header { color: #d29922; }
+:root.dark .mid-alert--caution { border-left-color: #f85149; }
+:root.dark .mid-alert--caution .mid-alert-header { color: #f85149; }
+
+/* KaTeX math integration */
+.katex-display { overflow-x: auto; overflow-y: hidden; padding: var(--mid-space-2) 0; margin: var(--mid-space-3) 0; }
+.mid-math-error { color: var(--mid-danger); }
 .mid-preview h1, .mid-preview h2 {
   border-bottom: 1px solid var(--mid-border);
   padding-bottom: 0.3em;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -1,6 +1,8 @@
 import { renderMarkdown as coreRenderMarkdown, applyMermaidPlaceholders } from '../../../packages/core/src/markdown/renderer';
 import mermaid from 'mermaid';
 import hljs from 'highlight.js/lib/common';
+import katex from 'katex';
+import yaml from 'js-yaml';
 import { iconHTML, IconName } from '../../../packages/ui-tokens/src/icons';
 
 interface TreeEntry {
@@ -120,12 +122,47 @@ function initMermaid(themeKind: number): void {
   mermaidThemeKind = themeKind;
 }
 
+function extractFrontmatter(md: string): { meta?: Record<string, unknown>; body: string } {
+  const m = /^---\r?\n([\s\S]+?)\r?\n---\r?\n?/.exec(md);
+  if (!m) return { body: md };
+  try {
+    const parsed = yaml.load(m[1]);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return { meta: parsed as Record<string, unknown>, body: md.slice(m[0].length) };
+    }
+  } catch {
+    // Invalid YAML — render raw.
+  }
+  return { body: md };
+}
+
+function renderFrontmatterHTML(meta: Record<string, unknown>): string {
+  const rows = Object.entries(meta)
+    .map(([k, v]) => {
+      const valueText = Array.isArray(v) ? v.join(', ') : typeof v === 'object' && v !== null ? JSON.stringify(v) : String(v);
+      return `<div class="mid-fm-row"><span class="mid-fm-key">${escapeHTML(k)}</span><span class="mid-fm-val">${escapeHTML(valueText)}</span></div>`;
+    })
+    .join('');
+  return `<aside class="mid-frontmatter" aria-label="Frontmatter">${rows}</aside>`;
+}
+
+function escapeHTML(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function renderMarkdown(md: string): string {
-  const { html, mermaidBlocks } = coreRenderMarkdown(md);
+  const { meta, body } = extractFrontmatter(md);
+  const { html, mermaidBlocks } = coreRenderMarkdown(body);
   const container = document.createElement('div');
   container.innerHTML = html;
   applyMermaidPlaceholders(container, mermaidBlocks);
-  return container.innerHTML;
+  const fmHTML = meta ? renderFrontmatterHTML(meta) : '';
+  return fmHTML + container.innerHTML;
 }
 
 function emptyStateHTML(): string {
@@ -161,6 +198,8 @@ function populatePreview(preview: HTMLElement): void {
   attachCodeCopyButtons(preview);
   attachHeadingAnchors(preview);
   attachImageLightbox(preview);
+  attachAlerts(preview);
+  attachMath(preview);
   preview.querySelectorAll<HTMLDivElement>('.mermaid').forEach((el, i) => {
     const id = `mermaid-${Date.now()}-${i}`;
     const code = (el.textContent ?? '').trim();
@@ -245,6 +284,70 @@ function attachHeadingAnchors(scope: HTMLElement): void {
     });
     h.appendChild(anchor);
   });
+}
+
+const ALERT_ICONS: Record<string, IconName> = {
+  note: 'list-ul',
+  tip: 'bookmark',
+  important: 'link',
+  warning: 'tag',
+  caution: 'x',
+};
+
+function attachAlerts(scope: HTMLElement): void {
+  scope.querySelectorAll('blockquote').forEach(bq => {
+    const firstP = bq.querySelector('p');
+    if (!firstP) return;
+    const m = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*/.exec(firstP.textContent ?? '');
+    if (!m) return;
+    const type = m[1].toLowerCase();
+    bq.classList.add('mid-alert', `mid-alert--${type}`);
+    firstP.innerHTML = firstP.innerHTML.replace(/^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*/, '');
+    const header = document.createElement('div');
+    header.className = 'mid-alert-header';
+    header.innerHTML = `${iconHTML(ALERT_ICONS[type] ?? 'list-ul', 'mid-icon--sm')}<span>${m[1].charAt(0)}${m[1].slice(1).toLowerCase()}</span>`;
+    bq.insertBefore(header, bq.firstChild);
+    if (firstP.textContent?.trim() === '') firstP.remove();
+  });
+}
+
+function attachMath(scope: HTMLElement): void {
+  const walker = document.createTreeWalker(scope, NodeFilter.SHOW_TEXT, {
+    acceptNode(node: Text) {
+      if (!node.textContent || !/\$/.test(node.textContent)) return NodeFilter.FILTER_REJECT;
+      let p = node.parentElement;
+      while (p) {
+        const tag = p.tagName;
+        if (tag === 'CODE' || tag === 'PRE' || tag === 'SCRIPT' || tag === 'STYLE') return NodeFilter.FILTER_REJECT;
+        p = p.parentElement;
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+  const targets: Text[] = [];
+  let n: Node | null = walker.nextNode();
+  while (n) {
+    targets.push(n as Text);
+    n = walker.nextNode();
+  }
+  for (const text of targets) {
+    const original = text.textContent ?? '';
+    const replaced = original
+      .replace(/\$\$([\s\S]+?)\$\$/g, (_, expr) => renderKatex(expr.trim(), true))
+      .replace(/(?<!\$)\$([^$\n]+?)\$(?!\$)/g, (_, expr) => renderKatex(expr.trim(), false));
+    if (replaced === original) continue;
+    const wrap = document.createElement('span');
+    wrap.innerHTML = replaced;
+    text.replaceWith(...Array.from(wrap.childNodes));
+  }
+}
+
+function renderKatex(expr: string, displayMode: boolean): string {
+  try {
+    return katex.renderToString(expr, { displayMode, throwOnError: false, output: 'html' });
+  } catch (err) {
+    return `<code class="mid-math-error" title="${escapeHTML(String((err as Error).message))}">${escapeHTML(expr)}</code>`;
+  }
 }
 
 function attachImageLightbox(scope: HTMLElement): void {

--- a/docs/markdown-features.md
+++ b/docs/markdown-features.md
@@ -1,0 +1,89 @@
+# Markdown features (desktop)
+
+The desktop renderer extends the core marked-based renderer (`packages/core/src/markdown`) with three GitHub-flavored features that aren't in plain GFM:
+
+## 1. YAML frontmatter
+
+A leading `---\n…\n---` block is parsed as YAML and rendered as a styled meta panel **above** the body. The keys are presented as a two-column grid; arrays are joined with commas; objects are JSON-stringified.
+
+````markdown
+---
+title: Project notes
+date: 2026-04-30
+tags: [planning, mvp]
+status: draft
+---
+
+# Body content
+````
+
+If the frontmatter is malformed YAML, the original text is preserved verbatim and the meta block is skipped.
+
+## 2. GitHub-style alerts
+
+A blockquote whose first paragraph begins with `[!TYPE]` becomes a colored alert. Five types are supported, mirroring github.com:
+
+| Marker | Color |
+| --- | --- |
+| `[!NOTE]` | blue |
+| `[!TIP]` | green |
+| `[!IMPORTANT]` | purple |
+| `[!WARNING]` | amber |
+| `[!CAUTION]` | red |
+
+The marker is stripped from the rendered text and a labeled icon header is prepended.
+
+```markdown
+> [!WARNING]
+> Don't run this in production.
+```
+
+Each alert gets `.mid-alert` and `.mid-alert--<type>` classes for styling.
+
+## 3. KaTeX math
+
+Inline math: `$ E = mc^2 $`. Display math: `$$ \\int_a^b f(x)\\,dx $$`.
+
+Math is processed **after** the markdown render via a TreeWalker that scans text nodes (skipping nodes inside `<code>`, `<pre>`, `<script>`, `<style>`). Each `$$…$$` is replaced with KaTeX display-mode HTML; each `$…$` with inline-mode HTML. Errors render as a red `<code class="mid-math-error">` with the parser message in the title attribute.
+
+KaTeX's stylesheet ships next to the renderer (`out/electron/renderer/katex.css`); its fonts are copied to `out/electron/renderer/fonts/` so `font-src 'self'` in the CSP is enough.
+
+## Out of scope (follow-up)
+
+- **Footnotes** (`[^1]` markers + `[^1]: definition` blocks) — needs a marked extension; tracked separately.
+- **Definition lists** (`Term\\n: Definition`) — same; rare in practice and best handled at parse time.
+
+## Files
+
+- `apps/electron/renderer/renderer.ts` — `extractFrontmatter`, `renderFrontmatterHTML`, `attachAlerts`, `attachMath`, `renderKatex`.
+- `apps/electron/renderer/renderer.css` — `.mid-frontmatter*`, `.mid-alert*`, `.katex-display`, `.mid-math-error`.
+- `scripts/copy-electron-assets.mjs` — copies `katex.min.css` + KaTeX fonts into the renderer out dir.
+- `apps/electron/renderer/index.html` — links `katex.css`.
+
+## Verifying
+
+Open a markdown file with all three features:
+
+````markdown
+---
+title: Smoke test
+date: 2026-04-30
+tags: [test, demo]
+---
+
+# Headline
+
+> [!NOTE]
+> Frontmatter parses, alerts colorize, math renders.
+
+Inline: $a^2 + b^2 = c^2$.
+
+Display:
+
+$$ \\int_0^\\infty e^{-x^2}\\,dx = \\frac{\\sqrt{\\pi}}{2} $$
+
+> [!WARNING]
+> Production check before merging.
+````
+
+You should see: a meta panel (title/date/tags), a blue NOTE box, KaTeX-rendered Pythagoras inline + Gauss integral display, and an amber WARNING box.

--- a/scripts/copy-electron-assets.mjs
+++ b/scripts/copy-electron-assets.mjs
@@ -1,4 +1,4 @@
-import { mkdirSync, copyFileSync } from 'node:fs';
+import { mkdirSync, copyFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 const out = 'out/electron/renderer';
@@ -10,5 +10,14 @@ const copies = [
   ['packages/ui-tokens/src/tokens.css', join(out, 'tokens.css')],
   ['packages/ui-tokens/src/primitives.css', join(out, 'primitives.css')],
   ['packages/ui-tokens/src/icons.css', join(out, 'icons.css')],
+  ['node_modules/katex/dist/katex.min.css', join(out, 'katex.css')],
 ];
 for (const [src, dest] of copies) copyFileSync(src, dest);
+
+// Copy KaTeX fonts (the stylesheet references them via relative URLs).
+const fontsSrc = 'node_modules/katex/dist/fonts';
+const fontsDest = join(out, 'fonts');
+mkdirSync(fontsDest, { recursive: true });
+for (const f of readdirSync(fontsSrc)) {
+  copyFileSync(join(fontsSrc, f), join(fontsDest, f));
+}


### PR DESCRIPTION
## Summary
- **Frontmatter**: leading `---\n…\n---` block parsed via `js-yaml` and rendered as a styled meta panel above the body.
- **GH alerts**: `> [!NOTE|TIP|IMPORTANT|WARNING|CAUTION]` blockquotes become labeled, color-coded alert boxes with icon headers.
- **KaTeX math**: `$…$` inline and `$$…$$` display, post-processed via a TreeWalker that skips code/pre. KaTeX stylesheet + fonts copied to the renderer out dir; CSP `font-src 'self'` covers them.
- Footnotes and definition lists tracked as a follow-up — they need marked extensions and weren't in the high-value path.
- Docs at `docs/markdown-features.md` (with a smoke-test sample).

Closes #91 — part of #87.

## Test plan
- [ ] Open a md file with `---\ntitle:…\n---` frontmatter — meta panel shows above the body.
- [ ] `> [!WARNING]\n> ...` renders as an amber alert with icon + label.
- [ ] `$ E=mc^2 $` renders inline math; `$$ \\int … $$` renders display math.
- [ ] Code blocks with `$` (e.g. shell vars) are NOT processed.