### PR TITLE
feat(desktop): code-block PNG with macOS-window chrome (#128)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -587,6 +587,48 @@ main.splitting .mid-preview {
   padding-right: var(--mid-space-2);
 }
 
+/* Carbon-style PNG export frame (macOS traffic lights + filename) */
+.mid-code-export-frame {
+  background: var(--mid-bg);
+  border-radius: var(--mid-radius-lg);
+  padding: 16px;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--mid-border);
+  width: max-content;
+  max-width: 920px;
+}
+.mid-code-export-chrome {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 12px;
+  position: relative;
+}
+.mid-code-export-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.mid-code-export-title {
+  position: absolute;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-family: var(--mid-font-mono);
+  font-size: 12px;
+  color: var(--mid-fg-muted);
+  pointer-events: none;
+}
+.mid-code-export-body pre {
+  margin: 0;
+  padding: var(--mid-space-3) var(--mid-space-4);
+  background: var(--mid-code-bg);
+  border-radius: var(--mid-radius-md);
+  box-shadow: inset 0 0 0 1px var(--mid-border);
+  overflow: visible;
+  white-space: pre;
+}
+
 /* Data-table viewer (sort / filter / export) */
 .mid-table {
   margin: 1.2em 0;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -597,14 +597,44 @@ function downloadCode(text: string, lang?: string): void {
 }
 
 async function exportCodeBlockAsPNG(pre: HTMLPreElement): Promise<void> {
-  const dataUrl = await toPng(pre, {
-    pixelRatio: 2,
-    backgroundColor: getComputedStyle(document.documentElement).getPropertyValue('--mid-code-bg').trim() || '#0d1117',
-  });
-  const a = document.createElement('a');
-  a.href = dataUrl;
-  a.download = 'code.png';
-  a.click();
+  // Build a Carbon-style frame off-screen with macOS traffic lights + filename label.
+  const frame = document.createElement('div');
+  frame.className = 'mid-code-export-frame';
+  frame.style.cssText = 'position: fixed; left: -10000px; top: 0;';
+
+  const chrome = document.createElement('div');
+  chrome.className = 'mid-code-export-chrome';
+  chrome.innerHTML = `
+    <span class="mid-code-export-dot" style="background: #ff5f57"></span>
+    <span class="mid-code-export-dot" style="background: #febc2e"></span>
+    <span class="mid-code-export-dot" style="background: #28c840"></span>
+    <span class="mid-code-export-title"></span>
+  `;
+  const lang = pre.querySelector<HTMLElement>('.mid-code-lang')?.textContent ?? '';
+  const titleEl = chrome.querySelector('.mid-code-export-title') as HTMLSpanElement;
+  titleEl.textContent = lang ? `snippet.${LANG_TO_EXT[lang] ?? 'txt'}` : 'snippet.txt';
+
+  const cloneHost = document.createElement('div');
+  cloneHost.className = 'mid-code-export-body';
+  const preClone = pre.cloneNode(true) as HTMLElement;
+  preClone.querySelector('.mid-code-lang')?.remove();
+  cloneHost.appendChild(preClone);
+
+  frame.append(chrome, cloneHost);
+  document.body.appendChild(frame);
+
+  try {
+    const dataUrl = await toPng(frame, {
+      pixelRatio: 2,
+      backgroundColor: getComputedStyle(document.documentElement).getPropertyValue('--mid-bg').trim() || '#0d1117',
+    });
+    const a = document.createElement('a');
+    a.href = dataUrl;
+    a.download = 'code.png';
+    a.click();
+  } finally {
+    frame.remove();
+  }
 }
 
 function addLineNumbers(pre: HTMLPreElement, code: HTMLElement): void {


### PR DESCRIPTION
Right-click code → Export PNG now wraps the block in a Carbon-style frame: rounded outer panel, three traffic-light dots (red/yellow/green), centered filename derived from the language (`snippet.ts` etc.), and a soft drop shadow. The frame is built off-screen, captured via html-to-image, then disposed. Closes #128.