### PR TITLE
feat(desktop): right-click context menus replacing hover toolbars (#114)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -478,39 +478,44 @@ main.splitting .mid-preview {
   border-radius: var(--mid-radius-pill);
 }
 
-.mid-code-toolbar {
-  position: absolute;
-  top: var(--mid-space-2);
-  right: var(--mid-space-2);
-  display: flex;
-  gap: 2px;
-  padding: 2px;
+/* Context menu (replaces hover toolbars on code / table / mermaid / file-tree / notes) */
+.mid-context-menu {
+  position: fixed;
+  z-index: var(--mid-z-modal);
+  min-width: 200px;
+  padding: var(--mid-space-1);
   background: var(--mid-surface);
   border: 1px solid var(--mid-border);
-  border-radius: var(--mid-radius-sm);
-  opacity: 0;
-  transition: opacity var(--mid-motion-fast) var(--mid-ease-out);
+  border-radius: var(--mid-radius-md);
+  box-shadow: var(--mid-shadow-lg);
+  animation: mid-fade-in var(--mid-motion-fast) var(--mid-ease-out);
 }
-.mid-pre:hover .mid-code-toolbar,
-.mid-code-toolbar:focus-within { opacity: 1; }
-.mid-code-tool-btn {
-  display: inline-flex;
+.mid-context-item {
+  display: flex;
   align-items: center;
-  gap: var(--mid-space-1);
-  padding: 2px var(--mid-space-1);
+  gap: var(--mid-space-2);
+  width: 100%;
+  padding: var(--mid-space-1) var(--mid-space-3);
   font-family: var(--mid-font-sans);
-  font-size: var(--mid-font-size-xs);
-  color: var(--mid-fg-muted);
+  font-size: var(--mid-font-size-sm);
+  color: var(--mid-fg);
+  text-align: left;
   background: transparent;
   border: 0;
-  border-radius: var(--mid-radius-xs);
+  border-radius: var(--mid-radius-sm);
   cursor: pointer;
 }
-.mid-code-tool-btn:hover { background: var(--mid-surface-hover); color: var(--mid-fg); }
-.mid-code-tool-flash {
+.mid-context-item:hover:not(:disabled) { background: var(--mid-accent); color: var(--mid-accent-fg); }
+.mid-context-item:hover:not(:disabled) .mid-icon { color: var(--mid-accent-fg); }
+.mid-context-item:disabled { color: var(--mid-fg-subtle); cursor: default; }
+.mid-context-label { flex: 1; }
+.mid-context-kbd {
+  font-family: var(--mid-font-mono);
   font-size: var(--mid-font-size-xs);
-  font-weight: var(--mid-weight-medium);
+  color: var(--mid-fg-muted);
 }
+.mid-context-item:hover .mid-context-kbd { color: var(--mid-accent-fg); opacity: 0.85; }
+.mid-context-sep { height: 1px; margin: var(--mid-space-1) 0; background: var(--mid-border); }
 
 .mid-code-gutter {
   display: none;
@@ -532,38 +537,41 @@ main.splitting .mid-preview {
   overflow: hidden;
   background: var(--mid-bg);
 }
+.mid-table { position: relative; }
 .mid-table table { margin: 0; border: 0; border-radius: 0; }
 .mid-table th { position: sticky; top: 0; z-index: 1; }
-.mid-table-toolbar {
+
+/* Compact filter chip in the top-right of large tables (>5 rows). */
+.mid-table-chip {
+  position: absolute;
+  top: var(--mid-space-2);
+  right: var(--mid-space-2);
+  z-index: 2;
   display: flex;
   align-items: center;
   gap: var(--mid-space-2);
-  padding: var(--mid-space-2) var(--mid-space-3);
-  background: var(--mid-surface);
-  border-bottom: 1px solid var(--mid-border);
+  padding: 2px var(--mid-space-2);
+  background: var(--mid-bg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-pill);
+  box-shadow: var(--mid-shadow-sm);
 }
+.mid-table-chip[hidden] { display: none; }
 .mid-table-filter {
-  flex: 1;
-  min-width: 0;
-  padding: 4px var(--mid-space-2);
+  width: 140px;
+  padding: 0;
   font-family: inherit;
   font-size: var(--mid-font-size-sm);
   color: var(--mid-fg);
-  background: var(--mid-bg);
-  border: 1px solid var(--mid-border);
-  border-radius: var(--mid-radius-sm);
+  background: transparent;
+  border: 0;
+  outline: none;
 }
-.mid-table-filter:focus-visible { outline: 2px solid var(--mid-accent); outline-offset: 1px; }
 .mid-table-counter {
   font-family: var(--mid-font-mono);
   font-size: var(--mid-font-size-xs);
   color: var(--mid-fg-muted);
   white-space: nowrap;
-}
-.mid-table-exports { display: flex; gap: 2px; }
-.mid-table-exports .mid-code-tool-btn {
-  background: var(--mid-bg);
-  border: 1px solid var(--mid-border);
 }
 
 /* Sort affordances on each header cell */
@@ -692,21 +700,6 @@ main.splitting .mid-preview {
   overflow-x: auto;
   position: relative;
 }
-.mid-mermaid-toolbar {
-  position: absolute;
-  top: var(--mid-space-2);
-  right: var(--mid-space-2);
-  display: flex;
-  gap: 2px;
-  padding: 2px;
-  background: var(--mid-surface);
-  border: 1px solid var(--mid-border);
-  border-radius: var(--mid-radius-sm);
-  opacity: 0;
-  transition: opacity var(--mid-motion-fast) var(--mid-ease-out);
-}
-.mid-preview .mermaid:hover .mid-mermaid-toolbar,
-.mid-mermaid-toolbar:focus-within { opacity: 1; }
 
 main.editing { padding: 0; max-width: none; display: block; height: 100%; }
 main.editing textarea {

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -257,15 +257,16 @@ function populatePreview(preview: HTMLElement): void {
 }
 
 function attachMermaidToolbar(host: HTMLDivElement, source: string): void {
-  const toolbar = document.createElement('div');
-  toolbar.className = 'mid-mermaid-toolbar';
-  toolbar.append(
-    makeIconButton('copy', 'Copy SVG', () => copyMermaidSVG(host)),
-    makeIconButton('download', 'Download SVG', () => downloadMermaidSVG(host, source)),
-    makeIconButton('image', 'Download PNG', () => void downloadMermaidPNG(host)),
-  );
   host.style.position = 'relative';
-  host.appendChild(toolbar);
+  host.addEventListener('contextmenu', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    openContextMenu([
+      { icon: 'copy', label: 'Copy SVG', action: () => copyMermaidSVG(host) },
+      { icon: 'download', label: 'Download SVG', action: () => downloadMermaidSVG(host, source) },
+      { icon: 'image', label: 'Download PNG', action: () => void downloadMermaidPNG(host) },
+    ], e.clientX, e.clientY);
+  });
 }
 
 function copyMermaidSVG(host: HTMLDivElement): void {
@@ -364,23 +365,78 @@ function attachCodeBlockToolbar(scope: HTMLElement): void {
       pre.appendChild(badge);
     }
 
-    const toolbar = document.createElement('div');
-    toolbar.className = 'mid-code-toolbar';
-    toolbar.append(
-      makeIconButton('list-ul', 'Toggle line numbers', () => pre.classList.toggle('with-lines')),
-      makeIconButton('copy', 'Copy', async (btn) => {
-        await navigator.clipboard.writeText(code.innerText).then(
-          () => flashButton(btn, 'copy', 'Copied'),
-          () => flashButton(btn, 'x', 'Failed'),
-        );
-      }),
-      makeIconButton('download', 'Download', () => downloadCode(code.innerText, lang)),
-      makeIconButton('image', 'Export PNG', () => void exportCodeBlockAsPNG(pre)),
-    );
-    pre.appendChild(toolbar);
-
     addLineNumbers(pre, code);
+
+    pre.addEventListener('contextmenu', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      openContextMenu([
+        { icon: 'copy', label: 'Copy', kbd: '⌘C', action: () => void navigator.clipboard.writeText(code.innerText) },
+        { icon: 'download', label: 'Download as file', action: () => downloadCode(code.innerText, lang) },
+        { icon: 'image', label: 'Export as PNG', action: () => void exportCodeBlockAsPNG(pre) },
+        { separator: true, label: '' },
+        { icon: 'list-ul', label: pre.classList.contains('with-lines') ? 'Hide line numbers' : 'Show line numbers', action: () => pre.classList.toggle('with-lines') },
+      ], e.clientX, e.clientY);
+    });
   });
+}
+
+interface MenuItem {
+  icon?: IconName;
+  label: string;
+  kbd?: string;
+  action?: () => void | Promise<void>;
+  separator?: boolean;
+  disabled?: boolean;
+}
+
+function openContextMenu(items: MenuItem[], x: number, y: number): void {
+  document.querySelectorAll('.mid-context-menu').forEach(el => el.remove());
+  const menu = document.createElement('div');
+  menu.className = 'mid-context-menu';
+  for (const item of items) {
+    if (item.separator) {
+      const sep = document.createElement('div');
+      sep.className = 'mid-context-sep';
+      menu.appendChild(sep);
+      continue;
+    }
+    const row = document.createElement('button');
+    row.className = 'mid-context-item';
+    row.type = 'button';
+    if (item.disabled) row.disabled = true;
+    const iconHtml = item.icon ? iconHTML(item.icon, 'mid-icon--sm mid-icon--muted') : '<span class="mid-icon mid-icon--sm"></span>';
+    const kbdHtml = item.kbd ? `<span class="mid-context-kbd">${item.kbd}</span>` : '';
+    row.innerHTML = `${iconHtml}<span class="mid-context-label">${escapeHTML(item.label)}</span>${kbdHtml}`;
+    row.addEventListener('click', () => {
+      void item.action?.();
+      close();
+    });
+    menu.appendChild(row);
+  }
+  document.body.appendChild(menu);
+
+  const rect = menu.getBoundingClientRect();
+  const maxX = window.innerWidth - rect.width - 4;
+  const maxY = window.innerHeight - rect.height - 4;
+  menu.style.left = `${Math.min(x, maxX)}px`;
+  menu.style.top = `${Math.min(y, maxY)}px`;
+
+  const close = (): void => {
+    menu.remove();
+    document.removeEventListener('mousedown', onOutside, true);
+    document.removeEventListener('keydown', onKey, true);
+  };
+  const onOutside = (e: MouseEvent): void => {
+    if (!menu.contains(e.target as Node)) close();
+  };
+  const onKey = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') { e.stopPropagation(); close(); }
+  };
+  setTimeout(() => {
+    document.addEventListener('mousedown', onOutside, true);
+    document.addEventListener('keydown', onKey, true);
+  }, 0);
 }
 
 function makeIconButton(icon: IconName, title: string, onClick: (btn: HTMLButtonElement) => void): HTMLButtonElement {
@@ -549,30 +605,23 @@ function attachTableTools(scope: HTMLElement): void {
     wrapper.className = 'mid-table';
     table.replaceWith(wrapper);
 
-    const toolbar = document.createElement('div');
-    toolbar.className = 'mid-table-toolbar';
-
+    // Compact filter chip — only shown for tables with > 5 rows so small tables stay clean.
+    const showChip = rows.length > 5;
+    const chip = document.createElement('div');
+    chip.className = 'mid-table-chip';
     const filterInput = document.createElement('input');
     filterInput.type = 'search';
     filterInput.className = 'mid-table-filter';
-    filterInput.placeholder = 'Filter rows…';
-
+    filterInput.placeholder = 'Filter…';
     const counter = document.createElement('span');
     counter.className = 'mid-table-counter';
+    chip.append(filterInput, counter);
+    if (!showChip) chip.hidden = true;
 
-    const exportGroup = document.createElement('div');
-    exportGroup.className = 'mid-table-exports';
-    exportGroup.append(
-      makeIconButton('copy', 'Copy as Markdown', () => copyTableAsMarkdown(headers, getVisibleRows(rows))),
-      makeIconButton('download', 'Download CSV', () => downloadTable(headers, getVisibleRows(rows), 'csv')),
-      makeIconButton('list-ul', 'Download JSON', () => downloadTable(headers, getVisibleRows(rows), 'json')),
-    );
-
-    toolbar.append(filterInput, counter, exportGroup);
-    wrapper.append(toolbar, table);
+    wrapper.append(chip, table);
 
     const state: TableState = { sortColumn: null, sortDir: null, filter: '' };
-
+    const getVisible = (): HTMLTableRowElement[] => rows.filter(r => !r.hidden);
     const apply = (): void => applyTableState(headers, rows, state, counter);
     apply();
 
@@ -594,11 +643,20 @@ function attachTableTools(scope: HTMLElement): void {
         apply();
       }, 120);
     });
-  });
 
-  function getVisibleRows(rows: HTMLTableRowElement[]): HTMLTableRowElement[] {
-    return rows.filter(r => !r.hidden);
-  }
+    wrapper.addEventListener('contextmenu', e => {
+      if ((e.target as HTMLElement).closest('input, button')) return;
+      e.preventDefault();
+      e.stopPropagation();
+      openContextMenu([
+        { icon: 'copy', label: 'Copy as Markdown', action: () => copyTableAsMarkdown(headers, getVisible()) },
+        { icon: 'download', label: 'Download CSV', action: () => downloadTable(headers, getVisible(), 'csv') },
+        { icon: 'list-ul', label: 'Download JSON', action: () => downloadTable(headers, getVisible(), 'json') },
+        { separator: true, label: '' },
+        { icon: state.sortColumn === null ? 'x' : 'refresh', label: state.sortColumn === null ? 'No sort active' : 'Reset sort', disabled: state.sortColumn === null, action: () => { state.sortColumn = null; state.sortDir = null; apply(); } },
+      ], e.clientX, e.clientY);
+    });
+  });
 }
 
 function applyTableState(
@@ -945,6 +1003,14 @@ function renderTreeEntry(entry: TreeEntry): HTMLElement {
     item.appendChild(document.createTextNode(` ${entry.name}`));
     if (currentPath === entry.path) item.classList.add('is-active');
     item.addEventListener('click', () => void selectTreeFile(entry.path));
+    item.addEventListener('contextmenu', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      openContextMenu([
+        { icon: 'show', label: 'Open', action: () => void selectTreeFile(entry.path) },
+        { icon: 'folder-open', label: 'Reveal in Finder', action: () => void window.mid.openExternal(`file://${entry.path.replace(/\/[^/]+$/, '')}`) },
+      ], e.clientX, e.clientY);
+    });
     wrapper.appendChild(item);
   }
   return wrapper;
@@ -1169,7 +1235,27 @@ function renderNoteRow(note: NoteEntry): HTMLElement {
   });
   row.append(title, meta, del);
   row.addEventListener('click', () => void openNote(note));
+  row.addEventListener('contextmenu', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    openContextMenu([
+      { icon: 'show', label: 'Open', action: () => void openNote(note) },
+      { icon: 'edit', label: 'Rename…', action: () => void renameNote(note) },
+      { separator: true, label: '' },
+      { icon: 'trash', label: 'Delete', action: () => void deleteNote(note) },
+    ], e.clientX, e.clientY);
+  });
   return row;
+}
+
+async function renameNote(note: NoteEntry): Promise<void> {
+  if (!currentFolder) return;
+  const next = await midPrompt('Rename note', 'Title', note.title);
+  if (next === null || next.trim() === '' || next === note.title) return;
+  const updated = await window.mid.notesRename(currentFolder, note.id, next.trim());
+  if (!updated) return;
+  Object.assign(note, updated);
+  renderNotes();
 }
 
 async function openNote(note: NoteEntry): Promise<void> {
@@ -1278,6 +1364,22 @@ window.mid.onMenuOpen(() => void openFile());
 window.mid.onMenuOpenFolder(() => void openFolder());
 window.mid.onMenuSave(() => void saveFile());
 window.mid.onMenuExport(fmt => void exportAs(fmt));
+
+document.addEventListener('contextmenu', e => {
+  const el = e.target as HTMLElement;
+  if (el.closest('pre, .mid-table, .mermaid, .mid-tree-item, .mid-note-row, input, textarea, button, select')) return;
+  if (!el.closest('.mid-preview, main')) return;
+  e.preventDefault();
+  openContextMenu([
+    { icon: 'copy', label: 'Copy text', action: () => void navigator.clipboard.writeText(currentText) },
+    { separator: true, label: '' },
+    { icon: 'download', label: 'Export Markdown', action: () => void exportAs('md') },
+    { icon: 'image', label: 'Export HTML', action: () => void exportAs('html') },
+    { icon: 'image', label: 'Export PDF', action: () => void exportAs('pdf') },
+    { icon: 'image', label: 'Export PNG', action: () => void exportAs('png') },
+    { icon: 'list-ul', label: 'Export plain text', action: () => void exportAs('txt') },
+  ], e.clientX, e.clientY);
+});
 
 hydrateIconButtons(document);
 wireSettingsPanel();

--- a/docs/desktop-context-menus.md
+++ b/docs/desktop-context-menus.md
@@ -1,0 +1,45 @@
+# Right-click context menus
+
+Hover-only toolbars on code blocks, tables, and mermaid diagrams have been replaced with native-style right-click context menus. The chrome is quieter, the actions are still discoverable (right-click is the universal "what can I do here?" gesture), and there's room to grow the menus without crowding the visible UI.
+
+## Where they're wired
+
+| Surface | Menu items |
+| --- | --- |
+| **Code block** (`<pre>`) | Copy · Download as file · Export as PNG · — · Show / Hide line numbers |
+| **Table** (`.mid-table`) | Copy as Markdown · Download CSV · Download JSON · — · Reset sort (when active) |
+| **Mermaid** (`.mermaid`) | Copy SVG · Download SVG · Download PNG |
+| **File-tree row** (`.mid-tree-item`, files only) | Open · Reveal in Finder |
+| **Note row** (`.mid-note-row`) | Open · Rename… · — · Delete |
+| **Document body** (`.mid-preview`) | Copy text · — · Export Markdown / HTML / PDF / PNG / Plain text |
+
+Right-click on any nested element bubbles to the closest matching surface — e.g. right-click on a table cell opens the table menu, right-click on a code-block keyword opens the code menu. The body menu only fires when no other surface claimed the event.
+
+## What's still visible
+
+- **Code blocks** keep the language pill (top-left) — visual cue, not an action.
+- **Tables > 5 rows** keep a small filter+counter chip in the top-right (the filter is functional and not duplicated by the right-click menu).
+- **Sortable headers** still cycle on click (asc → desc → unsorted).
+
+Smaller tables (≤ 5 rows) hide the chip entirely so prose flows uninterrupted.
+
+## Implementation
+
+`openContextMenu(items, x, y)` builds an absolutely-positioned `.mid-context-menu` overlay with a one-frame fade-in animation, auto-clamps to viewport edges, closes on outside-click or Esc, and routes each item to its `action`. Items are typed `{ icon?, label, kbd?, action?, separator?, disabled? }`.
+
+No main-process roundtrip — the menu is purely renderer-side, so it inherits the active theme tokens and animates with the rest of the chrome.
+
+## Files
+
+- `apps/electron/renderer/renderer.ts` — `openContextMenu`, `MenuItem`, `attachCodeBlockToolbar`/`attachTableTools`/`attachMermaidToolbar` rewritten to register `contextmenu` listeners; `renameNote` added; document-level body fallback handler.
+- `apps/electron/renderer/renderer.css` — `.mid-context-menu`, `.mid-context-item`, `.mid-context-sep`, `.mid-context-kbd` styles. `.mid-table-chip` replaces the old full-width `.mid-table-toolbar`.
+
+## Verifying
+
+1. Right-click a code block → menu appears with Copy / Download / Export PNG / line-numbers toggle.
+2. Right-click a table → menu offers Copy as MD / CSV / JSON. Click the column header to sort, then right-click → Reset sort is enabled.
+3. Right-click a mermaid diagram → SVG / SVG download / PNG download.
+4. Right-click a file in the sidebar tree → Open / Reveal in Finder.
+5. Right-click a note row → Open / Rename / Delete.
+6. Right-click empty space in the preview → Copy text + 5 export formats.
+7. Esc closes the menu without firing any action.


### PR DESCRIPTION
## Summary
- Hover-only toolbars on code blocks, tables, and mermaid diagrams removed. Right-click is now the primary action affordance.
- New `openContextMenu(items, x, y)` renderer-side helper builds an absolutely-positioned `.mid-context-menu` overlay, auto-clamps to viewport, closes on outside-click or Esc.
- Wired to: `pre` (code) / `.mid-table` (tables) / `.mermaid` (diagrams) / `.mid-tree-item` (file rows) / `.mid-note-row` (notes) / `.mid-preview` (document body fallback).
- Code blocks keep only the language pill. Tables keep a compact filter+counter **chip** (top-right, only for tables > 5 rows). Sortable headers still cycle on click.
- Note rows get a real **Rename** flow (uses the new `notesRename` IPC + `midPrompt`).
- Document body right-click offers Copy text + all five export formats — same set as File → Export menu.
- Docs at `docs/desktop-context-menus.md`.

Closes #114 — part of #112.

## Test plan
- [ ] Right-click a code block — Copy / Download / Export PNG / line-numbers toggle.
- [ ] Right-click a table — Copy as MD / CSV / JSON; sort column, right-click again, Reset sort enabled.
- [ ] Right-click a mermaid diagram — Copy SVG / Download SVG / Download PNG.
- [ ] Right-click a sidebar file row — Open / Reveal in Finder.
- [ ] Right-click a note row — Open / Rename / Delete; Rename opens the modal and persists.
- [ ] Right-click empty preview space — Copy text + 5 export formats.
- [ ] Esc closes the menu without firing any action.