### PR TITLE
feat(desktop): code-block toolbar — language label, line numbers, download, PNG export (#92)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -320,29 +320,77 @@ main.splitting .mid-preview {
 }
 .mid-preview pre code { background: transparent; padding: 0; font-size: 0.88em; }
 
-/* Copy button overlay on code blocks */
-.mid-copy-btn {
+/* Code-block toolbar (Copy / Download / Image / Lines) + language badge */
+.mid-pre { padding-top: var(--mid-space-6); }
+.mid-pre.with-lines {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: var(--mid-space-3);
+  align-items: start;
+}
+.mid-pre.with-lines .mid-code-gutter { display: block; }
+
+.mid-code-lang {
   position: absolute;
   top: var(--mid-space-2);
-  right: var(--mid-space-2);
-  display: inline-flex;
-  align-items: center;
-  gap: var(--mid-space-1);
-  padding: 2px var(--mid-space-2);
-  font-family: var(--mid-font-sans);
-  font-size: var(--mid-font-size-xs);
-  font-weight: var(--mid-weight-medium);
+  left: var(--mid-space-3);
+  padding: 1px var(--mid-space-2);
+  font-family: var(--mid-font-mono);
+  font-size: 10px;
+  font-weight: var(--mid-weight-semibold);
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
   color: var(--mid-fg-muted);
   background: var(--mid-surface);
   border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-pill);
+}
+
+.mid-code-toolbar {
+  position: absolute;
+  top: var(--mid-space-2);
+  right: var(--mid-space-2);
+  display: flex;
+  gap: 2px;
+  padding: 2px;
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
   border-radius: var(--mid-radius-sm);
-  cursor: pointer;
   opacity: 0;
   transition: opacity var(--mid-motion-fast) var(--mid-ease-out);
 }
-.mid-preview pre:hover .mid-copy-btn,
-.mid-copy-btn:focus-visible { opacity: 1; }
-.mid-copy-btn:hover { background: var(--mid-surface-hover); color: var(--mid-fg); }
+.mid-pre:hover .mid-code-toolbar,
+.mid-code-toolbar:focus-within { opacity: 1; }
+.mid-code-tool-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mid-space-1);
+  padding: 2px var(--mid-space-1);
+  font-family: var(--mid-font-sans);
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+  background: transparent;
+  border: 0;
+  border-radius: var(--mid-radius-xs);
+  cursor: pointer;
+}
+.mid-code-tool-btn:hover { background: var(--mid-surface-hover); color: var(--mid-fg); }
+.mid-code-tool-flash {
+  font-size: var(--mid-font-size-xs);
+  font-weight: var(--mid-weight-medium);
+}
+
+.mid-code-gutter {
+  display: none;
+  white-space: pre;
+  font-family: var(--mid-font-mono);
+  font-size: 0.88em;
+  color: var(--mid-fg-subtle);
+  user-select: none;
+  text-align: right;
+  border-right: 1px solid var(--mid-border);
+  padding-right: var(--mid-space-2);
+}
 
 /* Heading anchors (#) shown on hover */
 .mid-preview h1, .mid-preview h2, .mid-preview h3,

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -3,6 +3,7 @@ import mermaid from 'mermaid';
 import hljs from 'highlight.js/lib/common';
 import katex from 'katex';
 import yaml from 'js-yaml';
+import { toPng } from 'html-to-image';
 import { iconHTML, IconName } from '../../../packages/ui-tokens/src/icons';
 
 interface TreeEntry {
@@ -195,7 +196,7 @@ function populatePreview(preview: HTMLElement): void {
     }
   });
   applySyntaxHighlighting(preview);
-  attachCodeCopyButtons(preview);
+  attachCodeBlockToolbar(preview);
   attachHeadingAnchors(preview);
   attachImageLightbox(preview);
   attachAlerts(preview);
@@ -226,33 +227,120 @@ function applySyntaxHighlighting(scope: HTMLElement): void {
   });
 }
 
-function attachCodeCopyButtons(scope: HTMLElement): void {
+const LANG_TO_EXT: Record<string, string> = {
+  typescript: 'ts', ts: 'ts',
+  javascript: 'js', js: 'js',
+  jsx: 'jsx', tsx: 'tsx',
+  python: 'py', py: 'py',
+  ruby: 'rb', rb: 'rb',
+  shell: 'sh', sh: 'sh', bash: 'sh', zsh: 'sh',
+  json: 'json', yaml: 'yml', yml: 'yml',
+  markdown: 'md', md: 'md',
+  html: 'html', xml: 'xml', css: 'css', scss: 'scss',
+  go: 'go', rust: 'rs', rs: 'rs',
+  java: 'java', kotlin: 'kt', swift: 'swift',
+  c: 'c', cpp: 'cpp', 'c++': 'cpp', csharp: 'cs', cs: 'cs',
+  sql: 'sql',
+  php: 'php',
+  diff: 'diff',
+  dockerfile: 'Dockerfile',
+  makefile: 'mk',
+};
+
+function detectCodeLanguage(code: HTMLElement): string | undefined {
+  for (const cls of code.classList) {
+    if (cls.startsWith('language-')) {
+      const lang = cls.slice('language-'.length).toLowerCase();
+      if (lang && lang !== 'plaintext') return lang;
+    }
+  }
+  return undefined;
+}
+
+function attachCodeBlockToolbar(scope: HTMLElement): void {
   scope.querySelectorAll<HTMLPreElement>('pre').forEach(pre => {
-    if (pre.querySelector('.mid-copy-btn')) return;
+    if (pre.dataset.midToolbar === '1') return;
     if (pre.classList.contains('mermaid')) return;
-    pre.classList.add('has-copy');
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'mid-copy-btn';
-    btn.title = 'Copy';
-    btn.innerHTML = `${iconHTML('copy', 'mid-icon--sm')}<span class="mid-copy-btn-label">Copy</span>`;
-    const setLabel = (text: string): void => {
-      const label = btn.querySelector('.mid-copy-btn-label');
-      if (label) label.textContent = text;
-    };
-    btn.addEventListener('click', async () => {
-      const code = pre.querySelector('code')?.innerText ?? pre.innerText;
-      try {
-        await navigator.clipboard.writeText(code);
-        setLabel('Copied');
-        setTimeout(() => setLabel('Copy'), 1200);
-      } catch {
-        setLabel('Failed');
-        setTimeout(() => setLabel('Copy'), 1200);
-      }
-    });
-    pre.appendChild(btn);
+    const code = pre.querySelector<HTMLElement>('code');
+    if (!code) return;
+    pre.dataset.midToolbar = '1';
+    pre.classList.add('mid-pre');
+
+    const lang = detectCodeLanguage(code);
+    if (lang) {
+      const badge = document.createElement('span');
+      badge.className = 'mid-code-lang';
+      badge.textContent = lang;
+      pre.appendChild(badge);
+    }
+
+    const toolbar = document.createElement('div');
+    toolbar.className = 'mid-code-toolbar';
+    toolbar.append(
+      makeIconButton('list-ul', 'Toggle line numbers', () => pre.classList.toggle('with-lines')),
+      makeIconButton('copy', 'Copy', async (btn) => {
+        await navigator.clipboard.writeText(code.innerText).then(
+          () => flashButton(btn, 'copy', 'Copied'),
+          () => flashButton(btn, 'x', 'Failed'),
+        );
+      }),
+      makeIconButton('download', 'Download', () => downloadCode(code.innerText, lang)),
+      makeIconButton('image', 'Export PNG', () => void exportCodeBlockAsPNG(pre)),
+    );
+    pre.appendChild(toolbar);
+
+    addLineNumbers(pre, code);
   });
+}
+
+function makeIconButton(icon: IconName, title: string, onClick: (btn: HTMLButtonElement) => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'mid-code-tool-btn';
+  btn.title = title;
+  btn.setAttribute('aria-label', title);
+  btn.innerHTML = iconHTML(icon, 'mid-icon--sm');
+  btn.addEventListener('click', () => onClick(btn));
+  return btn;
+}
+
+function flashButton(btn: HTMLButtonElement, finalIcon: IconName, label: string): void {
+  const original = btn.innerHTML;
+  btn.innerHTML = `${iconHTML(finalIcon, 'mid-icon--sm')}<span class="mid-code-tool-flash">${label}</span>`;
+  setTimeout(() => { btn.innerHTML = original; }, 1200);
+}
+
+function downloadCode(text: string, lang?: string): void {
+  const ext = (lang && LANG_TO_EXT[lang]) ?? 'txt';
+  const isExtensionlessName = ext === 'Dockerfile' || ext === 'mk';
+  const filename = isExtensionlessName ? ext : `snippet.${ext}`;
+  const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+async function exportCodeBlockAsPNG(pre: HTMLPreElement): Promise<void> {
+  const dataUrl = await toPng(pre, {
+    pixelRatio: 2,
+    backgroundColor: getComputedStyle(document.documentElement).getPropertyValue('--mid-code-bg').trim() || '#0d1117',
+  });
+  const a = document.createElement('a');
+  a.href = dataUrl;
+  a.download = 'code.png';
+  a.click();
+}
+
+function addLineNumbers(pre: HTMLPreElement, code: HTMLElement): void {
+  const lines = (code.textContent ?? '').replace(/\n$/, '').split('\n').length;
+  const gutter = document.createElement('span');
+  gutter.className = 'mid-code-gutter';
+  gutter.setAttribute('aria-hidden', 'true');
+  gutter.textContent = Array.from({ length: lines }, (_, i) => String(i + 1)).join('\n');
+  pre.insertBefore(gutter, code);
 }
 
 function slugify(text: string): string {

--- a/docs/code-blocks.md
+++ b/docs/code-blocks.md
@@ -1,0 +1,40 @@
+# Code-block toolbar
+
+Each rendered `<pre>` (excluding mermaid blocks) gets:
+
+- A **language badge** in the top-left, lowercase, derived from `language-<n>` on the inner `<code>`. Hidden when no language is declared.
+- A floating **toolbar** in the top-right that fades in on hover with four actions:
+
+| Icon | Action |
+| --- | --- |
+| `list-ul` | Toggle line numbers (per-block, no persistence) |
+| `copy` | Copy to clipboard — flashes "Copied" on success |
+| `download` | Download as `snippet.<ext>` based on detected language |
+| `image` | Export the rendered block as a PNG (2× pixel ratio) |
+
+## Language → file extension
+
+The map in `LANG_TO_EXT` (renderer.ts) covers the common set: `ts`, `js`, `jsx`/`tsx`, `py`, `rb`, `sh` (sh/bash/zsh), `json`, `yml`, `md`, `html`, `xml`, `css`, `scss`, `go`, `rs`, `java`, `kt`, `swift`, `c`, `cpp`, `cs`, `sql`, `php`, `diff`. Unknown languages fall back to `.txt`. `dockerfile` and `makefile` use their canonical filename instead of an extension.
+
+## Line numbers
+
+Off by default — clicking the **Lines** icon adds `.with-lines` to the `<pre>`, which switches it from a single column to a 2-column grid (gutter + code) and shows a `<span class="mid-code-gutter">` filled with line numbers. State is per-block and resets on each render.
+
+## PNG export
+
+Uses `html-to-image` (`toPng`) at `pixelRatio: 2`. The background colour is read from the live `--mid-code-bg` custom property so the exported image matches the current theme. Triggers a download of `code.png`.
+
+## Files
+
+- `apps/electron/renderer/renderer.ts` — `attachCodeBlockToolbar`, `LANG_TO_EXT`, `detectCodeLanguage`, `downloadCode`, `exportCodeBlockAsPNG`, `addLineNumbers`, helpers `makeIconButton` / `flashButton`.
+- `apps/electron/renderer/renderer.css` — `.mid-pre`, `.mid-code-toolbar`, `.mid-code-tool-btn`, `.mid-code-lang`, `.mid-code-gutter`, `.mid-pre.with-lines`.
+
+## Verifying
+
+Open any markdown file with code fences. Hover a block:
+
+- Toolbar fades in top-right.
+- Click `list-ul` — line-numbered gutter appears.
+- Click `copy` — clipboard fills; button flashes "Copied".
+- Click `download` — file dialog or auto-download with `snippet.<ext>`.
+- Click `image` — `code.png` saves with the same theme palette.


### PR DESCRIPTION
## Summary
- Replaced the single Copy button with a hover-fade toolbar: **Lines** (toggle line numbers) / **Copy** / **Download** / **Image**.
- Language badge pill in the top-left, derived from the highlight.js `language-<n>` class.
- Per-block line-number gutter rendered in a CSS grid layout when `.with-lines` toggled.
- Download writes the snippet as `snippet.<ext>` using a curated `LANG_TO_EXT` map (`ts`/`js`/`py`/`go`/`rs`/etc.; unknown → `.txt`).
- PNG export via `html-to-image` at 2× pixel-ratio with the current `--mid-code-bg` as background — exports respect the active theme.
- Docs at `docs/code-blocks.md`.

Closes #92 — part of #87.

## Test plan
- [ ] Open a md file with multiple language blocks (ts/python/sh). Each shows a lowercase language pill.
- [ ] Hover one — toolbar fades in.
- [ ] Toggle line numbers — gutter appears in monospace, right-aligned, separated by a border.
- [ ] Copy — clipboard fills; button flashes "Copied".
- [ ] Download — saves a file with the correct extension.
- [ ] Image — saves `code.png` matching the current theme bg.
- [ ] Switch to dark mode — re-export PNG; new image uses dark palette.