### PR TITLE
fix(desktop): replace unsupported prompt/confirm with HTML5 dialog modal (#110)

### DIFF
--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -94,6 +94,20 @@
     </div>
   </main>
 </div>
+<dialog id="mid-dialog" class="mid-dialog">
+  <form method="dialog" class="mid-dialog-form">
+    <h3 class="mid-dialog-title" id="mid-dialog-title"></h3>
+    <p class="mid-dialog-message" id="mid-dialog-message" hidden></p>
+    <label class="mid-dialog-label" id="mid-dialog-label" hidden>
+      <span id="mid-dialog-label-text"></span>
+      <input type="text" id="mid-dialog-input" class="mid-settings-control" />
+    </label>
+    <div class="mid-dialog-actions">
+      <button type="button" id="mid-dialog-cancel" class="mid-btn">Cancel</button>
+      <button type="submit" id="mid-dialog-ok" class="mid-btn mid-btn--primary">OK</button>
+    </div>
+  </form>
+</dialog>
 <script src="renderer.js"></script>
 </body>
 </html>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -186,6 +186,35 @@ body.has-sidebar .mid-shell {
   text-overflow: ellipsis;
 }
 
+/* Modal dialog (replaces window.prompt / window.confirm — unsupported in Electron) */
+.mid-dialog {
+  margin: auto;
+  padding: 0;
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-lg);
+  background: var(--mid-surface);
+  color: var(--mid-fg);
+  box-shadow: var(--mid-shadow-lg);
+  width: min(440px, calc(100vw - 32px));
+}
+.mid-dialog::backdrop { background: rgba(0, 0, 0, 0.5); }
+.mid-dialog-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-3);
+  padding: var(--mid-space-4);
+}
+.mid-dialog-title { margin: 0; font-size: var(--mid-font-size-lg); font-weight: var(--mid-weight-semibold); }
+.mid-dialog-message { margin: 0; color: var(--mid-fg-muted); font-size: var(--mid-font-size-sm); white-space: pre-wrap; }
+.mid-dialog-label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-1);
+  font-size: var(--mid-font-size-sm);
+  font-weight: var(--mid-weight-medium);
+}
+.mid-dialog-actions { display: flex; justify-content: flex-end; gap: var(--mid-space-2); }
+
 .mid-titlebar {
   display: grid;
   grid-template-columns: 1fr auto 1fr;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -886,10 +886,13 @@ async function promptConnectRepo(): Promise<void> {
   if (!currentFolder) return;
   const auth = await window.mid.ghAuthStatus();
   if (!auth.authenticated) {
-    const proceed = window.confirm(`gh CLI is not authenticated.\n\n${auth.output}\n\nRun "gh auth login" in a terminal first, then retry.\n\nContinue anyway?`);
+    const proceed = await midConfirm(
+      'gh CLI not authenticated',
+      `${auth.output.split('\n')[0]}\n\nRun "gh auth login" in a terminal first, then retry. Continue anyway?`,
+    );
     if (!proceed) return;
   }
-  const slug = window.prompt('GitHub repo (owner/name):');
+  const slug = await midPrompt('Connect GitHub repo', 'owner/name', '');
   if (!slug || !/^[^/]+\/[^/]+$/.test(slug)) return;
   await window.mid.repoConnect(currentFolder, slug);
   flashStatus(`Connected to ${slug}`);
@@ -899,7 +902,7 @@ async function promptConnectRepo(): Promise<void> {
 async function syncRepo(): Promise<void> {
   if (!currentFolder) return;
   repoSyncBtn.disabled = true;
-  const message = window.prompt('Commit message (leave empty for auto):') ?? '';
+  const message = (await midPrompt('Sync repo', 'Commit message (blank = auto)', '')) ?? '';
   const result = await window.mid.repoSync(currentFolder, message);
   repoSyncBtn.disabled = false;
   if (result.ok) flashStatus(`Synced — ${result.steps.join(', ')}`);
@@ -1182,7 +1185,7 @@ async function promptCreateNote(): Promise<void> {
     flashStatus('Open a folder first');
     return;
   }
-  const title = window.prompt('New note title:');
+  const title = await midPrompt('New note', 'Title', '');
   if (!title) return;
   const { entry, fullPath } = await window.mid.notesCreate(currentFolder, title);
   notes.push(entry);
@@ -1193,10 +1196,81 @@ async function promptCreateNote(): Promise<void> {
 
 async function deleteNote(note: NoteEntry): Promise<void> {
   if (!currentFolder) return;
-  if (!window.confirm(`Delete "${note.title}"? The file will be removed too.`)) return;
+  const ok = await midConfirm('Delete note?', `"${note.title}" — the file will be removed too.`);
+  if (!ok) return;
   await window.mid.notesDelete(currentFolder, note.id);
   notes = notes.filter(n => n.id !== note.id);
   renderNotes();
+}
+
+interface DialogResult { canceled: boolean; value: string; }
+function openDialog(opts: { title: string; message?: string; label?: string; defaultValue?: string }): Promise<DialogResult> {
+  return new Promise(resolve => {
+    const dlg = document.getElementById('mid-dialog') as HTMLDialogElement;
+    const titleEl = document.getElementById('mid-dialog-title') as HTMLHeadingElement;
+    const messageEl = document.getElementById('mid-dialog-message') as HTMLParagraphElement;
+    const labelEl = document.getElementById('mid-dialog-label') as HTMLLabelElement;
+    const labelTextEl = document.getElementById('mid-dialog-label-text') as HTMLSpanElement;
+    const inputEl = document.getElementById('mid-dialog-input') as HTMLInputElement;
+    const cancelBtn = document.getElementById('mid-dialog-cancel') as HTMLButtonElement;
+    const form = dlg.querySelector('form') as HTMLFormElement;
+
+    titleEl.textContent = opts.title;
+    if (opts.message) {
+      messageEl.textContent = opts.message;
+      messageEl.hidden = false;
+    } else {
+      messageEl.hidden = true;
+    }
+    if (opts.label !== undefined) {
+      labelEl.hidden = false;
+      labelTextEl.textContent = opts.label;
+      inputEl.value = opts.defaultValue ?? '';
+    } else {
+      labelEl.hidden = true;
+    }
+
+    let canceled = true;
+    const onSubmit = (e: Event): void => {
+      e.preventDefault();
+      canceled = false;
+      cleanup();
+      dlg.close();
+      resolve({ canceled: false, value: inputEl.value });
+    };
+    const onCancel = (): void => {
+      cleanup();
+      dlg.close();
+      resolve({ canceled: true, value: '' });
+    };
+    const onClose = (): void => {
+      if (canceled) {
+        cleanup();
+        resolve({ canceled: true, value: '' });
+      }
+    };
+    function cleanup(): void {
+      form.removeEventListener('submit', onSubmit);
+      cancelBtn.removeEventListener('click', onCancel);
+      dlg.removeEventListener('close', onClose);
+    }
+    form.addEventListener('submit', onSubmit);
+    cancelBtn.addEventListener('click', onCancel);
+    dlg.addEventListener('close', onClose);
+
+    dlg.showModal();
+    if (opts.label !== undefined) inputEl.focus();
+  });
+}
+
+async function midPrompt(title: string, label: string, defaultValue = ''): Promise<string | null> {
+  const result = await openDialog({ title, label, defaultValue });
+  return result.canceled ? null : result.value;
+}
+
+async function midConfirm(title: string, message: string): Promise<boolean> {
+  const result = await openDialog({ title, message });
+  return !result.canceled;
 }
 
 window.mid.onThemeChanged(applyTheme);


### PR DESCRIPTION
## Summary
Electron's renderer process throws `Error: prompt() is not supported.` when JS calls `window.prompt()` or `window.confirm()` — they're disabled by default. PRs #108 and #109 used both, so New Note / Delete Note / Connect Repo / Sync Repo / gh-auth-not-authenticated all crashed on click.

- New `<dialog id="mid-dialog">` shell in `index.html` with title / message / optional input / OK / Cancel.
- New helpers in renderer.ts: `midPrompt(title, label, defaultValue?) → Promise<string | null>` and `midConfirm(title, message) → Promise<boolean>`.
- All four call sites switched: `promptCreateNote`, `deleteNote`, `promptConnectRepo` (auth + slug), `syncRepo`.
- Styled to match the rest of the chrome via `--mid-*` tokens — modal sits centered with the standard backdrop, focus lands on the input.

Closes #110.

## Test plan
- [ ] Sidebar → Notes tab → `+` or `Cmd/Ctrl+N` → modal opens, type a title, OK creates the note. No "prompt() is not supported" in the console.
- [ ] Hover a note row → click trash → modal asks for confirmation, Delete proceeds.
- [ ] Repo bar → GitHub icon → modal asks for `owner/name`. If `gh` not authenticated, a confirm modal precedes it.
- [ ] Repo bar → sync icon → modal asks for commit message; blank submits an auto message.
- [ ] Esc cancels the modal in all cases (no action taken).