### PR TITLE
feat(desktop): system tray + MCP indicator + Claude Code/Cursor install (#96)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -1,7 +1,9 @@
-import { app, BrowserWindow, dialog, ipcMain, Menu, MenuItemConstructorOptions, nativeTheme, shell } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, Menu, MenuItemConstructorOptions, nativeImage, nativeTheme, shell, Tray } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { promises as fs } from 'fs';
 import * as path from 'path';
+import { fork, ChildProcess } from 'child_process';
+import * as os from 'os';
 
 const isDev = process.env.MID_DEV === '1' || !app.isPackaged;
 const updateState = {
@@ -12,6 +14,11 @@ const updateState = {
 };
 
 let mainWindow: BrowserWindow | null = null;
+let tray: Tray | null = null;
+let mcpProcess: ChildProcess | null = null;
+type MCPStatus = 'stopped' | 'running' | 'error';
+let mcpStatus: MCPStatus = 'stopped';
+let mcpLastError: string | null = null;
 
 function resolveAppIcon(): string | undefined {
   // In dev: use a 512px PNG so the dock/taskbar shows brand art.
@@ -75,11 +82,15 @@ app.whenReady().then(async () => {
   }
   await createWindow();
   Menu.setApplicationMenu(buildMenu());
+  buildTray();
+  startMCP();
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) void createWindow();
   });
   setupAutoUpdate();
 });
+
+app.on('before-quit', () => stopMCP());
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();
@@ -279,6 +290,128 @@ interface AppState {
   fontSize?: number;
   theme?: 'auto' | 'light' | 'dark' | 'sepia';
   previewMaxWidth?: number;
+}
+
+function resolveMCPServerScript(): string {
+  // In dev: out/mcp/server.js sits in the repo. Packaged: ships under app resources.
+  const candidates = [
+    path.join(process.cwd(), 'out/mcp/server.js'),
+    path.join(__dirname, '../../mcp/server.js'),
+    path.join(__dirname, '../mcp/server.js'),
+  ];
+  for (const p of candidates) {
+    try { require('fs').accessSync(p); return p; } catch { /* try next */ }
+  }
+  return '';
+}
+
+function setMCPStatus(s: MCPStatus, err?: string): void {
+  mcpStatus = s;
+  mcpLastError = err ?? null;
+  rebuildTrayMenu();
+}
+
+function startMCP(): void {
+  if (mcpProcess) return;
+  const script = resolveMCPServerScript();
+  if (!script) {
+    setMCPStatus('error', 'MCP server script not found');
+    return;
+  }
+  try {
+    mcpProcess = fork(script, [], {
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+      env: { ...process.env, MID_TRAY_MANAGED: '1' },
+    });
+    setMCPStatus('running');
+    mcpProcess.on('error', e => setMCPStatus('error', e.message));
+    mcpProcess.on('exit', code => {
+      mcpProcess = null;
+      if (code !== 0 && mcpStatus !== 'stopped') setMCPStatus('error', `MCP exited with code ${code}`);
+      else setMCPStatus('stopped');
+    });
+  } catch (err) {
+    setMCPStatus('error', (err as Error).message);
+  }
+}
+
+function stopMCP(): void {
+  if (!mcpProcess) {
+    if (mcpStatus !== 'stopped') setMCPStatus('stopped');
+    return;
+  }
+  setMCPStatus('stopped');
+  try { mcpProcess.kill(); } catch { /* ignore */ }
+  mcpProcess = null;
+}
+
+function buildTray(): void {
+  const iconPath = path.join(process.cwd(), 'media/brand/iconTemplate.png');
+  let icon = nativeImage.createFromPath(iconPath);
+  if (icon.isEmpty()) {
+    // Fallback: use the colored 16-px PNG.
+    icon = nativeImage.createFromPath(path.join(process.cwd(), 'build/icons/16.png'));
+  }
+  if (process.platform === 'darwin') icon.setTemplateImage(true);
+  tray = new Tray(icon);
+  tray.setToolTip('Mark It Down');
+  rebuildTrayMenu();
+}
+
+function rebuildTrayMenu(): void {
+  if (!tray) return;
+  const statusLabel =
+    mcpStatus === 'running' ? '● MCP server: running'
+    : mcpStatus === 'error' ? `● MCP server: error${mcpLastError ? ` — ${mcpLastError}` : ''}`
+    : '○ MCP server: stopped';
+  const menu = Menu.buildFromTemplate([
+    { label: statusLabel, enabled: false },
+    { type: 'separator' },
+    { label: 'Start MCP', enabled: mcpStatus !== 'running', click: () => startMCP() },
+    { label: 'Stop MCP', enabled: mcpStatus === 'running', click: () => stopMCP() },
+    { type: 'separator' },
+    { label: 'Install MCP for Claude Code…', click: () => void installMCPFor('claude') },
+    { label: 'Install MCP for Cursor…', click: () => void installMCPFor('cursor') },
+    { type: 'separator' },
+    { label: 'Show window', click: () => mainWindow?.show() },
+    { label: 'Hide window', click: () => mainWindow?.hide() },
+    { type: 'separator' },
+    { label: 'Quit Mark It Down', click: () => app.quit() },
+  ]);
+  tray.setContextMenu(menu);
+}
+
+async function installMCPFor(target: 'claude' | 'cursor'): Promise<void> {
+  const script = resolveMCPServerScript();
+  if (!script) {
+    await dialog.showMessageBox({ type: 'error', title: 'Mark It Down', message: 'MCP server script not found.' });
+    return;
+  }
+  const home = os.homedir();
+  const configPath = target === 'claude' ? path.join(home, '.claude.json') : path.join(home, '.cursor', 'mcp.json');
+  let json: { mcpServers?: Record<string, { command: string; args: string[] }> } = {};
+  try {
+    const raw = await fs.readFile(configPath, 'utf8');
+    json = JSON.parse(raw);
+  } catch {
+    // file doesn't exist or invalid JSON — start fresh
+  }
+  json.mcpServers = json.mcpServers ?? {};
+  json.mcpServers['mark-it-down'] = {
+    command: process.execPath.includes('Electron')
+      ? 'node'
+      : process.execPath, // packaged: invoke node directly if available
+    args: [script],
+  };
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, JSON.stringify(json, null, 2), 'utf8');
+  await dialog.showMessageBox({
+    type: 'info',
+    title: 'Mark It Down',
+    message: `Installed for ${target === 'claude' ? 'Claude Code' : 'Cursor'}`,
+    detail: `Wrote mcpServers["mark-it-down"] to ${configPath}.\n\nRestart ${target === 'claude' ? 'Claude Code' : 'Cursor'} to pick up the change.`,
+    buttons: ['OK'],
+  });
 }
 
 const MD_EXT = new Set(['.md', '.mdx', '.markdown']);

--- a/docs/desktop-tray-mcp.md
+++ b/docs/desktop-tray-mcp.md
@@ -1,0 +1,56 @@
+# System tray + MCP server
+
+The desktop app installs a system-tray (macOS menu-bar / Windows / Linux tray) entry with the brand `#` template image. The tray is a real surface for the bundled **Model Context Protocol (MCP) server** — start / stop, see status, and one-click install for AI clients.
+
+## Tray menu
+
+| Row | Behavior |
+| --- | --- |
+| `● MCP server: running` / `○ MCP server: stopped` / `● MCP server: error — <msg>` | Disabled status row at the top. Color dot reflects state. |
+| Start MCP | Forks `out/mcp/server.js` as a child process with `MID_TRAY_MANAGED=1`. Disabled while running. |
+| Stop MCP | Kills the child process. Disabled while stopped. |
+| Install MCP for Claude Code… | Writes the `mark-it-down` server entry into `~/.claude.json#mcpServers`. |
+| Install MCP for Cursor… | Writes the same entry into `~/.cursor/mcp.json#mcpServers`. |
+| Show window / Hide window | Toggles `mainWindow` visibility. |
+| Quit Mark It Down | `app.quit()`. |
+
+## Lifecycle
+
+`startMCP()` runs automatically once the app is ready (so the tray reflects "running" the moment the user opens it). `stopMCP()` runs on `before-quit` to keep the process tree clean. Crashes or non-zero exits flip the status to `error` and surface the message in the tray label.
+
+## Install — what it actually writes
+
+For both clients the format is the standard MCP-server stanza. Example written into `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "mark-it-down": {
+      "command": "node",
+      "args": ["/Users/you/Sites/mark-it-down/out/mcp/server.js"]
+    }
+  }
+}
+```
+
+The script path resolves at install time via `resolveMCPServerScript()` so the recorded path is absolute and survives the working directory. Restart the AI client (Claude Code / Cursor) for the new server to be picked up.
+
+If `~/.claude.json` already has other `mcpServers`, the install is **non-destructive** — it merges the new entry and rewrites the file with two-space indentation.
+
+## Tray icon
+
+`media/brand/iconTemplate.png` (and the `@2x` / `@3x` densities) generated in #80 by `scripts/build-icons.mjs`. On macOS the icon is marked as a template image (`setTemplateImage(true)`), so the OS recolors it to match the active menu bar (white in dark mode, black in light, blue-tinted when the menu is open).
+
+If the template PNGs aren't found (e.g. fresh checkout without `npm run build:icons`), the tray falls back to the colored 16-px brand asset.
+
+## Files
+
+- `apps/electron/main.ts` — `buildTray`, `rebuildTrayMenu`, `startMCP`, `stopMCP`, `installMCPFor`, `resolveMCPServerScript`, `setMCPStatus`. Tray + MCP wired in `app.whenReady()` and `app.on('before-quit', …)`.
+
+## Verifying
+
+1. `npm run dev:electron` — tray icon shows in menu bar / tray.
+2. Open the menu — status row shows `● MCP server: running` immediately.
+3. Click **Stop MCP** — status flips to `○ stopped`; **Start MCP** is enabled.
+4. Click **Install MCP for Claude Code…** — confirmation dialog cites the path written; open the file and confirm `mcpServers.mark-it-down` is there with absolute `args` path.
+5. Quit the app — `out/mcp/server.js` process is gone (`pgrep -f mcp/server.js` should return empty).


### PR DESCRIPTION
## Summary
- Tray icon installed using the `iconTemplate*.png` set generated in #80 (template image on macOS — auto-recolors with menu bar).
- Tray menu shows live MCP server status (`running` / `stopped` / `error`), Start / Stop, two install actions, Show / Hide window, Quit.
- MCP server child process spawned via `child_process.fork('out/mcp/server.js')` on app ready; killed on `before-quit`. Crashes flip status to `error` with the surfaced message.
- **Install for Claude Code** writes `mcpServers["mark-it-down"]` to `~/.claude.json` (non-destructive merge with existing entries).
- **Install for Cursor** writes the same to `~/.cursor/mcp.json`.
- Confirmation dialogs cite the path that was written and remind the user to restart the client.
- Docs at `docs/desktop-tray-mcp.md`.

Closes #96 — part of #87.

## Test plan
- [ ] `npm run dev:electron` — tray icon appears in menu bar with the brand `#` glyph.
- [ ] Tray status row shows `● MCP server: running` on launch.
- [ ] Stop MCP — status flips, Start MCP enables.
- [ ] Install for Claude Code — `~/.claude.json` contains `mcpServers.mark-it-down` with an absolute `args` path. Existing servers preserved.
- [ ] Install for Cursor — same in `~/.cursor/mcp.json`.
- [ ] Quit — child process gone (`pgrep -f mcp/server.js`).