### PR TITLE
feat(desktop): welcome hero with quick actions, recent files, and sample (#118)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -477,6 +477,7 @@ interface AppState {
   fontSize?: number;
   theme?: 'auto' | 'light' | 'dark' | 'sepia';
   previewMaxWidth?: number;
+  recentFiles?: string[];
 }
 
 function resolveMCPServerScript(): string {

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -22,6 +22,7 @@ export interface AppState {
   fontSize?: number;
   theme?: 'auto' | 'light' | 'dark' | 'sepia';
   previewMaxWidth?: number;
+  recentFiles?: string[];
 }
 
 export interface NoteEntry {

--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -84,12 +84,7 @@
     <div class="mid-sidebar-tree" id="tree-root"></div>
     <div class="mid-notes-list" id="notes-list" hidden></div>
   </aside>
-  <main id="root" class="viewing">
-    <div class="empty-state">
-      <h1>Mark It Down</h1>
-      <p>Open a folder with <kbd class="mid-kbd">Cmd/Ctrl+Shift+O</kbd> to browse, or open a single file with <kbd class="mid-kbd">Cmd/Ctrl+O</kbd>.</p>
-    </div>
-  </main>
+  <main id="root" class="viewing"></main>
 </div>
 <footer class="mid-statusbar" id="statusbar">
   <button class="mid-status-cell mid-status-cell--button" id="status-repo" title="Click to connect / sync">

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -781,13 +781,105 @@ main.editing textarea {
   white-space: pre;
 }
 
-.empty-state {
+/* Welcome / empty-state hero */
+.mid-welcome {
+  max-width: 540px;
+  margin: var(--mid-space-12) auto;
+  padding: var(--mid-space-8) var(--mid-space-6);
   text-align: center;
-  padding: var(--mid-space-12) var(--mid-space-4);
+}
+.mid-welcome-glyph {
+  width: 84px;
+  height: 84px;
+  margin: 0 auto var(--mid-space-4);
+}
+.mid-welcome-glyph svg { width: 100%; height: 100%; display: block; }
+.mid-welcome-title {
+  font-size: 1.85em;
+  font-weight: var(--mid-weight-semibold);
+  margin: 0 0 var(--mid-space-1);
+  letter-spacing: -0.01em;
+}
+.mid-welcome-tagline {
+  margin: 0 0 var(--mid-space-8);
+  color: var(--mid-fg-muted);
+  font-size: var(--mid-font-size-base);
+}
+.mid-welcome-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--mid-space-2);
+  margin-bottom: var(--mid-space-8);
+}
+.mid-welcome-action {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--mid-space-3);
+  padding: var(--mid-space-3) var(--mid-space-4);
+  font-family: inherit;
+  font-size: var(--mid-font-size-sm);
+  color: var(--mid-fg);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-md);
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background var(--mid-motion-fast) var(--mid-ease-out),
+    border-color var(--mid-motion-fast) var(--mid-ease-out),
+    transform var(--mid-motion-fast) var(--mid-ease-out);
+}
+.mid-welcome-action:hover:not(:disabled) {
+  background: var(--mid-surface-hover);
+  border-color: var(--mid-border-strong);
+  transform: translateY(-1px);
+}
+.mid-welcome-action:disabled { opacity: 0.45; cursor: not-allowed; }
+.mid-welcome-action-label { font-weight: var(--mid-weight-medium); }
+.mid-welcome-action-kbd {
+  font-family: var(--mid-font-mono);
+  font-size: var(--mid-font-size-xs);
   color: var(--mid-fg-muted);
 }
-.empty-state h1 {
-  font-size: var(--mid-font-size-3xl);
+
+.mid-welcome-recent {
+  text-align: left;
+  border-top: 1px solid var(--mid-border);
+  padding-top: var(--mid-space-5);
+}
+.mid-welcome-recent-title {
+  font-size: var(--mid-font-size-xs);
+  font-weight: var(--mid-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--mid-fg-muted);
+  margin-bottom: var(--mid-space-2);
+}
+.mid-welcome-recent-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--mid-space-2);
+  width: 100%;
+  padding: var(--mid-space-1) var(--mid-space-2);
+  font-family: inherit;
+  font-size: var(--mid-font-size-sm);
   color: var(--mid-fg);
+  background: transparent;
   border: 0;
+  border-radius: var(--mid-radius-sm);
+  cursor: pointer;
+  text-align: left;
+}
+.mid-welcome-recent-item:hover { background: var(--mid-surface-hover); }
+.mid-welcome-recent-name { font-weight: var(--mid-weight-medium); }
+.mid-welcome-recent-path {
+  font-family: var(--mid-font-mono);
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-subtle);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
 }

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -119,6 +119,7 @@ let osIsDark = false;
 let sidebarMode: 'files' | 'notes' = 'files';
 let notes: NoteEntry[] = [];
 let notesFilterText = '';
+let recentFiles: string[] = [];
 const settings = { ...DEFAULT_SETTINGS };
 const expandedDirs = new Set<string>();
 
@@ -205,8 +206,131 @@ function renderMarkdown(md: string): string {
   return fmHTML + container.innerHTML;
 }
 
+function welcomeHeroHTML(recent: string[]): string {
+  const recentHTML = recent.length === 0 ? '' : `
+    <div class="mid-welcome-recent">
+      <div class="mid-welcome-recent-title">Recent</div>
+      ${recent.slice(0, 5).map(p => {
+        const name = p.split('/').pop() ?? p;
+        return `<button class="mid-welcome-recent-item" data-recent-path="${escapeHTML(p)}">
+          ${iconHTML('file', 'mid-icon--sm mid-icon--muted')}
+          <span class="mid-welcome-recent-name">${escapeHTML(name)}</span>
+          <span class="mid-welcome-recent-path">${escapeHTML(p.replace(/\/[^/]+$/, ''))}</span>
+        </button>`;
+      }).join('')}
+    </div>`;
+  return `
+    <div class="mid-welcome">
+      <div class="mid-welcome-glyph">${midBrandGlyphSVG()}</div>
+      <h1 class="mid-welcome-title">Mark It Down</h1>
+      <p class="mid-welcome-tagline">A calm markdown studio — read first, edit second.</p>
+      <div class="mid-welcome-actions">
+        <button class="mid-welcome-action" data-welcome-action="open-folder">
+          ${iconHTML('folder-open')}
+          <span class="mid-welcome-action-label">Open Folder</span>
+          <span class="mid-welcome-action-kbd">⌘⇧O</span>
+        </button>
+        <button class="mid-welcome-action" data-welcome-action="open-file">
+          ${iconHTML('file')}
+          <span class="mid-welcome-action-label">Open File</span>
+          <span class="mid-welcome-action-kbd">⌘O</span>
+        </button>
+        <button class="mid-welcome-action" data-welcome-action="new-note" ${currentFolder ? '' : 'disabled'}>
+          ${iconHTML('plus')}
+          <span class="mid-welcome-action-label">New Note</span>
+          <span class="mid-welcome-action-kbd">⌘N</span>
+        </button>
+        <button class="mid-welcome-action" data-welcome-action="sample">
+          ${iconHTML('image')}
+          <span class="mid-welcome-action-label">Try the sample</span>
+          <span class="mid-welcome-action-kbd"></span>
+        </button>
+      </div>
+      ${recentHTML}
+    </div>`;
+}
+
+function midBrandGlyphSVG(): string {
+  return `<svg viewBox="0 0 1024 1024" aria-hidden="true">
+    <defs>
+      <linearGradient id="mid-hero-page" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stop-color="#1d2333"/><stop offset="1" stop-color="#3b3a7a"/>
+      </linearGradient>
+      <linearGradient id="mid-hero-hash" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0" stop-color="#fff5d8"/><stop offset="1" stop-color="#f7c97b"/>
+      </linearGradient>
+    </defs>
+    <rect x="64" y="64" width="896" height="896" rx="200" fill="url(#mid-hero-page)"/>
+    <g fill="url(#mid-hero-hash)">
+      <g transform="translate(512 512) skewX(-8) translate(-512 -512)">
+        <rect x="350" y="232" width="92" height="560" rx="46"/>
+        <rect x="582" y="232" width="92" height="560" rx="46"/>
+      </g>
+      <rect x="232" y="402" width="560" height="92" rx="46"/>
+      <rect x="232" y="566" width="560" height="92" rx="46"/>
+    </g>
+  </svg>`;
+}
+
 function emptyStateHTML(): string {
-  return `<div class="empty-state"><h1>Mark It Down</h1><p>Open a folder with <kbd class="mid-kbd">Cmd/Ctrl+Shift+O</kbd> to browse, or open a single file with <kbd class="mid-kbd">Cmd/Ctrl+O</kbd>.</p></div>`;
+  return welcomeHeroHTML(recentFiles);
+}
+
+function attachWelcomeHandlers(container: HTMLElement): void {
+  container.querySelectorAll<HTMLButtonElement>('[data-welcome-action]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const action = btn.dataset.welcomeAction;
+      if (action === 'open-folder') void openFolder();
+      else if (action === 'open-file') void openFile();
+      else if (action === 'new-note') void promptCreateNote();
+      else if (action === 'sample') void openSample();
+    });
+  });
+  container.querySelectorAll<HTMLButtonElement>('[data-recent-path]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const p = btn.dataset.recentPath;
+      if (p) void openRecent(p);
+    });
+  });
+}
+
+async function openSample(): Promise<void> {
+  const candidates = [
+    'media/welcome-sample.md',
+    '../../../media/welcome-sample.md',
+  ];
+  for (const rel of candidates) {
+    try {
+      const text = await window.mid.readFile(rel);
+      currentText = text;
+      currentPath = null;
+      filenameEl.textContent = 'Welcome sample';
+      setMode('view');
+      updateWordCount();
+      return;
+    } catch {
+      // try next
+    }
+  }
+  flashStatus('Sample not found');
+}
+
+async function openRecent(p: string): Promise<void> {
+  try {
+    const content = await window.mid.readFile(p);
+    loadFileContent(p, content);
+    pushRecent(p);
+  } catch {
+    flashStatus('File no longer exists');
+    recentFiles = recentFiles.filter(f => f !== p);
+    void window.mid.patchAppState({ recentFiles });
+    if (currentMode === 'view') renderView();
+  }
+}
+
+function pushRecent(p: string): void {
+  recentFiles = [p, ...recentFiles.filter(f => f !== p)].slice(0, 10);
+  void window.mid.patchAppState({ recentFiles });
 }
 
 function renderView(): void {
@@ -214,6 +338,7 @@ function renderView(): void {
   root.classList.add('viewing');
   if (!currentText) {
     root.innerHTML = emptyStateHTML();
+    attachWelcomeHandlers(root);
     return;
   }
   const preview = document.createElement('div');
@@ -900,6 +1025,7 @@ function loadFileContent(filePath: string, content: string): void {
   setMode(currentMode);
   updateWordCount();
   updateSaveIndicator(true);
+  pushRecent(filePath);
 }
 
 async function selectTreeFile(filePath: string): Promise<void> {
@@ -1529,6 +1655,7 @@ void window.mid.readAppState().then(async state => {
   if (typeof state.previewMaxWidth === 'number' && state.previewMaxWidth >= 600 && state.previewMaxWidth <= 1400) {
     settings.previewMaxWidth = state.previewMaxWidth;
   }
+  if (Array.isArray(state.recentFiles)) recentFiles = state.recentFiles.slice(0, 10);
   applySettings();
   if (state.lastFolder) {
     try {

--- a/docs/desktop-welcome.md
+++ b/docs/desktop-welcome.md
@@ -1,0 +1,63 @@
+# Welcome / empty-state hero
+
+A first-launch surface that earns its space — brand glyph, tagline, four primary actions, and a Recent list — instead of a single "Open a folder" hint.
+
+## Layout
+
+```
+┌──────────────────────────────────────┐
+│              [#]                     │  ← inline brand SVG (84 px)
+│         Mark It Down                 │  ← title
+│  A calm markdown studio — read       │  ← tagline
+│  first, edit second.                 │
+│                                      │
+│  [📁 Open Folder  ⌘⇧O]               │  ← 2×2 quick-action grid
+│  [📄 Open File    ⌘O ]               │
+│  [➕ New Note      ⌘N ]               │
+│  [🖼 Try the sample    ]              │
+│                                      │
+│  RECENT                              │  ← only when state has any
+│  📄 docs/desktop-context-menus.md    │
+│  📄 README.md                        │
+└──────────────────────────────────────┘
+```
+
+## Quick actions
+
+| Action | Behavior |
+| --- | --- |
+| Open Folder | `Cmd/Ctrl+Shift+O` — same flow as the sidebar's folder picker |
+| Open File | `Cmd/Ctrl+O` — single file |
+| New Note | `Cmd/Ctrl+N` — disabled when no folder is open (with a muted look) |
+| Try the sample | Loads `media/welcome-sample.md` — a tour doc that exercises frontmatter, alerts, math, code, tables, mermaid, and task lists in one file |
+
+The buttons are square cards with icon + label + keyboard hint, arranged in a 2×2 grid for visual rhythm.
+
+## Recent files
+
+`AppState.recentFiles` is a most-recently-used list of absolute paths capped at 10. Pushed into on every `loadFileContent` (file open, sidebar tree click, recent-list click). The hero renders the top 5 with filename + folder path (mono).
+
+If a recent file is missing on click, it's silently pruned from the list and the hero re-renders.
+
+## Implementation
+
+- `welcomeHeroHTML(recent)` builds the markup string; `attachWelcomeHandlers(container)` wires the action + recent-file click events. Both are called from `renderView()` whenever `currentText` is empty.
+- `midBrandGlyphSVG()` inlines a smaller copy of the `#`-on-page brand glyph from `media/brand/icon.svg`, keyed off the same gradient so it matches the dock icon.
+- `pushRecent(path)` is the single write-side that persists via `mid:patch-app-state`.
+- `openSample()` reads the sample file and shows it in View mode without setting `currentPath`, so the user is never tempted to overwrite the tour with `Cmd+S`.
+
+## Files
+
+- `apps/electron/renderer/index.html` — empty `<main>` (was hardcoded empty-state markup).
+- `apps/electron/renderer/renderer.ts` — `welcomeHeroHTML`, `midBrandGlyphSVG`, `attachWelcomeHandlers`, `openSample`, `openRecent`, `pushRecent`. `recentFiles` state + `AppState` field.
+- `apps/electron/renderer/renderer.css` — `.mid-welcome*` styles.
+- `apps/electron/main.ts` / `preload.ts` — `recentFiles` in `AppState`.
+- `media/welcome-sample.md` — the tour doc.
+
+## Verifying
+
+1. Fresh launch (or close all files) → hero shows.
+2. Click **Try the sample** → tour doc renders. Frontmatter panel + alert + math + code + table + mermaid + checkboxes all visible.
+3. Click **Open File** → pick a markdown → loads in View. Quit + relaunch → hero now shows that file under "Recent".
+4. With a folder open, **New Note** is enabled; without a folder, it's muted.
+5. Click a recent entry → loads instantly; if you delete the file outside the app first, clicking it shows "File no longer exists" and prunes the entry.

--- a/media/welcome-sample.md
+++ b/media/welcome-sample.md
@@ -1,0 +1,67 @@
+---
+title: Welcome to Mark It Down
+date: 2026-04-30
+tags: [sample, intro]
+---
+
+# Welcome to Mark It Down
+
+A short tour of every renderer feature. Right-click anywhere to see the context actions.
+
+> [!NOTE]
+> This is a GitHub-style alert. Try `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]` too.
+
+## Inline & display math
+
+The Pythagorean theorem: $a^2 + b^2 = c^2$.
+
+The Gauss integral:
+
+$$ \int_0^\infty e^{-x^2}\,dx = \frac{\sqrt{\pi}}{2} $$
+
+## Code with syntax highlighting
+
+```ts
+import { greet } from './greeter';
+
+export async function main(): Promise<void> {
+  const subject = process.argv[2] ?? 'world';
+  console.log(greet(subject));
+}
+```
+
+Right-click the block: Copy, Download, Export PNG, line numbers.
+
+## A data table
+
+| Project   | Stage      | Owner | LOC   |
+| --------- | ---------- | ----- | ----- |
+| Atlas     | Production | Sara  | 12345 |
+| Beacon    | Beta       | Jamal |  4920 |
+| Crescent  | Planning   | Lina  |   210 |
+| Dawn      | Production | Karim |  8800 |
+| Echo      | Sunset     | Mona  |  1500 |
+| Fjord     | Beta       | Omar  |  6200 |
+
+Click a column header to sort. Right-click for CSV / JSON / Markdown export.
+
+## A diagram
+
+```mermaid
+graph LR
+  A[Read] --> B[Edit]
+  B --> C[Preview]
+  C --> A
+  C --> D[Publish]
+```
+
+Right-click the diagram for SVG / PNG export.
+
+## Lists
+
+- [x] Browse files in the sidebar
+- [x] Right-click code / tables / diagrams for actions
+- [ ] Try Settings (`Cmd/Ctrl+,`) — Sepia theme is the chef's kiss
+- [ ] Connect a GitHub repo from the bottom status bar
+
+Happy editing.


### PR DESCRIPTION
## Summary
- New empty-state hero: inline brand `#` glyph at 84 px, title, tagline, **2×2 quick-action grid** (Open Folder / Open File / New Note / Try the sample), and a **Recent files** list (top 5 of `AppState.recentFiles`).
- `recentFiles` MRU list, capped at 10, pushed into on every file open. Persisted via `mid:patch-app-state`. Missing files pruned silently.
- New `media/welcome-sample.md` — a tour doc that exercises frontmatter, GH alerts, KaTeX math, syntax-highlighted code, a sortable table, a mermaid diagram, and task lists. Loaded by **Try the sample** without setting `currentPath` (so the user can't overwrite the tour with `Cmd+S`).
- New Note is disabled in the hero when no folder is open (mirrors the existing `Cmd+N` behavior).
- Docs at `docs/desktop-welcome.md`.

Closes #118 — part of #112.

## Test plan
- [ ] Fresh launch — hero with brand glyph + four action cards.
- [ ] Click Try the sample → tour doc renders; check frontmatter, alert, math, code, table, mermaid, task list all visible.
- [ ] Click Open File → pick any md → loads. Quit + relaunch → that file appears under Recent.
- [ ] Click a recent entry — loads instantly.
- [ ] Delete a file outside the app, click it in the recent list → flash status reports gone, entry pruned, hero re-renders.
- [ ] Without a folder open, New Note button is muted/disabled. Open a folder, button enables.