### PR TITLE
feat(desktop): inline code in table cells as shadcn badge (#166)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -850,6 +850,23 @@ main.splitting .mid-preview {
   background: var(--mid-surface);
 }
 .mid-preview tr:last-child td { border-bottom: 0; }
+
+/* Inline <code> inside table cells styled as shadcn badges */
+.mid-preview td code,
+.mid-preview th code {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px var(--mid-space-2);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
+  color: var(--mid-fg);
+  font-family: var(--mid-font-mono);
+  font-size: 0.78em;
+  font-weight: var(--mid-weight-medium);
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
 .mid-preview img { max-width: 100%; border-radius: var(--mid-radius-sm); }
 .mid-preview hr {
   border: 0;


### PR DESCRIPTION
Inline `<code>` elements inside table cells now render as shadcn-style badges: surface bg, 1px border, sm radius, medium weight, smaller font. Applied to both `<td>` and `<th>` for consistency. Closes #166.