### PR TITLE
feat(desktop): bottom status bar (#116)

### DIFF
--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -83,11 +83,6 @@
     </div>
     <div class="mid-sidebar-tree" id="tree-root"></div>
     <div class="mid-notes-list" id="notes-list" hidden></div>
-    <footer class="mid-repo-bar" id="repo-bar" hidden>
-      <span class="mid-repo-status" id="repo-status">No repo connected</span>
-      <button id="repo-connect" class="mid-btn mid-btn--icon mid-btn--ghost" title="Connect repo" data-icon="github"></button>
-      <button id="repo-sync" class="mid-btn mid-btn--icon mid-btn--ghost" title="Sync (commit + pull + push)" data-icon="refresh" hidden></button>
-    </footer>
   </aside>
   <main id="root" class="viewing">
     <div class="empty-state">
@@ -96,6 +91,16 @@
     </div>
   </main>
 </div>
+<footer class="mid-statusbar" id="statusbar">
+  <button class="mid-status-cell mid-status-cell--button" id="status-repo" title="Click to connect / sync">
+    <span class="mid-icon mid-icon--sm" id="status-repo-icon"></span>
+    <span id="status-repo-text">No repo</span>
+  </button>
+  <span class="mid-status-spacer"></span>
+  <span class="mid-status-cell" id="status-cursor" hidden>L1:C1</span>
+  <span class="mid-status-cell" id="status-words">0 words</span>
+  <span class="mid-status-cell mid-status-dot" id="status-save" title="Saved">●</span>
+</footer>
 <dialog id="mid-dialog" class="mid-dialog">
   <form method="dialog" class="mid-dialog-form">
     <h3 class="mid-dialog-title" id="mid-dialog-title"></h3>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -4,7 +4,7 @@
 
 body {
   display: grid;
-  grid-template-rows: var(--mid-titlebar-h) 1fr;
+  grid-template-rows: var(--mid-titlebar-h) 1fr 24px;
 }
 
 .mid-shell {
@@ -165,26 +165,46 @@ body.has-sidebar .mid-shell {
 .mid-note-row:hover .mid-note-delete { opacity: 1; }
 .mid-note-delete:hover { color: var(--mid-danger); background: var(--mid-surface); }
 
-/* Repo status bar at the bottom of the sidebar */
-.mid-repo-bar {
+/* Bottom status bar */
+.mid-statusbar {
   display: flex;
   align-items: center;
-  gap: var(--mid-space-1);
-  padding: var(--mid-space-2) var(--mid-space-3);
-  border-top: 1px solid var(--mid-border);
+  gap: var(--mid-space-3);
+  padding: 0 var(--mid-space-3);
   background: var(--mid-surface);
-}
-.mid-repo-bar[hidden] { display: none; }
-.mid-repo-status {
-  flex: 1;
-  min-width: 0;
+  border-top: 1px solid var(--mid-border);
   font-family: var(--mid-font-mono);
   font-size: var(--mid-font-size-xs);
   color: var(--mid-fg-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  user-select: none;
+  -webkit-app-region: no-drag;
 }
+.mid-status-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mid-space-1);
+  white-space: nowrap;
+}
+.mid-status-cell--button {
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  padding: 0 var(--mid-space-1);
+  cursor: pointer;
+  border-radius: var(--mid-radius-xs);
+}
+.mid-status-cell--button:hover { background: var(--mid-surface-hover); color: var(--mid-fg); }
+.mid-status-cell--button .mid-icon { color: var(--mid-fg-muted); }
+.mid-status-cell--button:hover .mid-icon { color: var(--mid-fg); }
+.mid-status-cell--button[data-connected="false"] .mid-icon { color: var(--mid-fg-subtle); }
+.mid-status-spacer { flex: 1; }
+.mid-status-dot {
+  font-size: 12px;
+  line-height: 1;
+  color: var(--mid-success);
+}
+.mid-status-dot.is-dirty { color: var(--mid-warning); }
 
 /* Modal dialog (replaces window.prompt / window.confirm — unsupported in Electron) */
 .mid-dialog {

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -101,10 +101,12 @@ const sidebarNotesHeader = document.getElementById('sidebar-notes-header') as HT
 const notesListEl = document.getElementById('notes-list') as HTMLDivElement;
 const notesFilter = document.getElementById('notes-filter') as HTMLInputElement;
 const notesNewBtn = document.getElementById('notes-new') as HTMLButtonElement;
-const repoBar = document.getElementById('repo-bar') as HTMLElement;
-const repoStatusEl = document.getElementById('repo-status') as HTMLSpanElement;
-const repoConnectBtn = document.getElementById('repo-connect') as HTMLButtonElement;
-const repoSyncBtn = document.getElementById('repo-sync') as HTMLButtonElement;
+const statusRepoBtn = document.getElementById('status-repo') as HTMLButtonElement;
+const statusRepoText = document.getElementById('status-repo-text') as HTMLSpanElement;
+const statusRepoIcon = document.getElementById('status-repo-icon') as HTMLSpanElement;
+const statusWords = document.getElementById('status-words') as HTMLSpanElement;
+const statusCursor = document.getElementById('status-cursor') as HTMLSpanElement;
+const statusSave = document.getElementById('status-save') as HTMLSpanElement;
 
 let currentText = '';
 let currentPath: string | null = null;
@@ -833,7 +835,18 @@ function buildEditor(): HTMLTextAreaElement {
   ta.spellcheck = false;
   ta.addEventListener('input', () => {
     currentText = ta.value;
+    updateWordCount();
+    updateSaveIndicator(false);
   });
+  const onCursor = (): void => {
+    const before = ta.value.slice(0, ta.selectionStart);
+    const lines = before.split('\n');
+    updateCursor(lines.length, lines[lines.length - 1].length + 1);
+  };
+  ta.addEventListener('keyup', onCursor);
+  ta.addEventListener('click', onCursor);
+  ta.addEventListener('focus', onCursor);
+  ta.addEventListener('blur', hideCursor);
   return ta;
 }
 
@@ -870,6 +883,7 @@ function setMode(mode: Mode): void {
   if (mode === 'view') renderView();
   else if (mode === 'edit') renderEdit();
   else renderSplit();
+  if (mode === 'view') hideCursor();
 }
 
 async function openFile(): Promise<void> {
@@ -884,6 +898,8 @@ function loadFileContent(filePath: string, content: string): void {
   filenameEl.textContent = filePath.split('/').pop() ?? 'Untitled';
   highlightActiveTreeItem();
   setMode(currentMode);
+  updateWordCount();
+  updateSaveIndicator(true);
 }
 
 async function selectTreeFile(filePath: string): Promise<void> {
@@ -901,7 +917,6 @@ function applyFolder(folderPath: string, tree: TreeEntry[]): void {
   currentFolder = folderPath;
   document.body.classList.add('has-sidebar');
   sidebar.hidden = false;
-  repoBar.hidden = false;
   sidebarFolderName.textContent = folderPath.split('/').pop() ?? folderPath;
   sidebarFolderName.title = folderPath;
   treeRoot.replaceChildren(...renderTree(tree));
@@ -917,10 +932,11 @@ function applyFolder(folderPath: string, tree: TreeEntry[]): void {
 async function refreshRepoStatus(): Promise<void> {
   if (!currentFolder) return;
   const s = await window.mid.repoStatus(currentFolder);
+  statusRepoIcon.innerHTML = iconHTML('github', 'mid-icon--sm');
   if (!s.initialized || !s.remote) {
-    repoStatusEl.textContent = s.initialized ? 'No remote' : 'No repo connected';
-    repoStatusEl.title = s.remote || '';
-    repoSyncBtn.hidden = true;
+    statusRepoText.textContent = s.initialized ? 'No remote' : 'No repo';
+    statusRepoBtn.dataset.connected = 'false';
+    statusRepoBtn.title = 'Click to connect a GitHub repo';
     return;
   }
   const slug = parseSlugFromUrl(s.remote);
@@ -930,10 +946,27 @@ async function refreshRepoStatus(): Promise<void> {
   if (s.behind) counters.push(`↓${s.behind}`);
   if (s.dirty) counters.push(`±${s.dirty}`);
   const counterText = counters.length ? ` ${counters.join(' ')}` : '';
-  repoStatusEl.textContent = `${slug} · ${branch}${counterText}`;
-  repoStatusEl.title = s.remote;
-  repoSyncBtn.hidden = false;
+  statusRepoText.textContent = `${slug} · ${branch}${counterText}`;
+  statusRepoBtn.dataset.connected = 'true';
+  statusRepoBtn.title = `${s.remote} — click to sync, right-click for actions`;
 }
+
+function updateWordCount(): void {
+  const words = currentText.trim() ? currentText.trim().split(/\s+/).length : 0;
+  statusWords.textContent = `${words.toLocaleString()} word${words === 1 ? '' : 's'}`;
+}
+
+function updateSaveIndicator(saved: boolean): void {
+  statusSave.classList.toggle('is-dirty', !saved);
+  statusSave.title = saved ? 'Saved' : 'Unsaved changes';
+}
+
+function updateCursor(line: number, col: number): void {
+  statusCursor.hidden = false;
+  statusCursor.textContent = `L${line}:C${col}`;
+}
+
+function hideCursor(): void { statusCursor.hidden = true; }
 
 function parseSlugFromUrl(url: string): string {
   const m = /github\.com[:/]([^/]+\/[^/.]+?)(?:\.git)?\/?$/.exec(url);
@@ -1032,6 +1065,7 @@ async function saveFile(): Promise<void> {
   if (currentPath) {
     await window.mid.writeFile(currentPath, currentText);
     flashStatus(`Saved ${currentPath.split('/').pop()}`);
+    updateSaveIndicator(true);
     return;
   }
   const saved = await window.mid.saveFileDialog('untitled.md', currentText);
@@ -1039,6 +1073,7 @@ async function saveFile(): Promise<void> {
     currentPath = saved;
     filenameEl.textContent = saved.split('/').pop() ?? 'Untitled';
     flashStatus(`Saved ${saved.split('/').pop()}`);
+    updateSaveIndicator(true);
   }
 }
 
@@ -1156,8 +1191,22 @@ notesFilter.addEventListener('input', () => {
   notesFilterText = notesFilter.value.trim().toLowerCase();
   renderNotes();
 });
-repoConnectBtn.addEventListener('click', () => void promptConnectRepo());
-repoSyncBtn.addEventListener('click', () => void syncRepo());
+statusRepoBtn.addEventListener('click', () => {
+  if (statusRepoBtn.dataset.connected === 'true') void syncRepo();
+  else void promptConnectRepo();
+});
+statusRepoBtn.addEventListener('contextmenu', e => {
+  if (!currentFolder) return;
+  e.preventDefault();
+  const connected = statusRepoBtn.dataset.connected === 'true';
+  openContextMenu(connected ? [
+    { icon: 'refresh', label: 'Sync (commit + pull + push)', action: () => void syncRepo() },
+    { separator: true, label: '' },
+    { icon: 'github', label: 'Connect to a different repo…', action: () => void promptConnectRepo() },
+  ] : [
+    { icon: 'github', label: 'Connect repo…', action: () => void promptConnectRepo() },
+  ], e.clientX, e.clientY);
+});
 
 document.addEventListener('keydown', e => {
   if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'n' && !e.shiftKey && !e.altKey) {

--- a/docs/desktop-statusbar.md
+++ b/docs/desktop-statusbar.md
@@ -1,0 +1,45 @@
+# Desktop status bar
+
+A 24 px strip at the bottom of the window with the always-on document state. Single source of truth for things that the title bar shouldn't have to carry.
+
+## Cells
+
+| Cell | Content | Interaction |
+| --- | --- | --- |
+| **Repo** (left) | GitHub icon + `<owner/name> · <branch> ↑↓±` (or "No repo" / "No remote") | Click → connect or sync; right-click → context menu |
+| **Cursor** (right cluster) | `L<n>:C<n>` while focus is in the editor | Read-only |
+| **Words** | Live word count of the current buffer | Read-only |
+| **Save state** | `●` green = clean, amber = unsaved | Hover for tooltip |
+
+The mode toggle (View / Split / Edit) **stays in the title bar** as the segmented pill from #115 — keeping it close to the filename made it the more reachable affordance, and a status bar duplicate would create two truths.
+
+## Behavior
+
+- **Word count** updates on every editor `input` event (split + edit modes).
+- **Cursor** appears only while a textarea has focus; hidden on view mode and on blur.
+- **Save state** flips to `is-dirty` (amber) on first edit; back to clean on save.
+- **Repo** click is contextual:
+  - When unconnected → opens the connect modal.
+  - When connected → triggers sync (commit + pull-rebase + push).
+- **Repo** right-click reveals the full menu: Sync / Connect to a different repo.
+
+## Why a status bar at the bottom
+
+Modern markdown apps split running state into two zones: a tight title bar at the top (file + mode) and an unobtrusive status bar at the bottom (instrumentation). It keeps the chrome out of the reading column and gives the user a single place to glance at "what's happening?" — including dirty state, which used to live nowhere visible.
+
+## Files
+
+- `apps/electron/renderer/index.html` — `<footer class="mid-statusbar">` shell. Sidebar repo bar removed.
+- `apps/electron/renderer/renderer.ts` — `refreshRepoStatus` (rewritten for the new DOM), `updateWordCount`, `updateSaveIndicator`, `updateCursor`, `hideCursor`. Wired into `loadFileContent`, `saveFile`, `setMode`, and the textarea input/keyup/click/focus/blur events.
+- `apps/electron/renderer/renderer.css` — `.mid-statusbar`, `.mid-status-cell*`, `.mid-status-dot`, `.mid-status-spacer`. Body grid changed from 2 rows → 3 rows.
+
+## Verifying
+
+1. Launch — status bar shows "No repo · 0 words · ● (saved)".
+2. Open a folder of a connected repo — repo cell shows `<owner/name> · main`.
+3. Open a file → words count updates; save dot stays green.
+4. Switch to Edit / Split mode — cursor cell appears, tracks line/column as you type.
+5. Edit a character — save dot flips amber.
+6. `Cmd+S` — save dot flips back to green; word count re-flashes if changed.
+7. Click the repo cell when connected — runs sync; status updates with new ahead/behind/dirty.
+8. Right-click the repo cell — menu offers Sync / Connect to a different repo.


### PR DESCRIPTION
## Summary
- New 24 px `<footer class="mid-statusbar">` at the bottom: repo cell (left), word count, cursor `L:C` (only when editor focused), save-state dot (right).
- Sidebar repo footer removed; repo state lives in the status bar — single source of truth.
- Repo cell is a button: click syncs (when connected) or opens connect modal (when not). Right-click reveals the full menu.
- Word count updates on every editor input. Save dot flips amber on first edit, green again on save. Cursor cell hidden in View mode.
- Mode toggle stays in the title bar — close to the filename, easier to reach.
- Body grid changes from 2 rows → 3 rows to host the new footer.
- Docs at `docs/desktop-statusbar.md`.

Closes #116 — part of #112.

## Test plan
- [ ] Launch — bottom strip shows "No repo · 0 words · ● (saved)".
- [ ] Open a connected folder — repo cell shows `<owner/name> · main`.
- [ ] Open a file → words count populates.
- [ ] Edit a character → save dot turns amber. `Cmd+S` → back to green.
- [ ] Switch to Edit / Split — cursor cell appears, tracks position; switch to View → cursor cell hides.
- [ ] Click repo cell when connected → sync runs; counters update.
- [ ] Right-click repo cell → menu offers Sync + reconnect.