### PR TITLE
fix(desktop): code-block PNG export empty + drop macOS chrome (#147)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -594,47 +594,6 @@ main.splitting .mid-preview {
   padding-right: var(--mid-space-2);
 }
 
-/* Carbon-style PNG export frame (macOS traffic lights + filename) */
-.mid-code-export-frame {
-  background: var(--mid-bg);
-  border-radius: var(--mid-radius-lg);
-  padding: 16px;
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--mid-border);
-  width: max-content;
-  max-width: 920px;
-}
-.mid-code-export-chrome {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding-bottom: 12px;
-  position: relative;
-}
-.mid-code-export-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  display: inline-block;
-}
-.mid-code-export-title {
-  position: absolute;
-  left: 0;
-  right: 0;
-  text-align: center;
-  font-family: var(--mid-font-mono);
-  font-size: 12px;
-  color: var(--mid-fg-muted);
-  pointer-events: none;
-}
-.mid-code-export-body pre {
-  margin: 0;
-  padding: var(--mid-space-3) var(--mid-space-4);
-  background: var(--mid-code-bg);
-  border-radius: var(--mid-radius-md);
-  box-shadow: inset 0 0 0 1px var(--mid-border);
-  overflow: visible;
-  white-space: pre;
-}
 
 /* Data-table viewer (sort / filter / export) */
 .mid-table {

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -730,43 +730,22 @@ function downloadCode(text: string, lang?: string): void {
 }
 
 async function exportCodeBlockAsPNG(pre: HTMLPreElement): Promise<void> {
-  // Build a Carbon-style frame off-screen with macOS traffic lights + filename label.
-  const frame = document.createElement('div');
-  frame.className = 'mid-code-export-frame';
-  frame.style.cssText = 'position: fixed; left: -10000px; top: 0;';
-
-  const chrome = document.createElement('div');
-  chrome.className = 'mid-code-export-chrome';
-  chrome.innerHTML = `
-    <span class="mid-code-export-dot" style="background: #ff5f57"></span>
-    <span class="mid-code-export-dot" style="background: #febc2e"></span>
-    <span class="mid-code-export-dot" style="background: #28c840"></span>
-    <span class="mid-code-export-title"></span>
-  `;
-  const lang = pre.querySelector<HTMLElement>('.mid-code-lang')?.textContent ?? '';
-  const titleEl = chrome.querySelector('.mid-code-export-title') as HTMLSpanElement;
-  titleEl.textContent = lang ? `snippet.${LANG_TO_EXT[lang] ?? 'txt'}` : 'snippet.txt';
-
-  const cloneHost = document.createElement('div');
-  cloneHost.className = 'mid-code-export-body';
-  const preClone = pre.cloneNode(true) as HTMLElement;
-  preClone.querySelector('.mid-code-lang')?.remove();
-  cloneHost.appendChild(preClone);
-
-  frame.append(chrome, cloneHost);
-  document.body.appendChild(frame);
-
+  // Capture the live <pre> directly — clean shadcn-aligned image, no extra chrome.
+  // Hide the language pill during capture so the output has just the code surface.
+  const lang = pre.querySelector<HTMLElement>('.mid-code-lang');
+  const langDisplay = lang?.style.display ?? '';
+  if (lang) lang.style.display = 'none';
   try {
-    const dataUrl = await toPng(frame, {
+    const dataUrl = await toPng(pre, {
       pixelRatio: 2,
-      backgroundColor: getComputedStyle(document.documentElement).getPropertyValue('--mid-bg').trim() || '#0d1117',
+      backgroundColor: getComputedStyle(document.documentElement).getPropertyValue('--mid-code-bg').trim() || '#0d1117',
     });
     const a = document.createElement('a');
     a.href = dataUrl;
     a.download = 'code.png';
     a.click();
   } finally {
-    frame.remove();
+    if (lang) lang.style.display = langDisplay;
   }
 }
 


### PR DESCRIPTION
Empty image was caused by capturing an off-screen `position: fixed; left: -10000px` clone — `html-to-image` can't reliably read computed styles for off-screen subtrees. Fix: capture the live `<pre>` directly with the language pill temporarily hidden. Result is a clean, shadcn-aligned image of the highlighted code on the active theme bg — no traffic lights, no filename strip, no extra chrome (per user feedback). Closes #147.