### PR TITLE
feat(desktop): GitHub repo connection — gh CLI auth + git sync (#98)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -2,8 +2,11 @@ import { app, BrowserWindow, dialog, ipcMain, Menu, MenuItemConstructorOptions, 
 import { autoUpdater } from 'electron-updater';
 import { promises as fs } from 'fs';
 import * as path from 'path';
-import { fork, ChildProcess } from 'child_process';
+import { fork, ChildProcess, execFile } from 'child_process';
 import * as os from 'os';
+import { promisify } from 'util';
+
+const execFileP = promisify(execFile);
 
 const isDev = process.env.MID_DEV === '1' || !app.isPackaged;
 const updateState = {
@@ -213,6 +216,107 @@ ipcMain.handle('mid:notes-tag', async (_e, workspace: string, id: string, tags: 
   note.updated = new Date().toISOString();
   await writeNotes(workspace, notes);
   return note;
+});
+
+async function runGit(workspace: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return execFileP('git', args, { cwd: workspace });
+}
+
+ipcMain.handle('mid:gh-auth-status', async () => {
+  try {
+    const { stdout } = await execFileP('gh', ['auth', 'status']);
+    return { authenticated: true, output: stdout };
+  } catch (err) {
+    const message = (err as { stderr?: string; message: string }).stderr ?? (err as Error).message;
+    return { authenticated: false, output: message };
+  }
+});
+
+ipcMain.handle('mid:repo-status', async (_e, workspace: string) => {
+  try {
+    const { stdout } = await runGit(workspace, ['status', '--porcelain=v2', '--branch']);
+    let branch = '';
+    let ahead = 0;
+    let behind = 0;
+    let dirty = 0;
+    for (const line of stdout.split('\n')) {
+      if (line.startsWith('# branch.head ')) branch = line.slice('# branch.head '.length);
+      else if (line.startsWith('# branch.ab ')) {
+        const parts = line.slice('# branch.ab '.length).split(' ');
+        ahead = Math.abs(Number(parts[0] ?? 0));
+        behind = Math.abs(Number(parts[1] ?? 0));
+      } else if (line.trim()) dirty++;
+    }
+    let remote = '';
+    try {
+      const r = await runGit(workspace, ['config', '--get', 'remote.origin.url']);
+      remote = r.stdout.trim();
+    } catch { /* no remote — ok */ }
+    return { initialized: true, branch, ahead, behind, dirty, remote };
+  } catch {
+    return { initialized: false, branch: '', ahead: 0, behind: 0, dirty: 0, remote: '' };
+  }
+});
+
+ipcMain.handle('mid:repo-connect', async (_e, workspace: string, repoSlug: string) => {
+  // 1. Ensure git initialized
+  try {
+    await runGit(workspace, ['rev-parse', '--git-dir']);
+  } catch {
+    await runGit(workspace, ['init', '-b', 'main']);
+  }
+  // 2. Build remote URL — prefer https with gh credentials.
+  const url = `https://github.com/${repoSlug}.git`;
+  // 3. Add or update origin
+  try {
+    await runGit(workspace, ['remote', 'set-url', 'origin', url]);
+  } catch {
+    await runGit(workspace, ['remote', 'add', 'origin', url]);
+  }
+  // 4. Initial commit if no HEAD yet
+  try {
+    await runGit(workspace, ['rev-parse', '--verify', 'HEAD']);
+  } catch {
+    await runGit(workspace, ['add', '-A']);
+    try {
+      await runGit(workspace, ['commit', '-m', 'Initial commit from Mark It Down']);
+    } catch { /* nothing staged — fine */ }
+  }
+  return { url };
+});
+
+ipcMain.handle('mid:repo-sync', async (_e, workspace: string, message: string) => {
+  const result: { steps: string[]; ok: boolean; error?: string } = { steps: [], ok: true };
+  try {
+    const { stdout: status } = await runGit(workspace, ['status', '--porcelain']);
+    if (status.trim()) {
+      await runGit(workspace, ['add', '-A']);
+      result.steps.push('staged changes');
+      await runGit(workspace, ['commit', '-m', message || `notes: sync ${new Date().toISOString()}`]);
+      result.steps.push('committed');
+    } else {
+      result.steps.push('clean');
+    }
+    try {
+      await runGit(workspace, ['pull', '--rebase', '--autostash']);
+      result.steps.push('pulled');
+    } catch (err) {
+      result.ok = false;
+      result.error = (err as { stderr?: string }).stderr ?? (err as Error).message;
+      return result;
+    }
+    try {
+      await runGit(workspace, ['push']);
+      result.steps.push('pushed');
+    } catch (err) {
+      result.ok = false;
+      result.error = (err as { stderr?: string }).stderr ?? (err as Error).message;
+    }
+  } catch (err) {
+    result.ok = false;
+    result.error = (err as Error).message;
+  }
+  return result;
 });
 
 ipcMain.handle('mid:patch-app-state', async (_e, patch: Partial<AppState>) => {

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -56,6 +56,14 @@ contextBridge.exposeInMainWorld('mid', {
     ipcRenderer.invoke('mid:notes-delete', workspace, id),
   notesTag: (workspace: string, id: string, tags: string[]): Promise<NoteEntry | null> =>
     ipcRenderer.invoke('mid:notes-tag', workspace, id, tags),
+  ghAuthStatus: (): Promise<{ authenticated: boolean; output: string }> =>
+    ipcRenderer.invoke('mid:gh-auth-status'),
+  repoStatus: (workspace: string): Promise<{ initialized: boolean; branch: string; ahead: number; behind: number; dirty: number; remote: string }> =>
+    ipcRenderer.invoke('mid:repo-status', workspace),
+  repoConnect: (workspace: string, repoSlug: string): Promise<{ url: string }> =>
+    ipcRenderer.invoke('mid:repo-connect', workspace, repoSlug),
+  repoSync: (workspace: string, message: string): Promise<{ steps: string[]; ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('mid:repo-sync', workspace, message),
   saveAs: (defaultName: string, content: string | ArrayBuffer, filters: { name: string; extensions: string[] }[]): Promise<string | null> =>
     ipcRenderer.invoke('mid:save-as', defaultName, content, filters),
   exportPDF: (defaultName: string): Promise<string | null> =>

--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -81,6 +81,11 @@
     </div>
     <div class="mid-sidebar-tree" id="tree-root"></div>
     <div class="mid-notes-list" id="notes-list" hidden></div>
+    <footer class="mid-repo-bar" id="repo-bar" hidden>
+      <span class="mid-repo-status" id="repo-status">No repo connected</span>
+      <button id="repo-connect" class="mid-btn mid-btn--icon mid-btn--ghost" title="Connect repo" data-icon="github"></button>
+      <button id="repo-sync" class="mid-btn mid-btn--icon mid-btn--ghost" title="Sync (commit + pull + push)" data-icon="refresh" hidden></button>
+    </footer>
   </aside>
   <main id="root" class="viewing">
     <div class="empty-state">

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -165,6 +165,27 @@ body.has-sidebar .mid-shell {
 .mid-note-row:hover .mid-note-delete { opacity: 1; }
 .mid-note-delete:hover { color: var(--mid-danger); background: var(--mid-surface); }
 
+/* Repo status bar at the bottom of the sidebar */
+.mid-repo-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--mid-space-1);
+  padding: var(--mid-space-2) var(--mid-space-3);
+  border-top: 1px solid var(--mid-border);
+  background: var(--mid-surface);
+}
+.mid-repo-bar[hidden] { display: none; }
+.mid-repo-status {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--mid-font-mono);
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .mid-titlebar {
   display: grid;
   grid-template-columns: 1fr auto 1fr;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -63,6 +63,10 @@ interface Mid {
   notesRename(workspace: string, id: string, title: string): Promise<NoteEntry | null>;
   notesDelete(workspace: string, id: string): Promise<boolean>;
   notesTag(workspace: string, id: string, tags: string[]): Promise<NoteEntry | null>;
+  ghAuthStatus(): Promise<{ authenticated: boolean; output: string }>;
+  repoStatus(workspace: string): Promise<{ initialized: boolean; branch: string; ahead: number; behind: number; dirty: number; remote: string }>;
+  repoConnect(workspace: string, repoSlug: string): Promise<{ url: string }>;
+  repoSync(workspace: string, message: string): Promise<{ steps: string[]; ok: boolean; error?: string }>;
   saveAs(defaultName: string, content: string | ArrayBuffer, filters: { name: string; extensions: string[] }[]): Promise<string | null>;
   exportPDF(defaultName: string): Promise<string | null>;
   saveFileDialog(defaultName: string, content: string): Promise<string | null>;
@@ -97,6 +101,10 @@ const sidebarNotesHeader = document.getElementById('sidebar-notes-header') as HT
 const notesListEl = document.getElementById('notes-list') as HTMLDivElement;
 const notesFilter = document.getElementById('notes-filter') as HTMLInputElement;
 const notesNewBtn = document.getElementById('notes-new') as HTMLButtonElement;
+const repoBar = document.getElementById('repo-bar') as HTMLElement;
+const repoStatusEl = document.getElementById('repo-status') as HTMLSpanElement;
+const repoConnectBtn = document.getElementById('repo-connect') as HTMLButtonElement;
+const repoSyncBtn = document.getElementById('repo-sync') as HTMLButtonElement;
 
 let currentText = '';
 let currentPath: string | null = null;
@@ -835,6 +843,7 @@ function applyFolder(folderPath: string, tree: TreeEntry[]): void {
   currentFolder = folderPath;
   document.body.classList.add('has-sidebar');
   sidebar.hidden = false;
+  repoBar.hidden = false;
   sidebarFolderName.textContent = folderPath.split('/').pop() ?? folderPath;
   sidebarFolderName.title = folderPath;
   treeRoot.replaceChildren(...renderTree(tree));
@@ -844,6 +853,58 @@ function applyFolder(folderPath: string, tree: TreeEntry[]): void {
     empty.textContent = 'No markdown files in this folder.';
     treeRoot.appendChild(empty);
   }
+  void refreshRepoStatus();
+}
+
+async function refreshRepoStatus(): Promise<void> {
+  if (!currentFolder) return;
+  const s = await window.mid.repoStatus(currentFolder);
+  if (!s.initialized || !s.remote) {
+    repoStatusEl.textContent = s.initialized ? 'No remote' : 'No repo connected';
+    repoStatusEl.title = s.remote || '';
+    repoSyncBtn.hidden = true;
+    return;
+  }
+  const slug = parseSlugFromUrl(s.remote);
+  const branch = s.branch || 'detached';
+  const counters: string[] = [];
+  if (s.ahead) counters.push(`↑${s.ahead}`);
+  if (s.behind) counters.push(`↓${s.behind}`);
+  if (s.dirty) counters.push(`±${s.dirty}`);
+  const counterText = counters.length ? ` ${counters.join(' ')}` : '';
+  repoStatusEl.textContent = `${slug} · ${branch}${counterText}`;
+  repoStatusEl.title = s.remote;
+  repoSyncBtn.hidden = false;
+}
+
+function parseSlugFromUrl(url: string): string {
+  const m = /github\.com[:/]([^/]+\/[^/.]+?)(?:\.git)?\/?$/.exec(url);
+  return m ? m[1] : url;
+}
+
+async function promptConnectRepo(): Promise<void> {
+  if (!currentFolder) return;
+  const auth = await window.mid.ghAuthStatus();
+  if (!auth.authenticated) {
+    const proceed = window.confirm(`gh CLI is not authenticated.\n\n${auth.output}\n\nRun "gh auth login" in a terminal first, then retry.\n\nContinue anyway?`);
+    if (!proceed) return;
+  }
+  const slug = window.prompt('GitHub repo (owner/name):');
+  if (!slug || !/^[^/]+\/[^/]+$/.test(slug)) return;
+  await window.mid.repoConnect(currentFolder, slug);
+  flashStatus(`Connected to ${slug}`);
+  await refreshRepoStatus();
+}
+
+async function syncRepo(): Promise<void> {
+  if (!currentFolder) return;
+  repoSyncBtn.disabled = true;
+  const message = window.prompt('Commit message (leave empty for auto):') ?? '';
+  const result = await window.mid.repoSync(currentFolder, message);
+  repoSyncBtn.disabled = false;
+  if (result.ok) flashStatus(`Synced — ${result.steps.join(', ')}`);
+  else flashStatus(`Sync failed: ${result.error?.split('\n')[0] ?? 'unknown'}`);
+  await refreshRepoStatus();
 }
 
 function renderTree(entries: TreeEntry[]): HTMLElement[] {
@@ -1026,6 +1087,8 @@ notesFilter.addEventListener('input', () => {
   notesFilterText = notesFilter.value.trim().toLowerCase();
   renderNotes();
 });
+repoConnectBtn.addEventListener('click', () => void promptConnectRepo());
+repoSyncBtn.addEventListener('click', () => void syncRepo());
 
 document.addEventListener('keydown', e => {
   if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'n' && !e.shiftKey && !e.altKey) {

--- a/docs/desktop-github-sync.md
+++ b/docs/desktop-github-sync.md
@@ -1,0 +1,69 @@
+# GitHub repo connection
+
+A workspace folder can be connected to a GitHub repository so notes commit + push from inside the app. v1 uses the local `gh` CLI for auth and `git` for the actual sync — no embedded device-flow OAuth or keychain storage yet (tracked as a follow-up).
+
+## Sidebar repo bar
+
+A status row at the bottom of the sidebar:
+
+| State | Display |
+| --- | --- |
+| No git in workspace | `No repo connected` + GitHub icon to connect |
+| Git initialized, no remote | `No remote` + connect icon |
+| Connected | `<owner/name> · <branch> ↑N ↓N ±N` + sync icon |
+
+`↑N` = ahead of upstream, `↓N` = behind, `±N` = uncommitted dirty paths.
+
+## Connect
+
+Click the GitHub icon → free-text prompt for `owner/name`. The flow:
+
+1. Calls `mid:gh-auth-status` (`gh auth status`) — if `gh` isn't logged in, surfaces a confirm with the message and a tip to run `gh auth login`.
+2. `git init -b main` if the workspace has no `.git`.
+3. Adds `https://github.com/<owner>/<name>.git` as `origin` (set-url if present, add otherwise).
+4. If no `HEAD` yet, makes an initial `git add -A && git commit -m "Initial commit from Mark It Down"` (skipped if the index is empty).
+
+The remote URL uses HTTPS — credentials are pulled from `gh`'s credential helper at push time. If the user has SSH set up they can swap the URL manually with `git remote set-url`; the app doesn't currently rewrite SSH↔HTTPS.
+
+## Sync
+
+Click the refresh icon → optional commit-message prompt. The flow:
+
+1. `git status --porcelain` — if dirty, `git add -A` + `git commit -m "<msg or auto>"`.
+2. `git pull --rebase --autostash` — fast-forward / rebase any upstream changes.
+3. `git push` — publish.
+
+Each step is reported as a chip in the title-bar status flash (`Synced — staged changes, committed, pulled, pushed`). On failure, the first error line is surfaced to the user; partial state stays — sync is recoverable from the terminal.
+
+## IPC surface
+
+| Channel | Returns |
+| --- | --- |
+| `mid:gh-auth-status` | `{ authenticated, output }` from `gh auth status`. |
+| `mid:repo-status` | `{ initialized, branch, ahead, behind, dirty, remote }` parsed from `git status --porcelain=v2 --branch`. |
+| `mid:repo-connect(workspace, slug)` | Initializes git, sets origin, writes initial commit. |
+| `mid:repo-sync(workspace, message)` | Add → commit → pull → push, with per-step result. |
+
+## Out of scope (follow-up)
+
+- **Device-flow OAuth + keytar fallback** — when `gh` isn't installed, run the GitHub OAuth device flow inside the app and store the token in the OS keychain via `keytar`. Requires registering an OAuth app and a keytar dependency; deferred.
+- **Conflict UI** — `pull --rebase` may produce conflicts; the app currently surfaces the error string and leaves the user in a half-rebase state to resolve in their editor / terminal. A proper conflict resolver UI is a separate feature.
+- **Auto-commit-on-save toggle** — the issue body proposed it; v1 chose explicit Sync to keep behavior predictable.
+- **Repo picker autocomplete from `gh repo list`** — v1 uses a free-text prompt. A picker that lists the user's repos is a UX win; defer.
+
+## Files
+
+- `apps/electron/main.ts` — `runGit`, `mid:gh-auth-status`, `mid:repo-status`, `mid:repo-connect`, `mid:repo-sync`. Uses Node's `execFile` (promisified) — no extra dependencies.
+- `apps/electron/preload.ts` — bridges (`ghAuthStatus`, `repoStatus`, `repoConnect`, `repoSync`).
+- `apps/electron/renderer/index.html` — `<footer class="mid-repo-bar">` in the sidebar.
+- `apps/electron/renderer/renderer.ts` — `refreshRepoStatus`, `parseSlugFromUrl`, `promptConnectRepo`, `syncRepo`.
+- `apps/electron/renderer/renderer.css` — `.mid-repo-bar`, `.mid-repo-status`.
+
+## Verifying
+
+1. `gh auth status` — confirm you're logged in (else `gh auth login`).
+2. `npm run dev:electron`, open this repo as a folder.
+3. Sidebar footer reads `fadymondy/mark-it-down · main ↑0 ↓0`.
+4. Edit a markdown file in the editor, save → footer flips to `±1`.
+5. Click the sync icon → leave the message blank → rapid status chips → footer back to `±0`.
+6. Connect a fresh empty folder via the GitHub icon → `owner/new-repo-name`. Repo bar updates with the new slug and branch.


### PR DESCRIPTION
## Summary
- Sidebar footer **repo bar** showing `<owner/name> · <branch> ↑N ↓N ±N` once a workspace folder is connected.
- **Connect**: GitHub icon → prompts for `owner/name` → checks `gh auth status` → `git init`, sets origin to `https://…`, makes initial commit if HEAD is unborn.
- **Sync**: refresh icon → optional commit message → `git add -A && git commit && git pull --rebase --autostash && git push`. Per-step status flashed in the title bar.
- IPC: `mid:gh-auth-status`, `mid:repo-status`, `mid:repo-connect`, `mid:repo-sync`. All implemented via Node's `execFile` against `git` / `gh` — no new npm deps.
- Auth is **delegated to `gh`** for v1; no embedded device flow + keychain. Documented as a clear follow-up alongside conflict UI, auto-commit-on-save, and repo-picker autocomplete.
- Docs at `docs/desktop-github-sync.md`.

Closes #98 — part of #87.

## Test plan
- [ ] `gh auth status` is OK on the host.
- [ ] `npm run dev:electron`, open this repo — sidebar footer shows `fadymondy/mark-it-down · main ↑0 ↓0`.
- [ ] Edit a md file, save → footer flips to `±1`.
- [ ] Click sync, blank message → status flashes "staged, committed, pulled, pushed"; footer back to clean.
- [ ] Open an unconfigured folder → footer shows "No repo connected"; click connect → enter `owner/new-name` → footer updates.
- [ ] If `gh` not authenticated, connect surfaces the message with a tip to `gh auth login`.