### PR TITLE
feat(desktop): data-table viewer — sort, filter, CSV/JSON/Markdown export (#93)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -392,6 +392,73 @@ main.splitting .mid-preview {
   padding-right: var(--mid-space-2);
 }
 
+/* Data-table viewer (sort / filter / export) */
+.mid-table {
+  margin: 1.2em 0;
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-md);
+  overflow: hidden;
+  background: var(--mid-bg);
+}
+.mid-table table { margin: 0; border: 0; border-radius: 0; }
+.mid-table th { position: sticky; top: 0; z-index: 1; }
+.mid-table-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--mid-space-2);
+  padding: var(--mid-space-2) var(--mid-space-3);
+  background: var(--mid-surface);
+  border-bottom: 1px solid var(--mid-border);
+}
+.mid-table-filter {
+  flex: 1;
+  min-width: 0;
+  padding: 4px var(--mid-space-2);
+  font-family: inherit;
+  font-size: var(--mid-font-size-sm);
+  color: var(--mid-fg);
+  background: var(--mid-bg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
+}
+.mid-table-filter:focus-visible { outline: 2px solid var(--mid-accent); outline-offset: 1px; }
+.mid-table-counter {
+  font-family: var(--mid-font-mono);
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+  white-space: nowrap;
+}
+.mid-table-exports { display: flex; gap: 2px; }
+.mid-table-exports .mid-code-tool-btn {
+  background: var(--mid-bg);
+  border: 1px solid var(--mid-border);
+}
+
+/* Sort affordances on each header cell */
+.mid-table-sortable {
+  cursor: pointer;
+  user-select: none;
+  position: relative;
+  padding-right: 24px !important;
+}
+.mid-table-sortable::after {
+  content: "";
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  width: 8px;
+  height: 8px;
+  margin-top: -4px;
+  background: var(--mid-fg-subtle);
+  clip-path: polygon(50% 0, 0 100%, 100% 100%);
+  opacity: 0.5;
+  transform: rotate(180deg);
+  transition: opacity var(--mid-motion-fast) var(--mid-ease-out), transform var(--mid-motion-fast) var(--mid-ease-out), background var(--mid-motion-fast) var(--mid-ease-out);
+}
+.mid-table-sortable:hover::after { opacity: 1; }
+.mid-table-sortable.is-sort-asc::after { opacity: 1; transform: rotate(0deg); background: var(--mid-accent); }
+.mid-table-sortable.is-sort-desc::after { opacity: 1; transform: rotate(180deg); background: var(--mid-accent); }
+
 /* Heading anchors (#) shown on hover */
 .mid-preview h1, .mid-preview h2, .mid-preview h3,
 .mid-preview h4, .mid-preview h5, .mid-preview h6 {

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -201,6 +201,7 @@ function populatePreview(preview: HTMLElement): void {
   attachImageLightbox(preview);
   attachAlerts(preview);
   attachMath(preview);
+  attachTableTools(preview);
   preview.querySelectorAll<HTMLDivElement>('.mermaid').forEach((el, i) => {
     const id = `mermaid-${Date.now()}-${i}`;
     const code = (el.textContent ?? '').trim();
@@ -436,6 +437,172 @@ function renderKatex(expr: string, displayMode: boolean): string {
   } catch (err) {
     return `<code class="mid-math-error" title="${escapeHTML(String((err as Error).message))}">${escapeHTML(expr)}</code>`;
   }
+}
+
+interface TableState {
+  sortColumn: number | null;
+  sortDir: 'asc' | 'desc' | null;
+  filter: string;
+}
+
+function attachTableTools(scope: HTMLElement): void {
+  scope.querySelectorAll<HTMLTableElement>('table').forEach(table => {
+    if (table.dataset.midTable === '1') return;
+    const thead = table.querySelector('thead');
+    const tbody = table.querySelector('tbody');
+    if (!thead || !tbody) return;
+    const headers = Array.from(thead.querySelectorAll<HTMLTableCellElement>('th'));
+    const rows = Array.from(tbody.querySelectorAll<HTMLTableRowElement>('tr'));
+    if (headers.length === 0 || rows.length === 0) return;
+    table.dataset.midTable = '1';
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'mid-table';
+    table.replaceWith(wrapper);
+
+    const toolbar = document.createElement('div');
+    toolbar.className = 'mid-table-toolbar';
+
+    const filterInput = document.createElement('input');
+    filterInput.type = 'search';
+    filterInput.className = 'mid-table-filter';
+    filterInput.placeholder = 'Filter rows…';
+
+    const counter = document.createElement('span');
+    counter.className = 'mid-table-counter';
+
+    const exportGroup = document.createElement('div');
+    exportGroup.className = 'mid-table-exports';
+    exportGroup.append(
+      makeIconButton('copy', 'Copy as Markdown', () => copyTableAsMarkdown(headers, getVisibleRows(rows))),
+      makeIconButton('download', 'Download CSV', () => downloadTable(headers, getVisibleRows(rows), 'csv')),
+      makeIconButton('list-ul', 'Download JSON', () => downloadTable(headers, getVisibleRows(rows), 'json')),
+    );
+
+    toolbar.append(filterInput, counter, exportGroup);
+    wrapper.append(toolbar, table);
+
+    const state: TableState = { sortColumn: null, sortDir: null, filter: '' };
+
+    const apply = (): void => applyTableState(headers, rows, state, counter);
+    apply();
+
+    headers.forEach((th, idx) => {
+      th.classList.add('mid-table-sortable');
+      th.addEventListener('click', () => {
+        if (state.sortColumn !== idx) { state.sortColumn = idx; state.sortDir = 'asc'; }
+        else if (state.sortDir === 'asc') { state.sortDir = 'desc'; }
+        else { state.sortColumn = null; state.sortDir = null; }
+        apply();
+      });
+    });
+
+    let debounce: number | undefined;
+    filterInput.addEventListener('input', () => {
+      window.clearTimeout(debounce);
+      debounce = window.setTimeout(() => {
+        state.filter = filterInput.value.trim().toLowerCase();
+        apply();
+      }, 120);
+    });
+  });
+
+  function getVisibleRows(rows: HTMLTableRowElement[]): HTMLTableRowElement[] {
+    return rows.filter(r => !r.hidden);
+  }
+}
+
+function applyTableState(
+  headers: HTMLTableCellElement[],
+  rows: HTMLTableRowElement[],
+  state: TableState,
+  counter: HTMLSpanElement,
+): void {
+  headers.forEach((th, idx) => {
+    th.classList.remove('is-sort-asc', 'is-sort-desc');
+    if (state.sortColumn === idx && state.sortDir === 'asc') th.classList.add('is-sort-asc');
+    if (state.sortColumn === idx && state.sortDir === 'desc') th.classList.add('is-sort-desc');
+  });
+
+  const tbody = rows[0]?.parentElement;
+  if (!tbody) return;
+
+  const sorted = [...rows];
+  if (state.sortColumn !== null && state.sortDir !== null) {
+    const col = state.sortColumn;
+    const cellText = (r: HTMLTableRowElement): string => r.children[col]?.textContent?.trim() ?? '';
+    const allNumeric = rows.every(r => {
+      const t = cellText(r);
+      return t === '' || !Number.isNaN(Number(t.replace(/[$,%\s]/g, '')));
+    });
+    sorted.sort((a, b) => {
+      const av = cellText(a);
+      const bv = cellText(b);
+      let cmp: number;
+      if (allNumeric) {
+        cmp = (Number(av.replace(/[$,%\s]/g, '')) || 0) - (Number(bv.replace(/[$,%\s]/g, '')) || 0);
+      } else {
+        cmp = av.localeCompare(bv, undefined, { numeric: true, sensitivity: 'base' });
+      }
+      return state.sortDir === 'asc' ? cmp : -cmp;
+    });
+  }
+
+  for (const r of sorted) tbody.appendChild(r);
+
+  let visible = 0;
+  rows.forEach(r => {
+    if (!state.filter) {
+      r.hidden = false;
+      visible++;
+      return;
+    }
+    const haystack = (r.textContent ?? '').toLowerCase();
+    const match = haystack.includes(state.filter);
+    r.hidden = !match;
+    if (match) visible++;
+  });
+
+  counter.textContent = state.filter ? `${visible} of ${rows.length} rows` : `${rows.length} rows`;
+}
+
+function rowToValues(row: HTMLTableRowElement): string[] {
+  return Array.from(row.children).map(c => c.textContent?.trim() ?? '');
+}
+
+function copyTableAsMarkdown(headers: HTMLTableCellElement[], rows: HTMLTableRowElement[]): void {
+  const head = headers.map(h => h.textContent?.trim() ?? '');
+  const lines = [
+    `| ${head.join(' | ')} |`,
+    `| ${head.map(() => '---').join(' | ')} |`,
+    ...rows.map(r => `| ${rowToValues(r).join(' | ')} |`),
+  ];
+  void navigator.clipboard.writeText(lines.join('\n'));
+}
+
+function downloadTable(headers: HTMLTableCellElement[], rows: HTMLTableRowElement[], format: 'csv' | 'json'): void {
+  const head = headers.map(h => h.textContent?.trim() ?? '');
+  let blob: Blob;
+  let filename: string;
+  if (format === 'csv') {
+    const escape = (v: string): string => /[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v;
+    const lines = [head.map(escape).join(','), ...rows.map(r => rowToValues(r).map(escape).join(','))];
+    blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8' });
+    filename = 'table.csv';
+  } else {
+    const objs = rows.map(r => {
+      const vals = rowToValues(r);
+      return Object.fromEntries(head.map((h, i) => [h, vals[i] ?? '']));
+    });
+    blob = new Blob([JSON.stringify(objs, null, 2)], { type: 'application/json' });
+    filename = 'table.json';
+  }
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
 function attachImageLightbox(scope: HTMLElement): void {

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -1,0 +1,47 @@
+# Data-table viewer
+
+Every markdown table that survives rendering is wrapped in a `.mid-table` shell that gives the user the basic data-grid affordances expected of a "real" reader: sort, filter, and export.
+
+## Toolbar
+
+| Control | Behavior |
+| --- | --- |
+| Filter input | Free-text filter over the entire row. Debounced ~120 ms. Filters are case-insensitive and substring-based. |
+| Counter chip | "N rows" when no filter is active; "M of N rows" while filtering. |
+| Copy as Markdown | Copies the visible (post-filter) rows back as a GFM table to the clipboard. |
+| Download CSV | Saves visible rows as `table.csv` with proper quoting (`,`, `"`, newline). |
+| Download JSON | Saves visible rows as an array of objects (`{ headerName: value }`) to `table.json`. |
+
+## Sorting
+
+Every `<th>` is clickable. The sort cycle is **asc → desc → unsorted** (3-state). The active column shows a colored arrow (asc = up, desc = down).
+
+The renderer auto-detects whether a column is numeric: if every non-empty cell in the column parses as a number after stripping `$,%` and whitespace, the column is sorted numerically. Otherwise it falls back to `localeCompare(undefined, { numeric: true, sensitivity: 'base' })`, which gives a sensible alpha order with embedded number handling (`row 2` < `row 10`).
+
+## Persistence
+
+None — sort + filter state lives in DOM only. Re-rendering (any edit in split mode) starts fresh. This is intentional: tables in markdown are content, not configuration.
+
+## Files
+
+- `apps/electron/renderer/renderer.ts` — `attachTableTools`, `applyTableState`, `copyTableAsMarkdown`, `downloadTable`, `rowToValues`, `TableState`.
+- `apps/electron/renderer/renderer.css` — `.mid-table*`, `.mid-table-sortable`, sort indicator pseudo-element.
+
+## Verifying
+
+Open a markdown file containing a table, e.g.:
+
+```markdown
+| Name  | Age | City     |
+| ----- | --- | -------- |
+| Alice | 30  | Cairo    |
+| Bob   | 25  | Berlin   |
+| Carla | 41  | Bordeaux |
+```
+
+You should see:
+
+- Toolbar above with filter input, "3 rows", and three export icons.
+- Type "ber" in the filter — only Bob remains; counter says "1 of 3 rows".
+- Click the **Age** header — sorts ascending (numeric); click again — descending; click a third time — unsorted (markdown order).
+- Download CSV — opens a file with quoted rows matching the visible filter.


### PR DESCRIPTION
## Summary
- Every rendered `<table>` is wrapped in a `.mid-table` shell with a sticky toolbar.
- Toolbar: filter input (debounced 120 ms, substring case-insensitive over the whole row), counter chip ("M of N rows" when filtering, "N rows" when not), 3 export icons.
- Per-column sort: 3-state click cycle (asc → desc → unsorted). Auto-detects numeric columns (strips `$,%` whitespace) and uses numeric comparison; otherwise `localeCompare` with numeric option for natural alpha order.
- Exports operate on the **visible** (post-filter) rows.
  - **Copy as Markdown** writes a GFM table back to the clipboard.
  - **Download CSV** with proper RFC quoting.
  - **Download JSON** as an array of objects keyed by header.
- Docs at `docs/tables.md`.

Closes #93 — part of #87.

## Test plan
- [ ] Open a md file with a table — toolbar appears above.
- [ ] Type into filter — rows hide; counter updates.
- [ ] Click a numeric header — rows sort numerically; click again, descending; click a third time, unsorted.
- [ ] Click a text header — alpha sort with natural number handling.
- [ ] Download CSV — values containing commas/quotes are properly escaped.
- [ ] Download JSON — array of `{ HeaderA: …, HeaderB: … }` objects.
- [ ] Filter then Copy as Markdown — only filtered rows are in the clipboard payload.