### PR TITLE
feat(desktop): mermaid block toolbar — copy SVG / download SVG / PNG (#94)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -558,7 +558,23 @@ main.splitting .mid-preview {
   margin: 1em 0;
   text-align: center;
   overflow-x: auto;
+  position: relative;
 }
+.mid-mermaid-toolbar {
+  position: absolute;
+  top: var(--mid-space-2);
+  right: var(--mid-space-2);
+  display: flex;
+  gap: 2px;
+  padding: 2px;
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
+  opacity: 0;
+  transition: opacity var(--mid-motion-fast) var(--mid-ease-out);
+}
+.mid-preview .mermaid:hover .mid-mermaid-toolbar,
+.mid-mermaid-toolbar:focus-within { opacity: 1; }
 
 main.editing { padding: 0; max-width: none; display: block; height: 100%; }
 main.editing textarea {

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -206,15 +206,67 @@ function populatePreview(preview: HTMLElement): void {
     const id = `mermaid-${Date.now()}-${i}`;
     const code = (el.textContent ?? '').trim();
     el.removeAttribute('data-processed');
+    el.dataset.mermaidSource = code;
     mermaid
       .render(id, code)
       .then(({ svg }) => {
         el.innerHTML = svg;
+        attachMermaidToolbar(el, code);
       })
       .catch(err => {
         el.innerHTML = `<pre style="color: #d04444">Mermaid error: ${String((err as Error)?.message ?? err)}</pre>`;
       });
   });
+}
+
+function attachMermaidToolbar(host: HTMLDivElement, source: string): void {
+  const toolbar = document.createElement('div');
+  toolbar.className = 'mid-mermaid-toolbar';
+  toolbar.append(
+    makeIconButton('copy', 'Copy SVG', () => copyMermaidSVG(host)),
+    makeIconButton('download', 'Download SVG', () => downloadMermaidSVG(host, source)),
+    makeIconButton('image', 'Download PNG', () => void downloadMermaidPNG(host)),
+  );
+  host.style.position = 'relative';
+  host.appendChild(toolbar);
+}
+
+function copyMermaidSVG(host: HTMLDivElement): void {
+  const svg = host.querySelector('svg');
+  if (!svg) return;
+  void navigator.clipboard.writeText(serializeSVG(svg));
+}
+
+function downloadMermaidSVG(host: HTMLDivElement, _source: string): void {
+  const svg = host.querySelector('svg');
+  if (!svg) return;
+  const blob = new Blob([serializeSVG(svg)], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'diagram.svg';
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+async function downloadMermaidPNG(host: HTMLDivElement): Promise<void> {
+  const svg = host.querySelector('svg');
+  if (!svg) return;
+  const dataUrl = await toPng(host, {
+    pixelRatio: 2,
+    backgroundColor: getComputedStyle(document.documentElement).getPropertyValue('--mid-bg').trim() || '#ffffff',
+    filter: node => !((node as HTMLElement).classList?.contains('mid-mermaid-toolbar')),
+  });
+  const a = document.createElement('a');
+  a.href = dataUrl;
+  a.download = 'diagram.png';
+  a.click();
+}
+
+function serializeSVG(svg: SVGSVGElement): string {
+  const clone = svg.cloneNode(true) as SVGSVGElement;
+  clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  return new XMLSerializer().serializeToString(clone);
 }
 
 function applySyntaxHighlighting(scope: HTMLElement): void {

--- a/docs/mermaid.md
+++ b/docs/mermaid.md
@@ -1,0 +1,49 @@
+# Mermaid diagrams
+
+Markdown code-fences tagged `mermaid` render as live SVG diagrams. The desktop adds a hover toolbar to every rendered diagram for copy / SVG / PNG export.
+
+## Live preview while editing
+
+Already covered by the Split mode introduced in #79: every `input` event in the editor triggers a 50 ms-debounced re-render of the preview pane, and that re-render includes mermaid blocks. So while you're typing inside ` ```mermaid …``` ` the diagram updates in place — no additional plumbing required.
+
+## Toolbar
+
+Hovering a rendered mermaid block reveals a top-right toolbar:
+
+| Icon | Action |
+| --- | --- |
+| `copy` | Serializes the rendered `<svg>` and writes the markup to the clipboard. |
+| `download` | Downloads `diagram.svg`. |
+| `image` | Rasterizes the host div via `html-to-image` (toolbar excluded by a filter), 2× pixel-ratio, page background applied for nicer diff against light/dark themes; saves `diagram.png`. |
+
+The original mermaid source is captured in `data-mermaid-source` on the host div for any future tools (e.g. an "edit diagram" popout) that need it.
+
+## Out of scope (follow-up)
+
+- **Cursor-aware popout preview**: when the cursor is inside a `\`\`\`mermaid` fence in the editor, render the block in a floating preview docked next to the cursor. Useful for diagrams beyond a screen height.
+- **Standalone `.mmd` / `.mermaid` file support**: opening one would skip the markdown pipeline and treat the entire file as the diagram source.
+
+## Files
+
+- `apps/electron/renderer/renderer.ts` — `attachMermaidToolbar`, `copyMermaidSVG`, `downloadMermaidSVG`, `downloadMermaidPNG`, `serializeSVG`.
+- `apps/electron/renderer/renderer.css` — `.mid-mermaid-toolbar` styles.
+
+## Verifying
+
+Open a markdown file with a mermaid block:
+
+````markdown
+```mermaid
+graph LR
+  A --> B
+  B --> C
+  C --> A
+```
+````
+
+- Diagram renders.
+- Hover — toolbar fades in.
+- Click `copy` — clipboard contains the SVG markup.
+- Click `download` — `diagram.svg` saves and opens cleanly in any SVG viewer.
+- Click `image` — `diagram.png` matches the current theme bg.
+- Type in the editor (Split mode) — diagram updates after 50 ms.


### PR DESCRIPTION
## Summary
- Hover toolbar on every rendered mermaid block: **Copy SVG**, **Download SVG** (`diagram.svg`), **Download PNG** (`diagram.png` via `html-to-image`).
- Toolbar excluded from the PNG capture via an `html-to-image` `filter` so the screenshot is just the diagram.
- Original mermaid source captured on `data-mermaid-source` for future tools.
- Live preview while editing is already covered by Split mode's 50 ms debounced re-render — no new plumbing needed.
- Cursor-aware popout preview and standalone `.mmd` file mode listed as follow-ups in `docs/mermaid.md`.

Closes #94 — part of #87.

## Test plan
- [ ] Open a md file with a `\`\`\`mermaid` fence — diagram renders.
- [ ] Hover — toolbar fades in.
- [ ] Click Copy SVG — clipboard contains valid SVG markup.
- [ ] Click Download SVG — file opens correctly in any viewer.
- [ ] Click Download PNG — image bg matches the current theme.
- [ ] Switch to Split mode — type in the fence; diagram updates after a beat.