### PR TITLE
fix(desktop): default to View (preview) mode on launch (#113)

### DIFF
--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -22,8 +22,8 @@
     <span id="filename" class="mid-filename">Untitled</span>
   </div>
   <div class="mid-titlebar-right">
-    <button id="mode-view" class="mid-btn" title="View" data-icon="show" data-label="View"></button>
-    <button id="mode-split" class="mid-btn is-active" title="Split (default)" data-icon="columns" data-label="Split"></button>
+    <button id="mode-view" class="mid-btn is-active" title="View (default)" data-icon="show" data-label="View"></button>
+    <button id="mode-split" class="mid-btn" title="Split" data-icon="columns" data-label="Split"></button>
     <button id="mode-edit" class="mid-btn" title="Edit" data-icon="edit" data-label="Edit"></button>
     <button id="settings-btn" class="mid-btn mid-btn--icon mid-btn--ghost" title="Settings (Cmd/Ctrl+,)" data-icon="cog"></button>
   </div>

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -108,7 +108,7 @@ const repoSyncBtn = document.getElementById('repo-sync') as HTMLButtonElement;
 
 let currentText = '';
 let currentPath: string | null = null;
-let currentMode: Mode = 'split';
+let currentMode: Mode = 'view';
 let mermaidThemeKind = 0;
 let currentFolder: string | null = null;
 let splitRatio = 0.5;
@@ -825,7 +825,7 @@ function loadFileContent(filePath: string, content: string): void {
   currentPath = filePath;
   filenameEl.textContent = filePath.split('/').pop() ?? 'Untitled';
   highlightActiveTreeItem();
-  setMode(currentMode === 'view' && content.length > 0 ? 'split' : currentMode);
+  setMode(currentMode);
 }
 
 async function selectTreeFile(filePath: string): Promise<void> {


### PR DESCRIPTION
## Summary
- `currentMode` initial value flips from `'split'` to `'view'`.
- `loadFileContent` no longer auto-promotes View → Split when a file with content is loaded — preserves the user's chosen mode.
- HTML moves the `is-active` class to the View button.

This matches the app's pitch: a markdown previewer first, with editing one click away.

Closes #113 — part of #112.

## Test plan
- [ ] Launch — View mode is the active button.
- [ ] Open a file — preview is what you see, not split.
- [ ] Toggle Split / Edit — works.
- [ ] Open a second file — stays in the user's last mode (no auto-flip).