### PR TITLE
feat(desktop): mermaid visual editor (#150)

### DIFF
--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -91,6 +91,22 @@
   <span class="mid-status-cell" id="status-words">0 words</span>
   <span class="mid-status-cell mid-status-dot" id="status-save" title="Saved">●</span>
 </footer>
+<dialog id="mid-mermaid-editor" class="mid-mermaid-editor">
+  <header class="mid-mermaid-editor-header">
+    <h3 class="mid-mermaid-editor-title">Edit diagram</h3>
+    <button id="mid-mermaid-editor-close" class="mid-btn mid-btn--icon mid-btn--ghost" data-icon="x" title="Cancel"></button>
+  </header>
+  <div class="mid-mermaid-editor-body">
+    <textarea id="mid-mermaid-editor-src" class="mid-mermaid-editor-src" spellcheck="false"></textarea>
+    <div id="mid-mermaid-editor-preview" class="mid-mermaid-editor-preview"></div>
+  </div>
+  <footer class="mid-mermaid-editor-footer">
+    <span class="mid-mermaid-editor-hint">⌘↵ to save · Esc to cancel</span>
+    <span style="flex:1"></span>
+    <button id="mid-mermaid-editor-cancel" class="mid-btn">Cancel</button>
+    <button id="mid-mermaid-editor-save" class="mid-btn mid-btn--primary">Save</button>
+  </footer>
+</dialog>
 <dialog id="mid-dialog" class="mid-dialog">
   <form method="dialog" class="mid-dialog-form">
     <h3 class="mid-dialog-title" id="mid-dialog-title"></h3>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -213,6 +213,81 @@ body.has-sidebar .mid-shell {
 }
 .mid-status-dot.is-dirty { color: var(--mid-warning); }
 
+/* Mermaid editor modal — split textarea + live preview */
+.mid-mermaid-editor {
+  width: min(1100px, 92vw);
+  max-width: none;
+  height: min(720px, 86vh);
+  padding: 0;
+  margin: auto;
+  background: var(--mid-bg);
+  color: var(--mid-fg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-lg);
+  box-shadow: var(--mid-shadow-lg);
+  overflow: hidden;
+}
+.mid-mermaid-editor::backdrop { background: rgba(0, 0, 0, 0.5); }
+.mid-mermaid-editor[open] { display: flex; flex-direction: column; }
+.mid-mermaid-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--mid-space-3) var(--mid-space-4);
+  border-bottom: 1px solid var(--mid-border);
+}
+.mid-mermaid-editor-title { margin: 0; font-size: var(--mid-font-size-lg); font-weight: var(--mid-weight-semibold); }
+.mid-mermaid-editor-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 0;
+}
+.mid-mermaid-editor-src {
+  width: 100%;
+  height: 100%;
+  padding: var(--mid-space-4);
+  font-family: var(--mid-font-mono);
+  font-size: 13px;
+  line-height: 1.55;
+  background: var(--mid-bg);
+  color: var(--mid-fg);
+  border: 0;
+  border-right: 1px solid var(--mid-border);
+  outline: none;
+  resize: none;
+  tab-size: 2;
+  white-space: pre;
+}
+.mid-mermaid-editor-preview {
+  background: var(--mid-code-bg);
+  padding: var(--mid-space-4);
+  overflow: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.mid-mermaid-editor-preview svg { max-width: 100%; height: auto; }
+.mid-mermaid-editor-empty,
+.mid-mermaid-editor-error {
+  color: var(--mid-fg-muted);
+  font-family: var(--mid-font-mono);
+  font-size: var(--mid-font-size-sm);
+}
+.mid-mermaid-editor-error { color: var(--mid-danger); white-space: pre-wrap; }
+.mid-mermaid-editor-footer {
+  display: flex;
+  align-items: center;
+  gap: var(--mid-space-2);
+  padding: var(--mid-space-3) var(--mid-space-4);
+  border-top: 1px solid var(--mid-border);
+}
+.mid-mermaid-editor-hint {
+  font-family: var(--mid-font-mono);
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+}
+
 /* Modal dialog (replaces window.prompt / window.confirm — unsupported in Electron) */
 .mid-dialog {
   margin: auto;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -520,6 +520,8 @@ function attachMermaidToolbar(host: HTMLDivElement, source: string): void {
     e.stopPropagation();
     const reset = (host as HTMLDivElement & { _midResetMermaid?: () => void })._midResetMermaid;
     openContextMenu([
+      { icon: 'edit', label: 'Edit diagram…', action: () => openMermaidEditor(source) },
+      { separator: true, label: '' },
       { icon: 'copy', label: 'Copy SVG', action: () => copyMermaidSVG(host) },
       { icon: 'download', label: 'Download SVG', action: () => downloadMermaidSVG(host, source) },
       { icon: 'image', label: 'Download PNG', action: () => void downloadMermaidPNG(host) },
@@ -527,6 +529,82 @@ function attachMermaidToolbar(host: HTMLDivElement, source: string): void {
       { icon: 'refresh', label: 'Reset view', action: () => reset?.() },
     ], e.clientX, e.clientY);
   });
+}
+
+function openMermaidEditor(originalSource: string): void {
+  const dlg = document.getElementById('mid-mermaid-editor') as HTMLDialogElement;
+  const src = document.getElementById('mid-mermaid-editor-src') as HTMLTextAreaElement;
+  const preview = document.getElementById('mid-mermaid-editor-preview') as HTMLDivElement;
+  const closeBtn = document.getElementById('mid-mermaid-editor-close') as HTMLButtonElement;
+  const cancelBtn = document.getElementById('mid-mermaid-editor-cancel') as HTMLButtonElement;
+  const saveBtn = document.getElementById('mid-mermaid-editor-save') as HTMLButtonElement;
+
+  src.value = originalSource;
+  let timer: number | null = null;
+  let renderToken = 0;
+
+  const render = (): void => {
+    const code = src.value.trim();
+    if (!code) {
+      preview.innerHTML = '<div class="mid-mermaid-editor-empty">empty</div>';
+      return;
+    }
+    const id = `mermaid-edit-${++renderToken}`;
+    const myToken = renderToken;
+    mermaid.render(id, code).then(({ svg }) => {
+      if (myToken !== renderToken) return;
+      preview.innerHTML = svg;
+    }).catch(err => {
+      if (myToken !== renderToken) return;
+      preview.innerHTML = `<pre class="mid-mermaid-editor-error">${escapeHTML(String((err as Error)?.message ?? err))}</pre>`;
+    });
+  };
+  render();
+
+  src.oninput = (): void => {
+    if (timer !== null) window.clearTimeout(timer);
+    timer = window.setTimeout(render, 120);
+  };
+
+  const close = (): void => {
+    src.oninput = null;
+    if (timer !== null) window.clearTimeout(timer);
+    closeBtn.removeEventListener('click', cancel);
+    cancelBtn.removeEventListener('click', cancel);
+    saveBtn.removeEventListener('click', save);
+    document.removeEventListener('keydown', onKey);
+    if (dlg.open) dlg.close();
+  };
+  const cancel = (): void => close();
+  const save = (): void => {
+    const next = src.value;
+    if (next === originalSource) { close(); return; }
+    const before = '```mermaid\n' + originalSource + '\n```';
+    const after = '```mermaid\n' + next + '\n```';
+    const idx = currentText.indexOf(before);
+    if (idx === -1) {
+      flashStatus('Could not locate diagram source — editor closed without saving');
+      close();
+      return;
+    }
+    currentText = currentText.slice(0, idx) + after + currentText.slice(idx + before.length);
+    if (currentMode === 'view') renderView();
+    else if (currentMode === 'split') renderSplit();
+    updateSaveIndicator(false);
+    flashStatus('Diagram updated');
+    close();
+  };
+  const onKey = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') { e.preventDefault(); cancel(); }
+    else if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') { e.preventDefault(); save(); }
+  };
+
+  closeBtn.addEventListener('click', cancel);
+  cancelBtn.addEventListener('click', cancel);
+  saveBtn.addEventListener('click', save);
+  document.addEventListener('keydown', onKey);
+  dlg.showModal();
+  src.focus();
 }
 
 function copyMermaidSVG(host: HTMLDivElement): void {


### PR DESCRIPTION
Right-click any mermaid block → "Edit diagram…" opens a split modal: monospace textarea on the left with the original source, live diagram on the right re-rendered with a 120 ms debounce. Render token guards against late results overwriting newer ones; errors render as a red mono trace in the preview pane. Save locates the matching ```mermaid\n<source>\n``` block in the editor buffer and replaces it; the active mode re-renders. `Cmd/Ctrl+Enter` saves, `Esc` cancels. Save state flips to dirty so the user can persist with Cmd+S. Closes #150.