### PR TITLE
feat(desktop): universal document export — Markdown/HTML/PDF/PNG/TXT (#95)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -125,6 +125,33 @@ ipcMain.handle('mid:patch-app-state', async (_e, patch: Partial<AppState>) => {
   await writeAppState(patch);
 });
 
+ipcMain.handle('mid:save-as', async (_e, defaultName: string, content: string | ArrayBuffer, filters: Electron.FileFilter[]) => {
+  const result = await dialog.showSaveDialog({ defaultPath: defaultName, filters });
+  if (result.canceled || !result.filePath) return null;
+  if (typeof content === 'string') {
+    await fs.writeFile(result.filePath, content, 'utf8');
+  } else {
+    await fs.writeFile(result.filePath, Buffer.from(content));
+  }
+  return result.filePath;
+});
+
+ipcMain.handle('mid:export-pdf', async (_e, defaultName: string) => {
+  if (!mainWindow) return null;
+  const result = await dialog.showSaveDialog({
+    defaultPath: defaultName,
+    filters: [{ name: 'PDF', extensions: ['pdf'] }],
+  });
+  if (result.canceled || !result.filePath) return null;
+  const data = await mainWindow.webContents.printToPDF({
+    pageSize: 'A4',
+    printBackground: true,
+    landscape: false,
+  });
+  await fs.writeFile(result.filePath, data);
+  return result.filePath;
+});
+
 ipcMain.handle('mid:save-file-dialog', async (_e, defaultName: string, content: string) => {
   const result = await dialog.showSaveDialog({
     defaultPath: defaultName,
@@ -343,6 +370,17 @@ function buildMenu(): Menu {
           label: 'Save',
           accelerator: 'CmdOrCtrl+S',
           click: () => mainWindow?.webContents.send('mid:menu-save'),
+        },
+        { type: 'separator' },
+        {
+          label: 'Export',
+          submenu: [
+            { label: 'Markdown source…', click: () => mainWindow?.webContents.send('mid:menu-export', 'md') },
+            { label: 'HTML…', click: () => mainWindow?.webContents.send('mid:menu-export', 'html') },
+            { label: 'PDF…', click: () => mainWindow?.webContents.send('mid:menu-export', 'pdf') },
+            { label: 'Image (PNG)…', click: () => mainWindow?.webContents.send('mid:menu-export', 'png') },
+            { label: 'Plain text…', click: () => mainWindow?.webContents.send('mid:menu-export', 'txt') },
+          ],
         },
         { type: 'separator' },
         isMac ? { role: 'close' } : { role: 'quit' },

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -37,6 +37,10 @@ contextBridge.exposeInMainWorld('mid', {
   readAppState: (): Promise<AppState> => ipcRenderer.invoke('mid:read-app-state'),
   patchAppState: (patch: Partial<AppState>): Promise<void> =>
     ipcRenderer.invoke('mid:patch-app-state', patch),
+  saveAs: (defaultName: string, content: string | ArrayBuffer, filters: { name: string; extensions: string[] }[]): Promise<string | null> =>
+    ipcRenderer.invoke('mid:save-as', defaultName, content, filters),
+  exportPDF: (defaultName: string): Promise<string | null> =>
+    ipcRenderer.invoke('mid:export-pdf', defaultName),
   saveFileDialog: (defaultName: string, content: string): Promise<string | null> =>
     ipcRenderer.invoke('mid:save-file-dialog', defaultName, content),
   getAppInfo: (): Promise<AppInfo> => ipcRenderer.invoke('mid:get-app-info'),
@@ -60,5 +64,10 @@ contextBridge.exposeInMainWorld('mid', {
     const handler = () => cb();
     ipcRenderer.on('mid:menu-save', handler);
     return () => ipcRenderer.removeListener('mid:menu-save', handler);
+  },
+  onMenuExport: (cb: (format: 'md' | 'html' | 'pdf' | 'png' | 'txt') => void): (() => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, fmt: 'md' | 'html' | 'pdf' | 'png' | 'txt') => cb(fmt);
+    ipcRenderer.on('mid:menu-export', handler);
+    return () => ipcRenderer.removeListener('mid:menu-export', handler);
   },
 });

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -39,6 +39,8 @@ const FONT_STACKS: Record<FontFamilyChoice, string> = {
   mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
 };
 
+type ExportFormat = 'md' | 'html' | 'pdf' | 'png' | 'txt';
+
 interface Mid {
   readFile(path: string): Promise<string>;
   writeFile(path: string, content: string): Promise<boolean>;
@@ -47,6 +49,8 @@ interface Mid {
   listFolderMd(folderPath: string): Promise<TreeEntry[]>;
   readAppState(): Promise<AppState>;
   patchAppState(patch: Partial<AppState>): Promise<void>;
+  saveAs(defaultName: string, content: string | ArrayBuffer, filters: { name: string; extensions: string[] }[]): Promise<string | null>;
+  exportPDF(defaultName: string): Promise<string | null>;
   saveFileDialog(defaultName: string, content: string): Promise<string | null>;
   getAppInfo(): Promise<{ version: string; platform: string; isDark: boolean; userData: string; documents: string }>;
   openExternal(url: string): Promise<void>;
@@ -54,6 +58,7 @@ interface Mid {
   onMenuOpen(cb: () => void): () => void;
   onMenuOpenFolder(cb: () => void): () => void;
   onMenuSave(cb: () => void): () => void;
+  onMenuExport(cb: (format: ExportFormat) => void): () => void;
 }
 declare const window: Window & { mid: Mid };
 
@@ -883,6 +888,98 @@ async function saveFile(): Promise<void> {
   }
 }
 
+function defaultExportName(ext: string): string {
+  const base = currentPath ? currentPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? 'document' : 'document';
+  return `${base}.${ext}`;
+}
+
+async function exportAs(format: ExportFormat): Promise<void> {
+  if (!currentText && format !== 'pdf' && format !== 'png') {
+    flashStatus('Nothing to export');
+    return;
+  }
+  switch (format) {
+    case 'md':
+      await window.mid.saveAs(defaultExportName('md'), currentText, [{ name: 'Markdown', extensions: ['md'] }]);
+      flashStatus('Exported Markdown');
+      break;
+    case 'txt':
+      await window.mid.saveAs(defaultExportName('txt'), markdownToPlainText(currentText), [{ name: 'Plain text', extensions: ['txt'] }]);
+      flashStatus('Exported text');
+      break;
+    case 'html': {
+      const html = buildStandaloneHTML();
+      await window.mid.saveAs(defaultExportName('html'), html, [{ name: 'HTML', extensions: ['html'] }]);
+      flashStatus('Exported HTML');
+      break;
+    }
+    case 'pdf': {
+      const result = await window.mid.exportPDF(defaultExportName('pdf'));
+      flashStatus(result ? 'Exported PDF' : 'PDF cancelled');
+      break;
+    }
+    case 'png': {
+      const preview = root.querySelector<HTMLElement>('.mid-preview');
+      if (!preview) { flashStatus('No preview to capture'); return; }
+      const dataUrl = await toPng(preview, {
+        pixelRatio: 2,
+        backgroundColor: getComputedStyle(document.documentElement).getPropertyValue('--mid-bg').trim() || '#ffffff',
+      });
+      const buffer = dataUrlToArrayBuffer(dataUrl);
+      await window.mid.saveAs(defaultExportName('png'), buffer, [{ name: 'PNG', extensions: ['png'] }]);
+      flashStatus('Exported PNG');
+      break;
+    }
+  }
+}
+
+function dataUrlToArrayBuffer(dataUrl: string): ArrayBuffer {
+  const base64 = dataUrl.split(',')[1];
+  const binary = atob(base64);
+  const buf = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) buf[i] = binary.charCodeAt(i);
+  return buf.buffer;
+}
+
+function markdownToPlainText(md: string): string {
+  return md
+    .replace(/^---\r?\n[\s\S]+?\r?\n---\r?\n?/, '')   // strip frontmatter
+    .replace(/```[\s\S]*?```/g, m => m.replace(/```\w*\n?|```/g, ''))  // unwrap code fences
+    .replace(/`([^`]+)`/g, '$1')                       // inline code
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')          // images → alt text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')           // links → text
+    .replace(/^[#>\s-]+/gm, '')                         // heading / quote / list markers
+    .replace(/[*_~]+/g, '')                              // emphasis markers
+    .replace(/\n{3,}/g, '\n\n');                         // collapse extra blank lines
+}
+
+function buildStandaloneHTML(): string {
+  const preview = root.querySelector<HTMLElement>('.mid-preview');
+  const body = preview ? preview.outerHTML : '<p>(empty)</p>';
+  const title = currentPath ? currentPath.split('/').pop() ?? 'Untitled' : 'Untitled';
+  // Inline the active stylesheets so the export is self-contained.
+  const styles = Array.from(document.styleSheets)
+    .map(sheet => {
+      try {
+        return Array.from(sheet.cssRules).map(r => r.cssText).join('\n');
+      } catch {
+        return '';
+      }
+    })
+    .join('\n');
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>${escapeHTML(title)}</title>
+<style>${styles}</style>
+</head>
+<body class="${document.body.className}">
+<main class="viewing">${body}</main>
+</body>
+</html>`;
+}
+
 function flashStatus(message: string): void {
   const original = filenameEl.textContent;
   filenameEl.textContent = message;
@@ -903,6 +1000,7 @@ window.mid.onThemeChanged(applyTheme);
 window.mid.onMenuOpen(() => void openFile());
 window.mid.onMenuOpenFolder(() => void openFolder());
 window.mid.onMenuSave(() => void saveFile());
+window.mid.onMenuExport(fmt => void exportAs(fmt));
 
 hydrateIconButtons(document);
 wireSettingsPanel();

--- a/docs/desktop-export.md
+++ b/docs/desktop-export.md
@@ -1,0 +1,43 @@
+# Universal document export
+
+The desktop app can export the current document to five formats from **File → Export → …**:
+
+| Menu item | Output | Implementation |
+| --- | --- | --- |
+| Markdown source… | `.md` | Writes the editor buffer verbatim. |
+| HTML… | `.html` | Standalone file: `<head>` inlines all active stylesheets (tokens, primitives, icons, katex, renderer); `<body>` clones the current `.mid-preview`. The export is self-contained — opens in any browser without external assets. |
+| PDF… | `.pdf` | Main process calls `BrowserWindow.webContents.printToPDF({ pageSize: 'A4', printBackground: true })` against the live window. |
+| Image (PNG)… | `.png` | Renderer rasterizes the `.mid-preview` div via `html-to-image` at 2× pixel ratio, with the active `--mid-bg` for background. |
+| Plain text… | `.txt` | Strip-markdown pass: removes frontmatter, fence chrome, emphasis markers, link syntax, heading/quote/list markers; keeps the prose. |
+
+## File naming
+
+Each export prompts a save dialog. The default filename is the current document's basename + the target extension (e.g. `notes.md` → `notes.pdf`). Untitled buffers default to `document.<ext>`.
+
+## DOCX (deferred)
+
+The issue body listed DOCX too. Producing a faithful DOCX from arbitrary markdown requires walking the AST and emitting `docx`-package paragraphs/runs/tables/images, which is a substantial standalone feature. Tracked as a follow-up: open a sub-issue when the demand is clear, install `docx`, and wire `mid:export-docx` similarly.
+
+## IPC surface
+
+| Channel | From → To | Purpose |
+| --- | --- | --- |
+| `mid:save-as` | renderer → main | Generic save dialog + write. Accepts `string` (text) or `ArrayBuffer` (binary). |
+| `mid:export-pdf` | renderer → main | Save dialog → `webContents.printToPDF()` → write. |
+| `mid:menu-export` | main → renderer | Menu click ("Markdown source…", "HTML…", etc.) routes through with the format string. |
+
+## Files
+
+- `apps/electron/main.ts` — `mid:save-as`, `mid:export-pdf`, "Export" submenu wiring.
+- `apps/electron/preload.ts` — `saveAs`, `exportPDF`, `onMenuExport`.
+- `apps/electron/renderer/renderer.ts` — `exportAs`, `markdownToPlainText`, `buildStandaloneHTML`, `defaultExportName`, `dataUrlToArrayBuffer`.
+
+## Verifying
+
+Open any markdown file (e.g. `docs/desktop-workspace.md`):
+
+- File → Export → Markdown source… → identical to the editor buffer.
+- Export → HTML — open the saved file in a browser; the rendered page matches the in-app preview, including syntax highlighting and KaTeX.
+- Export → PDF — A4, multi-page if the document is long; backgrounds preserved.
+- Export → Image — single tall PNG of the entire preview; theme-aware.
+- Export → Plain text — markdown markers stripped; prose intact.


### PR DESCRIPTION
## Summary
- New **File → Export** submenu with five formats:
  - **Markdown source** — current buffer verbatim
  - **HTML** — standalone file with all active stylesheets inlined into `<head>`
  - **PDF** — main process `webContents.printToPDF({ pageSize: 'A4', printBackground: true })`
  - **Image (PNG)** — `html-to-image` of `.mid-preview` at 2× pixel ratio, theme-matched bg
  - **Plain text** — strip-markdown pass (frontmatter / fences / emphasis / link syntax removed)
- New IPCs `mid:save-as` (generic save dialog + write, supports strings or ArrayBuffer) and `mid:export-pdf`.
- Default filenames derive from the open document's basename.
- DOCX explicitly deferred — too much surface for this PR; tracked as follow-up in `docs/desktop-export.md`.

Closes #95 — part of #87.

## Test plan
- [ ] Open a md file, then File → Export → Markdown source — saved file matches editor buffer.
- [ ] Export → HTML — open in a browser; rendered page matches in-app preview (with hljs + KaTeX).
- [ ] Export → PDF — saved file is multi-page A4 with background colors preserved.
- [ ] Export → Image — single tall PNG of the whole preview.
- [ ] Export → Plain text — markdown markers gone, prose intact.
- [ ] Untitled buffer → exports default to `document.<ext>`.