### PR TITLE
fix(desktop): table chip overlap + cramped style (#127)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -595,36 +595,33 @@ main.splitting .mid-preview {
   background: var(--mid-bg);
   box-shadow: inset 0 0 0 1px var(--mid-border);
 }
-.mid-table { position: relative; }
 .mid-table table { margin: 0; border: 0; border-radius: 0; }
 .mid-table th { position: sticky; top: 0; z-index: 1; }
 
-/* Compact filter chip in the top-right of large tables (>5 rows). */
+/* Filter chip strip above the table — clear separation from sort indicators */
 .mid-table-chip {
-  position: absolute;
-  top: var(--mid-space-2);
-  right: var(--mid-space-2);
-  z-index: 2;
   display: flex;
   align-items: center;
-  gap: var(--mid-space-2);
-  padding: 2px var(--mid-space-2);
-  background: var(--mid-bg);
-  border: 1px solid var(--mid-border);
-  border-radius: var(--mid-radius-pill);
-  box-shadow: var(--mid-shadow-sm);
+  gap: var(--mid-space-3);
+  padding: var(--mid-space-1) var(--mid-space-3);
+  background: var(--mid-surface);
+  border-bottom: 1px solid var(--mid-border);
 }
 .mid-table-chip[hidden] { display: none; }
 .mid-table-filter {
-  width: 140px;
-  padding: 0;
+  flex: 1;
+  min-width: 0;
+  max-width: 280px;
+  padding: 4px var(--mid-space-2);
   font-family: inherit;
   font-size: var(--mid-font-size-sm);
   color: var(--mid-fg);
-  background: transparent;
-  border: 0;
+  background: var(--mid-bg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
   outline: none;
 }
+.mid-table-filter:focus-visible { border-color: var(--mid-accent); box-shadow: 0 0 0 2px rgba(9, 105, 218, 0.15); }
 .mid-table-counter {
   font-family: var(--mid-font-mono);
   font-size: var(--mid-font-size-xs);


### PR DESCRIPTION
Filter chip moves out of the absolute-positioned overlay into a header strip above the table. Filter input grows to a flex 1fr with max-width 280px; focus ring matches accent. Sort indicators now sit free of any overlay. Closes #127.