### PR TITLE
feat(desktop): Notes management — registry + create/delete/filter/open (#97)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -132,6 +132,89 @@ ipcMain.handle('mid:list-folder-md', async (_e, folderPath: string) => {
 
 ipcMain.handle('mid:read-app-state', async () => readAppState());
 
+interface NoteEntry {
+  id: string;
+  title: string;
+  path: string;
+  tags: string[];
+  created: string;
+  updated: string;
+}
+
+const NOTES_DIR = '.mid';
+const NOTES_FILE = 'notes.json';
+
+async function readNotes(workspace: string): Promise<NoteEntry[]> {
+  try {
+    const raw = await fs.readFile(path.join(workspace, NOTES_DIR, NOTES_FILE), 'utf8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as NoteEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeNotes(workspace: string, notes: NoteEntry[]): Promise<void> {
+  const dir = path.join(workspace, NOTES_DIR);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, NOTES_FILE), JSON.stringify(notes, null, 2), 'utf8');
+}
+
+function slugify(text: string): string {
+  return text.toLowerCase().trim().replace(/[^a-z0-9\s-]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-') || 'untitled';
+}
+
+ipcMain.handle('mid:notes-list', async (_e, workspace: string) => readNotes(workspace));
+
+ipcMain.handle('mid:notes-create', async (_e, workspace: string, title: string) => {
+  const notes = await readNotes(workspace);
+  const baseSlug = slugify(title || 'untitled');
+  const taken = new Set(notes.map(n => n.id));
+  let id = baseSlug;
+  let n = 1;
+  while (taken.has(id)) id = `${baseSlug}-${++n}`;
+  const now = new Date().toISOString();
+  const relPath = `notes/${id}.md`;
+  const fullPath = path.join(workspace, relPath);
+  await fs.mkdir(path.dirname(fullPath), { recursive: true });
+  await fs.writeFile(fullPath, `# ${title || 'Untitled'}\n\n`, 'utf8');
+  const entry: NoteEntry = { id, title: title || 'Untitled', path: relPath, tags: [], created: now, updated: now };
+  notes.push(entry);
+  await writeNotes(workspace, notes);
+  return { entry, fullPath };
+});
+
+ipcMain.handle('mid:notes-rename', async (_e, workspace: string, id: string, title: string) => {
+  const notes = await readNotes(workspace);
+  const note = notes.find(n => n.id === id);
+  if (!note) return null;
+  note.title = title;
+  note.updated = new Date().toISOString();
+  await writeNotes(workspace, notes);
+  return note;
+});
+
+ipcMain.handle('mid:notes-delete', async (_e, workspace: string, id: string) => {
+  const notes = await readNotes(workspace);
+  const idx = notes.findIndex(n => n.id === id);
+  if (idx === -1) return false;
+  const note = notes[idx];
+  notes.splice(idx, 1);
+  await writeNotes(workspace, notes);
+  try { await fs.unlink(path.join(workspace, note.path)); } catch { /* file gone — fine */ }
+  return true;
+});
+
+ipcMain.handle('mid:notes-tag', async (_e, workspace: string, id: string, tags: string[]) => {
+  const notes = await readNotes(workspace);
+  const note = notes.find(n => n.id === id);
+  if (!note) return null;
+  note.tags = tags;
+  note.updated = new Date().toISOString();
+  await writeNotes(workspace, notes);
+  return note;
+});
+
 ipcMain.handle('mid:patch-app-state', async (_e, patch: Partial<AppState>) => {
   await writeAppState(patch);
 });

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -24,6 +24,15 @@ export interface AppState {
   previewMaxWidth?: number;
 }
 
+export interface NoteEntry {
+  id: string;
+  title: string;
+  path: string;
+  tags: string[];
+  created: string;
+  updated: string;
+}
+
 contextBridge.exposeInMainWorld('mid', {
   readFile: (path: string): Promise<string> => ipcRenderer.invoke('mid:read-file', path),
   writeFile: (path: string, content: string): Promise<boolean> =>
@@ -37,6 +46,16 @@ contextBridge.exposeInMainWorld('mid', {
   readAppState: (): Promise<AppState> => ipcRenderer.invoke('mid:read-app-state'),
   patchAppState: (patch: Partial<AppState>): Promise<void> =>
     ipcRenderer.invoke('mid:patch-app-state', patch),
+  notesList: (workspace: string): Promise<NoteEntry[]> =>
+    ipcRenderer.invoke('mid:notes-list', workspace),
+  notesCreate: (workspace: string, title: string): Promise<{ entry: NoteEntry; fullPath: string }> =>
+    ipcRenderer.invoke('mid:notes-create', workspace, title),
+  notesRename: (workspace: string, id: string, title: string): Promise<NoteEntry | null> =>
+    ipcRenderer.invoke('mid:notes-rename', workspace, id, title),
+  notesDelete: (workspace: string, id: string): Promise<boolean> =>
+    ipcRenderer.invoke('mid:notes-delete', workspace, id),
+  notesTag: (workspace: string, id: string, tags: string[]): Promise<NoteEntry | null> =>
+    ipcRenderer.invoke('mid:notes-tag', workspace, id, tags),
   saveAs: (defaultName: string, content: string | ArrayBuffer, filters: { name: string; extensions: string[] }[]): Promise<string | null> =>
     ipcRenderer.invoke('mid:save-as', defaultName, content, filters),
   exportPDF: (defaultName: string): Promise<string | null> =>

--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -67,11 +67,20 @@
 </aside>
 <div class="mid-shell">
   <aside class="mid-sidebar" id="sidebar" hidden>
-    <div class="mid-sidebar-header">
+    <div class="mid-sidebar-mode" role="tablist">
+      <button id="mode-files" class="mid-sidebar-mode-btn is-active" role="tab">Files</button>
+      <button id="mode-notes" class="mid-sidebar-mode-btn" role="tab">Notes</button>
+    </div>
+    <div class="mid-sidebar-header" id="sidebar-files-header">
       <span class="mid-sidebar-title" id="sidebar-folder-name">Files</span>
       <button id="sidebar-refresh" class="mid-btn mid-btn--icon mid-btn--ghost" title="Refresh" data-icon="refresh"></button>
     </div>
+    <div class="mid-sidebar-header" id="sidebar-notes-header" hidden>
+      <input id="notes-filter" class="mid-table-filter" type="search" placeholder="Filter notes…" />
+      <button id="notes-new" class="mid-btn mid-btn--icon mid-btn--ghost" title="New note (Cmd/Ctrl+N)" data-icon="plus"></button>
+    </div>
     <div class="mid-sidebar-tree" id="tree-root"></div>
+    <div class="mid-notes-list" id="notes-list" hidden></div>
   </aside>
   <main id="root" class="viewing">
     <div class="empty-state">

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -83,6 +83,88 @@ body.has-sidebar .mid-shell {
   font-size: var(--mid-font-size-sm);
 }
 
+/* Sidebar mode toggle (Files / Notes) */
+.mid-sidebar-mode {
+  display: flex;
+  border-bottom: 1px solid var(--mid-border);
+}
+.mid-sidebar-mode-btn {
+  flex: 1;
+  padding: var(--mid-space-2);
+  font-family: inherit;
+  font-size: var(--mid-font-size-sm);
+  font-weight: var(--mid-weight-medium);
+  color: var(--mid-fg-muted);
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+}
+.mid-sidebar-mode-btn:hover { color: var(--mid-fg); background: var(--mid-surface-hover); }
+.mid-sidebar-mode-btn.is-active {
+  color: var(--mid-fg);
+  border-bottom-color: var(--mid-accent);
+}
+
+/* Notes list */
+.mid-notes-list {
+  flex: 1;
+  overflow: auto;
+  padding: var(--mid-space-1);
+}
+.mid-note-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+  gap: 2px var(--mid-space-2);
+  padding: var(--mid-space-2);
+  border-radius: var(--mid-radius-sm);
+  cursor: pointer;
+  user-select: none;
+}
+.mid-note-row:hover { background: var(--mid-surface-hover); }
+.mid-note-row.is-active { background: var(--mid-accent); color: var(--mid-accent-fg); }
+.mid-note-row.is-active .mid-note-meta,
+.mid-note-row.is-active .mid-note-tag { color: var(--mid-accent-fg); opacity: 0.85; }
+.mid-note-title {
+  font-size: var(--mid-font-size-sm);
+  font-weight: var(--mid-weight-medium);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  grid-column: 1;
+  grid-row: 1;
+}
+.mid-note-meta {
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+  grid-column: 1;
+  grid-row: 2;
+}
+.mid-note-tags { display: inline-flex; gap: var(--mid-space-1); margin-left: var(--mid-space-2); }
+.mid-note-tag {
+  font-family: var(--mid-font-mono);
+  font-size: 10px;
+  padding: 0 var(--mid-space-1);
+  background: var(--mid-inline-code-bg);
+  border-radius: var(--mid-radius-pill);
+  color: var(--mid-fg-muted);
+}
+.mid-note-delete {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  background: transparent;
+  border: 0;
+  color: var(--mid-fg-subtle);
+  cursor: pointer;
+  border-radius: var(--mid-radius-sm);
+  padding: 2px;
+  opacity: 0;
+  transition: opacity var(--mid-motion-fast) var(--mid-ease-out);
+}
+.mid-note-row:hover .mid-note-delete { opacity: 1; }
+.mid-note-delete:hover { color: var(--mid-danger); background: var(--mid-surface); }
+
 .mid-titlebar {
   display: grid;
   grid-template-columns: 1fr auto 1fr;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -41,6 +41,15 @@ const FONT_STACKS: Record<FontFamilyChoice, string> = {
 
 type ExportFormat = 'md' | 'html' | 'pdf' | 'png' | 'txt';
 
+interface NoteEntry {
+  id: string;
+  title: string;
+  path: string;
+  tags: string[];
+  created: string;
+  updated: string;
+}
+
 interface Mid {
   readFile(path: string): Promise<string>;
   writeFile(path: string, content: string): Promise<boolean>;
@@ -49,6 +58,11 @@ interface Mid {
   listFolderMd(folderPath: string): Promise<TreeEntry[]>;
   readAppState(): Promise<AppState>;
   patchAppState(patch: Partial<AppState>): Promise<void>;
+  notesList(workspace: string): Promise<NoteEntry[]>;
+  notesCreate(workspace: string, title: string): Promise<{ entry: NoteEntry; fullPath: string }>;
+  notesRename(workspace: string, id: string, title: string): Promise<NoteEntry | null>;
+  notesDelete(workspace: string, id: string): Promise<boolean>;
+  notesTag(workspace: string, id: string, tags: string[]): Promise<NoteEntry | null>;
   saveAs(defaultName: string, content: string | ArrayBuffer, filters: { name: string; extensions: string[] }[]): Promise<string | null>;
   exportPDF(defaultName: string): Promise<string | null>;
   saveFileDialog(defaultName: string, content: string): Promise<string | null>;
@@ -76,6 +90,13 @@ const sidebar = document.getElementById('sidebar') as HTMLElement;
 const sidebarFolderName = document.getElementById('sidebar-folder-name') as HTMLSpanElement;
 const sidebarRefresh = document.getElementById('sidebar-refresh') as HTMLButtonElement;
 const treeRoot = document.getElementById('tree-root') as HTMLDivElement;
+const modeFilesBtn = document.getElementById('mode-files') as HTMLButtonElement;
+const modeNotesBtn = document.getElementById('mode-notes') as HTMLButtonElement;
+const sidebarFilesHeader = document.getElementById('sidebar-files-header') as HTMLElement;
+const sidebarNotesHeader = document.getElementById('sidebar-notes-header') as HTMLElement;
+const notesListEl = document.getElementById('notes-list') as HTMLDivElement;
+const notesFilter = document.getElementById('notes-filter') as HTMLInputElement;
+const notesNewBtn = document.getElementById('notes-new') as HTMLButtonElement;
 
 let currentText = '';
 let currentPath: string | null = null;
@@ -85,6 +106,9 @@ let currentFolder: string | null = null;
 let splitRatio = 0.5;
 let renderTimer: number | null = null;
 let osIsDark = false;
+let sidebarMode: 'files' | 'notes' = 'files';
+let notes: NoteEntry[] = [];
+let notesFilterText = '';
 const settings = { ...DEFAULT_SETTINGS };
 const expandedDirs = new Set<string>();
 
@@ -995,6 +1019,122 @@ btnOpen.addEventListener('click', () => void openFile());
 btnOpenFolder.addEventListener('click', () => void openFolder());
 btnSave.addEventListener('click', () => void saveFile());
 sidebarRefresh.addEventListener('click', () => void refreshFolder());
+modeFilesBtn.addEventListener('click', () => setSidebarMode('files'));
+modeNotesBtn.addEventListener('click', () => setSidebarMode('notes'));
+notesNewBtn.addEventListener('click', () => void promptCreateNote());
+notesFilter.addEventListener('input', () => {
+  notesFilterText = notesFilter.value.trim().toLowerCase();
+  renderNotes();
+});
+
+document.addEventListener('keydown', e => {
+  if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'n' && !e.shiftKey && !e.altKey) {
+    if (currentFolder) {
+      e.preventDefault();
+      setSidebarMode('notes');
+      void promptCreateNote();
+    }
+  }
+});
+
+function setSidebarMode(mode: 'files' | 'notes'): void {
+  sidebarMode = mode;
+  modeFilesBtn.classList.toggle('is-active', mode === 'files');
+  modeNotesBtn.classList.toggle('is-active', mode === 'notes');
+  sidebarFilesHeader.hidden = mode !== 'files';
+  sidebarNotesHeader.hidden = mode !== 'notes';
+  treeRoot.hidden = mode !== 'files';
+  notesListEl.hidden = mode !== 'notes';
+  if (mode === 'notes') void loadNotes();
+}
+
+async function loadNotes(): Promise<void> {
+  if (!currentFolder) {
+    notesListEl.innerHTML = '<div class="mid-tree-empty">Open a folder first.</div>';
+    return;
+  }
+  notes = await window.mid.notesList(currentFolder);
+  renderNotes();
+}
+
+function renderNotes(): void {
+  if (!currentFolder) return;
+  const filtered = notesFilterText
+    ? notes.filter(n => n.title.toLowerCase().includes(notesFilterText) || n.tags.some(t => t.toLowerCase().includes(notesFilterText)))
+    : notes;
+  if (filtered.length === 0) {
+    notesListEl.innerHTML = `<div class="mid-tree-empty">${notes.length === 0 ? 'No notes yet. Create one with + or Cmd/Ctrl+N.' : 'No matches.'}</div>`;
+    return;
+  }
+  const sorted = [...filtered].sort((a, b) => b.updated.localeCompare(a.updated));
+  notesListEl.replaceChildren(...sorted.map(renderNoteRow));
+}
+
+function renderNoteRow(note: NoteEntry): HTMLElement {
+  const row = document.createElement('div');
+  row.className = 'mid-note-row';
+  row.dataset.id = note.id;
+  if (currentPath && currentPath.endsWith('/' + note.path)) row.classList.add('is-active');
+  const title = document.createElement('div');
+  title.className = 'mid-note-title';
+  title.textContent = note.title;
+  const meta = document.createElement('div');
+  meta.className = 'mid-note-meta';
+  const updated = new Date(note.updated).toLocaleDateString();
+  meta.textContent = updated;
+  if (note.tags.length > 0) {
+    const tags = document.createElement('div');
+    tags.className = 'mid-note-tags';
+    for (const t of note.tags) {
+      const chip = document.createElement('span');
+      chip.className = 'mid-note-tag';
+      chip.textContent = `#${t}`;
+      tags.appendChild(chip);
+    }
+    meta.appendChild(tags);
+  }
+  const del = document.createElement('button');
+  del.className = 'mid-note-delete';
+  del.title = 'Delete note';
+  del.innerHTML = iconHTML('trash', 'mid-icon--sm');
+  del.addEventListener('click', e => {
+    e.stopPropagation();
+    void deleteNote(note);
+  });
+  row.append(title, meta, del);
+  row.addEventListener('click', () => void openNote(note));
+  return row;
+}
+
+async function openNote(note: NoteEntry): Promise<void> {
+  if (!currentFolder) return;
+  const fullPath = `${currentFolder}/${note.path}`;
+  const content = await window.mid.readFile(fullPath);
+  loadFileContent(fullPath, content);
+  renderNotes();
+}
+
+async function promptCreateNote(): Promise<void> {
+  if (!currentFolder) {
+    flashStatus('Open a folder first');
+    return;
+  }
+  const title = window.prompt('New note title:');
+  if (!title) return;
+  const { entry, fullPath } = await window.mid.notesCreate(currentFolder, title);
+  notes.push(entry);
+  renderNotes();
+  const content = await window.mid.readFile(fullPath);
+  loadFileContent(fullPath, content);
+}
+
+async function deleteNote(note: NoteEntry): Promise<void> {
+  if (!currentFolder) return;
+  if (!window.confirm(`Delete "${note.title}"? The file will be removed too.`)) return;
+  await window.mid.notesDelete(currentFolder, note.id);
+  notes = notes.filter(n => n.id !== note.id);
+  renderNotes();
+}
 
 window.mid.onThemeChanged(applyTheme);
 window.mid.onMenuOpen(() => void openFile());

--- a/docs/desktop-notes.md
+++ b/docs/desktop-notes.md
@@ -1,0 +1,69 @@
+# Notes management
+
+The desktop sidebar has two modes: **Files** (the filesystem tree from #77) and **Notes** (a curated registry of markdown notes you've created through the app). The mode toggle sits at the top of the sidebar.
+
+## Notes registry
+
+When the user creates a note from the app, an entry is recorded in `<workspaceFolder>/.mid/notes.json`:
+
+```json
+[
+  {
+    "id": "project-kickoff",
+    "title": "Project kickoff",
+    "path": "notes/project-kickoff.md",
+    "tags": ["planning", "mvp"],
+    "created": "2026-04-30T01:23:45.000Z",
+    "updated": "2026-04-30T01:23:45.000Z"
+  }
+]
+```
+
+The registry lives **inside the workspace** so it travels with the project on disk, syncs along with the markdown files, and stays decoupled from the host machine's user-data dir.
+
+## Capabilities (v1)
+
+| Action | How |
+| --- | --- |
+| **Create** | `+` button or `Cmd/Ctrl+N` while a folder is open. Prompts for a title, slugifies it (`Project Kickoff` → `project-kickoff`), writes `notes/<slug>.md` with a `# Title` heading, registers the entry, opens it for editing. |
+| **Open** | Click a row → loads the file into the active mode (Split / View / Edit). |
+| **Delete** | Trash icon (revealed on hover) → confirm → registry entry removed and file `unlink`ed. |
+| **Filter** | Free-text input filters the list against title + tags, case-insensitive substring. |
+| **Sort** | Most recently updated first (auto). |
+
+The list shows `title` + `updated` date + tag chips per row.
+
+## IPC surface
+
+| Channel | Signature |
+| --- | --- |
+| `mid:notes-list` | `(workspace) → NoteEntry[]` |
+| `mid:notes-create` | `(workspace, title) → { entry, fullPath }` |
+| `mid:notes-rename` | `(workspace, id, title) → NoteEntry \| null` |
+| `mid:notes-delete` | `(workspace, id) → boolean` |
+| `mid:notes-tag` | `(workspace, id, tags) → NoteEntry \| null` |
+
+Slug collisions are auto-suffixed (`note-2`, `note-3`, …). Missing registry file is treated as empty list (first-time write creates `.mid/`).
+
+## Out of scope (follow-up)
+
+- **Tag editor UI** — the IPC + persistence are wired, but the renderer doesn't yet expose a way to edit tags interactively. Add when there's UX for it (e.g. inline chip editor on the active note).
+- **Full-text content search** — current filter only checks title + tags. Wiring `packages/core/src/search/searcher.ts` would let it span note bodies.
+- **Wikilink-aware rename** — renaming a note via the Notes panel doesn't currently rewrite `[[wikilink]]` references in other notes. The resolver in `packages/core/src/wikilinks/resolver.ts` could do this; tracked separately.
+
+## Files
+
+- `apps/electron/main.ts` — registry CRUD (`readNotes`, `writeNotes`, `slugify`, IPC handlers).
+- `apps/electron/preload.ts` — bridges (`notesList` / `notesCreate` / `notesRename` / `notesDelete` / `notesTag`).
+- `apps/electron/renderer/index.html` — Files/Notes toggle, notes header, notes list container.
+- `apps/electron/renderer/renderer.ts` — `setSidebarMode`, `loadNotes`, `renderNotes`, `renderNoteRow`, `openNote`, `promptCreateNote`, `deleteNote`, `Cmd/Ctrl+N` accelerator.
+- `apps/electron/renderer/renderer.css` — `.mid-sidebar-mode*`, `.mid-notes-list`, `.mid-note-row`, `.mid-note-tag`, `.mid-note-delete`.
+
+## Verifying
+
+1. `npm run dev:electron`, open this repo as a folder.
+2. Click the **Notes** tab in the sidebar — empty state ("No notes yet…").
+3. `Cmd+N` → enter "Test note" → a `notes/test-note.md` is created with a `# Test note` heading.
+4. Type some content. Type "test" in the filter — the row stays. Type "xyz" — no matches.
+5. Hover the row, click the trash icon → confirm → file is deleted from disk and registry.
+6. Quit and relaunch — the registry persists if it had any rows when you closed.


### PR DESCRIPTION
## Summary
- Sidebar tab toggle: **Files** (filesystem tree) / **Notes** (registry).
- Per-workspace registry stored at `<workspace>/.mid/notes.json`. Travels with the project.
- Note shape: `{ id, title, path, tags[], created, updated }`. Slug-based ids; collisions auto-suffixed.
- IPC: `notes-list` / `notes-create` / `notes-rename` / `notes-delete` / `notes-tag`.
- Renderer UI:
  - `+` button or `Cmd/Ctrl+N` (when a folder is open) creates a new note: prompts for title, writes `notes/<slug>.md` with `# Title` heading, opens it.
  - Free-text filter over title + tags (case-insensitive substring).
  - Most-recently-updated first.
  - Hover-revealed trash to delete (file unlinked + registry pruned).
- Tag editor UI / wikilink-aware rename / full-text content search documented as follow-ups.
- Docs at `docs/desktop-notes.md`.

Closes #97 — part of #87.

## Test plan
- [ ] Open a folder → sidebar shows Files | Notes tabs.
- [ ] Click Notes — empty state.
- [ ] `Cmd+N` → "Smoke test" → file created at `notes/smoke-test.md`, opened in editor with `# Smoke test`.
- [ ] Filter input "smoke" — matches; "xyz" — no rows.
- [ ] Hover the row, click trash — confirm, file gone, row gone.
- [ ] Relaunch — surviving notes persist.