### PR TITLE
feat(desktop): shadcn visual pass (#149)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -247,7 +247,7 @@ body.has-sidebar .mid-shell {
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: var(--mid-space-3);
-  padding: 0 var(--mid-space-3);
+  padding: 0 var(--mid-space-2);
   background: var(--mid-bg);
   border-bottom: 1px solid var(--mid-border);
   -webkit-app-region: drag;
@@ -361,9 +361,9 @@ main.splitting .mid-preview {
   top: var(--mid-titlebar-h);
   right: 0;
   bottom: 0;
-  width: 360px;
+  width: 380px;
   z-index: var(--mid-z-modal);
-  background: var(--mid-surface);
+  background: var(--mid-bg);
   border-left: 1px solid var(--mid-border);
   box-shadow: var(--mid-shadow-lg);
   display: flex;
@@ -412,14 +412,19 @@ main.splitting .mid-preview {
 .mid-settings-control {
   font-family: inherit;
   font-size: var(--mid-font-size-sm);
-  padding: var(--mid-space-1) var(--mid-space-2);
+  padding: 6px var(--mid-space-3);
   background: var(--mid-bg);
   color: var(--mid-fg);
   border: 1px solid var(--mid-border);
-  border-radius: var(--mid-radius-sm);
+  border-radius: var(--mid-radius-md);
+  outline: none;
+  transition: border-color var(--mid-motion-fast), box-shadow var(--mid-motion-fast);
 }
-.mid-settings-control[type="range"] { padding: 0; accent-color: var(--mid-accent); }
-.mid-settings-control:focus-visible { outline: 2px solid var(--mid-accent); outline-offset: 2px; border-color: var(--mid-accent); }
+.mid-settings-control[type="range"] { padding: 0; accent-color: var(--mid-fg); border: 0; }
+.mid-settings-control:focus-visible {
+  border-color: var(--mid-fg);
+  box-shadow: 0 0 0 1px var(--mid-fg);
+}
 
 /* Frontmatter meta block */
 .mid-frontmatter {
@@ -611,9 +616,10 @@ main.splitting .mid-preview {
   display: flex;
   align-items: center;
   gap: var(--mid-space-3);
-  padding: var(--mid-space-1) var(--mid-space-3);
-  background: var(--mid-surface);
-  border-bottom: 1px solid var(--mid-border);
+  margin-bottom: var(--mid-space-3);
+  padding: 0;
+  background: transparent;
+  border: 0;
 }
 .mid-table-chip[hidden] { display: none; }
 .mid-table-filter {

--- a/packages/ui-tokens/src/primitives.css
+++ b/packages/ui-tokens/src/primitives.css
@@ -20,25 +20,26 @@ button { font-family: inherit; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: var(--mid-space-1);
-  padding: var(--mid-space-1) var(--mid-space-3);
+  gap: var(--mid-space-2);
+  padding: 6px var(--mid-space-3);
   font-size: var(--mid-font-size-sm);
   font-weight: var(--mid-weight-medium);
   line-height: 1.4;
-  background: transparent;
+  background: var(--mid-bg);
   color: var(--mid-fg);
   border: 1px solid var(--mid-border);
-  border-radius: var(--mid-radius-sm);
+  border-radius: var(--mid-radius-md);
   cursor: pointer;
   transition:
     background var(--mid-motion-fast) var(--mid-ease-out),
     border-color var(--mid-motion-fast) var(--mid-ease-out),
-    color var(--mid-motion-fast) var(--mid-ease-out);
+    color var(--mid-motion-fast) var(--mid-ease-out),
+    box-shadow var(--mid-motion-fast) var(--mid-ease-out);
   -webkit-app-region: no-drag;
 }
-.mid-btn:hover { background: var(--mid-surface-hover); border-color: var(--mid-border-strong); }
-.mid-btn:active { background: var(--mid-surface-active); }
-.mid-btn:focus-visible { outline: 2px solid var(--mid-accent); outline-offset: 2px; }
+.mid-btn:hover { background: var(--mid-surface); border-color: var(--mid-border-strong); }
+.mid-btn:active { background: var(--mid-surface-hover); }
+.mid-btn:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--mid-bg), 0 0 0 4px var(--mid-fg); }
 .mid-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .mid-btn--primary {
@@ -50,8 +51,20 @@ button { font-family: inherit; }
   background: var(--mid-accent-hover);
   border-color: var(--mid-accent-hover);
 }
-.mid-btn--ghost { border-color: transparent; }
-.mid-btn--icon { padding: var(--mid-space-1); width: 28px; height: 28px; }
+.mid-btn--secondary {
+  background: var(--mid-surface);
+  border-color: transparent;
+}
+.mid-btn--secondary:hover { background: var(--mid-surface-hover); border-color: transparent; }
+.mid-btn--ghost { background: transparent; border-color: transparent; }
+.mid-btn--ghost:hover { background: var(--mid-surface); border-color: transparent; }
+.mid-btn--destructive {
+  background: var(--mid-danger);
+  color: #ffffff;
+  border-color: var(--mid-danger);
+}
+.mid-btn--icon { padding: 0; width: 32px; height: 32px; }
+.mid-btn--icon.mid-btn--ghost { width: 28px; height: 28px; }
 
 .mid-surface {
   background: var(--mid-surface);

--- a/packages/ui-tokens/src/tokens.css
+++ b/packages/ui-tokens/src/tokens.css
@@ -6,27 +6,27 @@
 :root {
   color-scheme: light dark;
 
-  /* Color — light */
+  /* Color — light (shadcn neutral palette) */
   --mid-bg: #ffffff;
-  --mid-surface: #f6f8fa;
-  --mid-surface-hover: #eaeef2;
-  --mid-surface-active: #d8dee4;
-  --mid-fg: #1f2328;
-  --mid-fg-muted: #656d76;
-  --mid-fg-subtle: #8b949e;
-  --mid-border: #d0d7de;
-  --mid-border-strong: #afb8c1;
-  --mid-accent: #0969da;
-  --mid-accent-fg: #ffffff;
-  --mid-accent-hover: #0550ae;
-  --mid-link: #0969da;
-  --mid-link-hover: #0550ae;
-  --mid-code-bg: #f6f8fa;
-  --mid-inline-code-bg: rgba(175, 184, 193, 0.2);
-  --mid-table-stripe: #f6f8fa;
-  --mid-danger: #d1242f;
-  --mid-warning: #9a6700;
-  --mid-success: #1a7f37;
+  --mid-surface: #f4f4f5;          /* zinc-100 */
+  --mid-surface-hover: #e4e4e7;    /* zinc-200 */
+  --mid-surface-active: #d4d4d8;   /* zinc-300 */
+  --mid-fg: #09090b;               /* zinc-950 */
+  --mid-fg-muted: #71717a;         /* zinc-500 */
+  --mid-fg-subtle: #a1a1aa;        /* zinc-400 */
+  --mid-border: #e4e4e7;           /* zinc-200 */
+  --mid-border-strong: #d4d4d8;    /* zinc-300 */
+  --mid-accent: #18181b;           /* zinc-900 — shadcn primary uses fg-tone */
+  --mid-accent-fg: #fafafa;        /* zinc-50 */
+  --mid-accent-hover: #27272a;     /* zinc-800 */
+  --mid-link: #2563eb;             /* blue-600 */
+  --mid-link-hover: #1d4ed8;       /* blue-700 */
+  --mid-code-bg: #fafafa;          /* zinc-50 */
+  --mid-inline-code-bg: rgba(161, 161, 170, 0.18);
+  --mid-table-stripe: #fafafa;
+  --mid-danger: #dc2626;           /* red-600 */
+  --mid-warning: #ca8a04;          /* yellow-600 */
+  --mid-success: #16a34a;          /* green-600 */
 
   /* Spacing — 4px base */
   --mid-space-0: 0;
@@ -94,26 +94,27 @@
 :root.dark {
   color-scheme: dark;
 
-  --mid-bg: #0d1117;
-  --mid-surface: #161b22;
-  --mid-surface-hover: #1f242c;
-  --mid-surface-active: #2a313c;
-  --mid-fg: #e6edf3;
-  --mid-fg-muted: #7d8590;
-  --mid-fg-subtle: #6e7681;
-  --mid-border: #30363d;
-  --mid-border-strong: #484f58;
-  --mid-accent: #2f81f7;
-  --mid-accent-fg: #ffffff;
-  --mid-accent-hover: #58a6ff;
-  --mid-link: #2f81f7;
-  --mid-link-hover: #58a6ff;
-  --mid-code-bg: #161b22;
-  --mid-inline-code-bg: rgba(110, 118, 129, 0.4);
-  --mid-table-stripe: #161b22;
-  --mid-danger: #f85149;
-  --mid-warning: #d29922;
-  --mid-success: #3fb950;
+  /* zinc-based dark palette — shadcn default */
+  --mid-bg: #09090b;               /* zinc-950 */
+  --mid-surface: #18181b;          /* zinc-900 */
+  --mid-surface-hover: #27272a;    /* zinc-800 */
+  --mid-surface-active: #3f3f46;   /* zinc-700 */
+  --mid-fg: #fafafa;               /* zinc-50 */
+  --mid-fg-muted: #a1a1aa;         /* zinc-400 */
+  --mid-fg-subtle: #71717a;        /* zinc-500 */
+  --mid-border: #27272a;           /* zinc-800 */
+  --mid-border-strong: #3f3f46;    /* zinc-700 */
+  --mid-accent: #fafafa;           /* zinc-50 — primary uses fg in dark */
+  --mid-accent-fg: #18181b;
+  --mid-accent-hover: #e4e4e7;
+  --mid-link: #60a5fa;             /* blue-400 */
+  --mid-link-hover: #93c5fd;       /* blue-300 */
+  --mid-code-bg: #18181b;
+  --mid-inline-code-bg: rgba(63, 63, 70, 0.6);
+  --mid-table-stripe: #18181b;
+  --mid-danger: #f87171;
+  --mid-warning: #facc15;
+  --mid-success: #4ade80;
 
   --mid-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
   --mid-shadow-md: 0 3px 6px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
Token + primitives + chrome shifts to align with shadcn/ui:

**Tokens** — palette swaps to zinc neutrals (light: zinc 50-950; dark: zinc 50-950 inverted). Accent = zinc-900 in light, zinc-50 in dark — shadcn's primary-fg pattern. Link is blue-600/400. Danger / warning / success use red/yellow/green-600.

**Primitives** — `.mid-btn` defaults to bg / border / md radius (was transparent / sm). New variants `.mid-btn--secondary` (surface bg, no border), `.mid-btn--destructive` (red). Focus ring uses outline+offset shadow trick (`box-shadow: 0 0 0 2px bg, 0 0 0 4px fg`). Icon-only buttons grow to 32px standard / 28px ghost.

**Chrome** — table chip drops surface bg + border, sits as plain margin-bottom block. Settings panel widens to 380px, drops surface bg (now matches body bg). Inputs get md radius + neutral focus ring (no blue glow). Title bar padding tightens to space-2.

Closes #149.