### PR TITLE
feat(desktop): macOS-window chrome on preview code blocks (#163)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -600,6 +600,52 @@ main.splitting .mid-preview {
 }
 .mid-preview pre code { background: transparent; padding: 0; font-size: 0.88em; }
 
+/* macOS-window chrome wrapper around each preview <pre> */
+.mid-code-window {
+  position: relative;
+  margin: 1em 0;
+  border-radius: var(--mid-radius-md);
+  overflow: hidden;
+  background: var(--mid-code-bg);
+  box-shadow: inset 0 0 0 1px var(--mid-border), 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+.mid-code-window-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--mid-space-3);
+  padding: 8px var(--mid-space-3);
+  background: var(--mid-surface);
+  border-bottom: 1px solid var(--mid-border);
+  user-select: none;
+}
+.mid-code-window-dots { display: inline-flex; gap: 6px; align-items: center; }
+.mid-code-window-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.mid-code-window-dot--red { background: #ff5f57; }
+.mid-code-window-dot--amber { background: #febc2e; }
+.mid-code-window-dot--green { background: #28c840; }
+.mid-code-window-title {
+  text-align: center;
+  font-family: var(--mid-font-mono);
+  font-size: 12px;
+  color: var(--mid-fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mid-code-window-spacer { width: 60px; }
+.mid-code-window > pre {
+  margin: 0;
+  border-radius: 0;
+  box-shadow: none !important;
+  background: var(--mid-code-bg);
+}
+
 /* Code-block toolbar (Copy / Download / Image / Lines) + language badge */
 .mid-pre { padding-top: var(--mid-space-6); }
 .mid-pre.with-lines {
@@ -610,18 +656,7 @@ main.splitting .mid-preview {
 }
 .mid-pre.with-lines .mid-code-gutter { display: block; }
 
-.mid-code-lang {
-  position: absolute;
-  top: var(--mid-space-2);
-  right: var(--mid-space-3);
-  font-family: var(--mid-font-mono);
-  font-size: 10px;
-  font-weight: var(--mid-weight-medium);
-  text-transform: lowercase;
-  letter-spacing: 0.06em;
-  color: var(--mid-fg-subtle);
-  pointer-events: none;
-}
+.mid-code-lang { display: none; }
 
 /* Context menu (replaces hover toolbars on code / table / mermaid / file-tree / notes) */
 .mid-context-menu {

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -696,26 +696,43 @@ function attachCodeBlockToolbar(scope: HTMLElement): void {
     pre.classList.add('mid-pre');
 
     const lang = detectCodeLanguage(code);
-    if (lang) {
-      const badge = document.createElement('span');
-      badge.className = 'mid-code-lang';
-      badge.textContent = lang;
-      pre.appendChild(badge);
-    }
+
+    // Wrap each <pre> in a macOS-window chrome container — visible in the preview
+    // and naturally captured by the PNG export.
+    const chrome = document.createElement('div');
+    chrome.className = 'mid-code-window';
+    const header = document.createElement('div');
+    header.className = 'mid-code-window-header';
+    header.innerHTML = `
+      <span class="mid-code-window-dots">
+        <span class="mid-code-window-dot mid-code-window-dot--red"></span>
+        <span class="mid-code-window-dot mid-code-window-dot--amber"></span>
+        <span class="mid-code-window-dot mid-code-window-dot--green"></span>
+      </span>
+      <span class="mid-code-window-title"></span>
+      <span class="mid-code-window-spacer"></span>
+    `;
+    const titleEl = header.querySelector('.mid-code-window-title') as HTMLSpanElement;
+    titleEl.textContent = lang ? `snippet.${LANG_TO_EXT[lang] ?? lang}` : 'snippet.txt';
+
+    pre.parentElement?.insertBefore(chrome, pre);
+    chrome.appendChild(header);
+    chrome.appendChild(pre);
 
     addLineNumbers(pre, code);
 
-    pre.addEventListener('contextmenu', e => {
+    const onMenu = (e: MouseEvent): void => {
       e.preventDefault();
       e.stopPropagation();
       openContextMenu([
         { icon: 'copy', label: 'Copy', kbd: '⌘C', action: () => void navigator.clipboard.writeText(code.innerText) },
         { icon: 'download', label: 'Download as file', action: () => downloadCode(code.innerText, lang) },
-        { icon: 'image', label: 'Export as PNG', action: () => void exportCodeBlockAsPNG(pre) },
+        { icon: 'image', label: 'Export as PNG', action: () => void exportCodeBlockAsPNG(chrome) },
         { separator: true, label: '' },
         { icon: 'list-ul', label: pre.classList.contains('with-lines') ? 'Hide line numbers' : 'Show line numbers', action: () => pre.classList.toggle('with-lines') },
       ], e.clientX, e.clientY);
-    });
+    };
+    chrome.addEventListener('contextmenu', onMenu);
   });
 }
 
@@ -807,24 +824,17 @@ function downloadCode(text: string, lang?: string): void {
   setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
-async function exportCodeBlockAsPNG(pre: HTMLPreElement): Promise<void> {
-  // Capture the live <pre> directly — clean shadcn-aligned image, no extra chrome.
-  // Hide the language pill during capture so the output has just the code surface.
-  const lang = pre.querySelector<HTMLElement>('.mid-code-lang');
-  const langDisplay = lang?.style.display ?? '';
-  if (lang) lang.style.display = 'none';
-  try {
-    const dataUrl = await toPng(pre, {
-      pixelRatio: 2,
-      backgroundColor: getComputedStyle(document.documentElement).getPropertyValue('--mid-code-bg').trim() || '#0d1117',
-    });
-    const a = document.createElement('a');
-    a.href = dataUrl;
-    a.download = 'code.png';
-    a.click();
-  } finally {
-    if (lang) lang.style.display = langDisplay;
-  }
+async function exportCodeBlockAsPNG(target: HTMLElement): Promise<void> {
+  // Captures the macOS-window chrome wrapper directly so the export naturally
+  // shows the traffic lights + filename + code surface as a whole.
+  const dataUrl = await toPng(target, {
+    pixelRatio: 2,
+    backgroundColor: getComputedStyle(document.documentElement).getPropertyValue('--mid-bg').trim() || '#0d1117',
+  });
+  const a = document.createElement('a');
+  a.href = dataUrl;
+  a.download = 'code.png';
+  a.click();
 }
 
 function addLineNumbers(pre: HTMLPreElement, code: HTMLElement): void {


### PR DESCRIPTION
Every `<pre>` in the preview now wraps in a `.mid-code-window` shell with a header strip: 3 traffic-light dots (red / amber / green) and a centered filename derived from the language. Right-click → Export PNG captures the whole chrome wrapper so the saved image has the same look as the live block. The old top-right language pill is hidden (filename in the chrome header is the new identifier). Closes #163.