### PR TITLE
feat(desktop): minimal title bar — icon-only buttons + segmented mode toggle (#115)

### DIFF
--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -14,17 +14,19 @@
 <body>
 <header class="mid-titlebar" role="toolbar">
   <div class="mid-titlebar-left">
-    <button id="open-folder-btn" class="mid-btn" title="Open folder (Cmd/Ctrl+Shift+O)" data-icon="folder-open" data-label="Folder"></button>
-    <button id="open-btn" class="mid-btn" title="Open file (Cmd/Ctrl+O)" data-icon="file" data-label="Open"></button>
-    <button id="save-btn" class="mid-btn" title="Save (Cmd/Ctrl+S)" data-icon="save" data-label="Save"></button>
+    <button id="open-folder-btn" class="mid-btn mid-btn--icon mid-btn--ghost" title="Open folder (Cmd/Ctrl+Shift+O)" data-icon="folder-open"></button>
+    <button id="open-btn" class="mid-btn mid-btn--icon mid-btn--ghost" title="Open file (Cmd/Ctrl+O)" data-icon="file"></button>
+    <button id="save-btn" class="mid-btn mid-btn--icon mid-btn--ghost" title="Save (Cmd/Ctrl+S)" data-icon="save"></button>
   </div>
   <div class="mid-titlebar-center">
     <span id="filename" class="mid-filename">Untitled</span>
   </div>
   <div class="mid-titlebar-right">
-    <button id="mode-view" class="mid-btn is-active" title="View (default)" data-icon="show" data-label="View"></button>
-    <button id="mode-split" class="mid-btn" title="Split" data-icon="columns" data-label="Split"></button>
-    <button id="mode-edit" class="mid-btn" title="Edit" data-icon="edit" data-label="Edit"></button>
+    <div class="mid-mode-toggle" role="tablist" aria-label="Render mode">
+      <button id="mode-view" class="mid-mode-seg is-active" title="View (default)" data-icon="show"></button>
+      <button id="mode-split" class="mid-mode-seg" title="Split" data-icon="columns"></button>
+      <button id="mode-edit" class="mid-mode-seg" title="Edit" data-icon="edit"></button>
+    </div>
     <button id="settings-btn" class="mid-btn mid-btn--icon mid-btn--ghost" title="Settings (Cmd/Ctrl+,)" data-icon="cog"></button>
   </div>
 </header>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -220,23 +220,56 @@ body.has-sidebar .mid-shell {
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: var(--mid-space-3);
-  padding: var(--mid-space-1) var(--mid-space-3);
-  background: var(--mid-surface);
+  padding: 0 var(--mid-space-3);
+  background: var(--mid-bg);
   border-bottom: 1px solid var(--mid-border);
   -webkit-app-region: drag;
 }
 body.is-mac .mid-titlebar { padding-left: 80px; }
-.mid-titlebar-left, .mid-titlebar-right { display: flex; gap: var(--mid-space-1); }
+.mid-titlebar-left, .mid-titlebar-right { display: flex; align-items: center; gap: var(--mid-space-1); }
 .mid-titlebar-right { justify-self: end; }
 .mid-titlebar-center {
   text-align: center;
-  color: var(--mid-fg-muted);
+  color: var(--mid-fg);
   font-size: var(--mid-font-size-sm);
+  font-weight: var(--mid-weight-medium);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0 var(--mid-space-3);
 }
-.mid-titlebar .mid-btn.is-active {
-  background: var(--mid-accent);
-  color: var(--mid-accent-fg);
-  border-color: var(--mid-accent);
+
+/* Segmented mode toggle (View / Split / Edit) */
+.mid-mode-toggle {
+  display: inline-flex;
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-md);
+  padding: 2px;
+  -webkit-app-region: no-drag;
+  margin-right: var(--mid-space-2);
+}
+.mid-mode-seg {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 22px;
+  padding: 0;
+  background: transparent;
+  color: var(--mid-fg-muted);
+  border: 0;
+  border-radius: var(--mid-radius-xs);
+  cursor: pointer;
+  transition:
+    background var(--mid-motion-fast) var(--mid-ease-out),
+    color var(--mid-motion-fast) var(--mid-ease-out);
+}
+.mid-mode-seg:hover { color: var(--mid-fg); }
+.mid-mode-seg.is-active {
+  background: var(--mid-bg);
+  color: var(--mid-fg);
+  box-shadow: var(--mid-shadow-sm);
 }
 
 main { overflow: hidden; min-height: 0; }

--- a/docs/desktop-titlebar.md
+++ b/docs/desktop-titlebar.md
@@ -1,4 +1,12 @@
-# Desktop titlebar — macOS traffic-light inset
+# Desktop titlebar
+
+A minimal, icon-only strip. Three quick actions on the left, a centered filename, a segmented render-mode toggle + settings on the right. No labels — every glyph carries a tooltip with its keyboard shortcut.
+
+```
+[📁] [📄] [💾]              <filename>              [👁 ⫶ ✏️]   [⚙]
+```
+
+## macOS traffic-light inset
 
 The Electron window uses `titleBarStyle: 'hiddenInset'` on macOS so the standard close/minimize/maximize controls render over a custom toolbar. Without explicit padding, our left-aligned toolbar buttons collide with the traffic lights.
 
@@ -11,6 +19,20 @@ The Electron window uses `titleBarStyle: 'hiddenInset'` on macOS so the standard
 
 `apps/electron/renderer/renderer.ts` reads `platform` from the `getAppInfo()` IPC response and toggles the body class on first paint. `apps/electron/renderer/renderer.css` reserves the inset only when that class is present, so no platform-specific styles run for non-mac users.
 
+## Layout
+
+| Region | Content |
+| --- | --- |
+| Left | `Folder` / `Open` / `Save` — ghost icon-only buttons. Tooltip carries the action + shortcut. |
+| Center | Active filename (`mid-titlebar-center`), elided to fit. Foreground color is the body fg, not muted, so it's the visual focus. |
+| Right | `.mid-mode-toggle` — segmented pill with three icons (View / Split / Edit). Active segment gets a raised surface + small shadow. Followed by the gear icon for Settings. |
+
+The toolbar is drag-region by default, so any non-button area drags the window. Each interactive element opts out via `-webkit-app-region: no-drag`.
+
 ## Verifying
 
-Run `npm run dev:electron` on macOS and confirm the Open / Save buttons sit ~80px from the left edge. On Windows or Linux, confirm the buttons sit flush at the left padding (12px).
+- Toolbar buttons are icon-only with tooltips on hover.
+- Mode toggle is one connected pill, not three separate buttons. Active segment looks "lifted".
+- Filename in the center reads as the visual anchor.
+- macOS: `npm run dev:electron` — Open / Save sit ~80px from the left edge to clear the traffic lights.
+- Windows / Linux: buttons sit flush at the 12px padding.


### PR DESCRIPTION
## Summary
- Toolbar buttons are now **icon-only**. Labels move into tooltips. The plain `.mid-btn` style is reserved for buttons that *do* carry text (modal actions, etc.); chrome buttons use `.mid-btn--icon .mid-btn--ghost`.
- View / Split / Edit become a single **segmented pill** (`.mid-mode-toggle` + `.mid-mode-seg`) — active segment gets a lifted surface + subtle shadow instead of a colored fill.
- Filename in the center is the visual anchor: body color, medium weight, elided.
- Title bar bg matches the body bg (was a different surface) for a calmer reading frame.
- Docs at `docs/desktop-titlebar.md` updated with the new layout description.

Closes #115 — part of #112.

## Test plan
- [ ] Title bar reads as one dense strip — no labeled buttons.
- [ ] Hover any button → tooltip with the keyboard shortcut.
- [ ] Mode toggle: clicking changes the active segment; the others are flush + muted.
- [ ] macOS traffic lights still cleared (80px inset).
- [ ] Filename in the center elides on narrow windows.