### PR TITLE
fix(desktop): v0.7.1 bundle — theme/docx/html/pdf/header/filter

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -135,6 +135,16 @@ ipcMain.handle('mid:list-folder-md', async (_e, folderPath: string) => {
 
 ipcMain.handle('mid:read-app-state', async () => readAppState());
 
+ipcMain.handle('mid:read-renderer-styles', async (): Promise<string> => {
+  const dir = path.join(process.cwd(), 'out/electron/renderer');
+  const files = ['tokens.css', 'icons.css', 'primitives.css', 'katex.css', 'renderer.css'];
+  const parts: string[] = [];
+  for (const f of files) {
+    try { parts.push(await fs.readFile(path.join(dir, f), 'utf8')); } catch { /* skip */ }
+  }
+  return parts.join('\n\n');
+});
+
 interface NoteEntry {
   id: string;
   title: string;

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -55,6 +55,7 @@ contextBridge.exposeInMainWorld('mid', {
   listFolderMd: (folderPath: string): Promise<TreeEntry[]> =>
     ipcRenderer.invoke('mid:list-folder-md', folderPath),
   readAppState: (): Promise<AppState> => ipcRenderer.invoke('mid:read-app-state'),
+  readRendererStyles: (): Promise<string> => ipcRenderer.invoke('mid:read-renderer-styles'),
   patchAppState: (patch: Partial<AppState>): Promise<void> =>
     ipcRenderer.invoke('mid:patch-app-state', patch),
   notesList: (workspace: string): Promise<NoteEntry[]> =>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -740,8 +740,7 @@ main.splitting .mid-preview {
 .mid-table-filter {
   flex: 1;
   min-width: 0;
-  max-width: 280px;
-  padding: 4px var(--mid-space-2);
+  padding: 8px var(--mid-space-3);
   font-family: inherit;
   font-size: var(--mid-font-size-sm);
   color: var(--mid-fg);
@@ -877,6 +876,29 @@ main.splitting .mid-preview {
   background: var(--mid-surface);
 }
 .mid-preview tr:last-child td { border-bottom: 0; }
+
+/* Header refinement v2 — uppercase tracking + subtle surface */
+.mid-preview thead { background: var(--mid-surface); }
+.mid-preview th {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: var(--mid-font-size-xs);
+  font-weight: var(--mid-weight-semibold);
+  color: var(--mid-fg-muted);
+  padding: var(--mid-space-2) var(--mid-space-4);
+  border-bottom: 1px solid var(--mid-border);
+}
+
+/* Print mode — hides chrome so PDF export captures only the document */
+body.is-printing .mid-titlebar,
+body.is-printing .mid-sidebar,
+body.is-printing .mid-statusbar,
+body.is-printing .mid-settings,
+body.is-printing #mid-dialog,
+body.is-printing #mid-mermaid-editor { display: none !important; }
+body.is-printing { display: block; grid-template-rows: none; }
+body.is-printing .mid-shell { display: block; }
+body.is-printing main.viewing { padding: 32px !important; max-width: 760px !important; }
 
 /* Inline <code> inside table cells styled as shadcn badges */
 .mid-preview td code,

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -5,7 +5,7 @@ import katex from 'katex';
 import yaml from 'js-yaml';
 import { toPng } from 'html-to-image';
 import * as XLSX from 'xlsx';
-import { Document, Paragraph, TextRun, HeadingLevel, AlignmentType, Packer, Table as DocxTable, TableRow as DocxTableRow, TableCell as DocxTableCell, WidthType } from 'docx';
+import { Document, Paragraph, TextRun, HeadingLevel, AlignmentType, Packer, Table as DocxTable, TableRow as DocxTableRow, TableCell as DocxTableCell, WidthType, BorderStyle, ShadingType } from 'docx';
 import { iconHTML, IconName } from '../../../packages/ui-tokens/src/icons';
 import { iconForFile } from '../../../packages/ui-tokens/src/file-icons';
 import { THEMES, ThemeDefinition } from '../../../packages/core/src/themes/themes';
@@ -72,6 +72,7 @@ interface Mid {
   openFolderDialog(): Promise<{ folderPath: string; tree: TreeEntry[] } | null>;
   listFolderMd(folderPath: string): Promise<TreeEntry[]>;
   readAppState(): Promise<AppState>;
+  readRendererStyles(): Promise<string>;
   patchAppState(patch: Partial<AppState>): Promise<void>;
   notesList(workspace: string): Promise<NoteEntry[]>;
   notesCreate(workspace: string, title: string): Promise<{ entry: NoteEntry; fullPath: string }>;
@@ -1508,14 +1509,20 @@ async function exportAs(format: ExportFormat): Promise<void> {
       flashStatus('Exported text');
       break;
     case 'html': {
-      const html = buildStandaloneHTML();
+      const html = await buildStandaloneHTML();
       await window.mid.saveAs(defaultExportName('html'), html, [{ name: 'HTML', extensions: ['html'] }]);
       flashStatus('Exported HTML');
       break;
     }
     case 'pdf': {
-      const result = await window.mid.exportPDF(defaultExportName('pdf'));
-      flashStatus(result ? 'Exported PDF' : 'PDF cancelled');
+      document.body.classList.add('is-printing');
+      try {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        const result = await window.mid.exportPDF(defaultExportName('pdf'));
+        flashStatus(result ? 'Exported PDF' : 'PDF cancelled');
+      } finally {
+        document.body.classList.remove('is-printing');
+      }
       break;
     }
     case 'png': {
@@ -1590,17 +1597,34 @@ function domNodeToDocx(el: HTMLElement): (Paragraph | DocxTable)[] {
   if (tag === 'TABLE' || el.classList.contains('mid-table')) {
     const tbl = el.querySelector('table') ?? (tag === 'TABLE' ? el : null);
     if (!tbl) return [];
-    const rows = Array.from(tbl.querySelectorAll('tr')).map(tr => {
-      const cells = Array.from(tr.querySelectorAll('th, td')).map(cell =>
-        new DocxTableCell({
+    const trs = Array.from(tbl.querySelectorAll('tr'));
+    const colCount = Math.max(...trs.map(tr => tr.querySelectorAll('th, td').length));
+    if (colCount === 0) return [];
+    const colWidth = Math.floor(100 / colCount);
+    const border = { style: BorderStyle.SINGLE, size: 4, color: 'D4D4D8' }; // 0.5pt zinc-300
+    const headerShading = { type: ShadingType.CLEAR, color: 'auto', fill: 'F4F4F5' }; // zinc-100
+    const rows = trs.map(tr => {
+      const cellEls = Array.from(tr.querySelectorAll('th, td'));
+      const cells = cellEls.map(cell => {
+        const isHeader = cell.tagName === 'TH';
+        return new DocxTableCell({
+          width: { size: colWidth, type: WidthType.PERCENTAGE },
+          shading: isHeader ? headerShading : undefined,
+          borders: {
+            top: border, bottom: border, left: border, right: border,
+          },
           children: [new Paragraph({
-            children: [new TextRun({ text: (cell.textContent ?? '').trim(), bold: cell.tagName === 'TH' })],
+            children: [new TextRun({ text: (cell.textContent ?? '').replace(/\s+/g, ' ').trim(), bold: isHeader })],
           })],
-        }),
-      );
+        });
+      });
       return new DocxTableRow({ children: cells });
     });
-    return [new DocxTable({ rows, width: { size: 100, type: WidthType.PERCENTAGE } })];
+    return [new DocxTable({
+      rows,
+      width: { size: 100, type: WidthType.PERCENTAGE },
+      columnWidths: Array.from({ length: colCount }, () => Math.floor(9000 / colCount)),
+    })];
   }
   if (tag === 'HR') {
     return [new Paragraph({ children: [new TextRun('───')], alignment: AlignmentType.CENTER })];
@@ -1629,26 +1653,23 @@ function markdownToPlainText(md: string): string {
     .replace(/\n{3,}/g, '\n\n');                         // collapse extra blank lines
 }
 
-function buildStandaloneHTML(): string {
+async function buildStandaloneHTML(): Promise<string> {
   const preview = root.querySelector<HTMLElement>('.mid-preview');
   const body = preview ? preview.outerHTML : '<p>(empty)</p>';
   const title = currentPath ? currentPath.split('/').pop() ?? 'Untitled' : 'Untitled';
-  // Inline the active stylesheets so the export is self-contained.
-  const styles = Array.from(document.styleSheets)
-    .map(sheet => {
-      try {
-        return Array.from(sheet.cssRules).map(r => r.cssText).join('\n');
-      } catch {
-        return '';
-      }
-    })
-    .join('\n');
+  // Inline the renderer CSS via main-process IPC — `cssRules` access fails
+  // on cross-origin sheets in Electron and yields an empty stylesheet.
+  const styles = await window.mid.readRendererStyles();
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="${document.documentElement.className}">
 <head>
 <meta charset="UTF-8" />
 <title>${escapeHTML(title)}</title>
-<style>${styles}</style>
+<style>${styles}
+body { display: block; padding: 32px; }
+.mid-titlebar, .mid-sidebar, .mid-statusbar, .mid-mode-toggle, .mid-shell > aside { display: none !important; }
+.mid-shell { display: block !important; }
+main.viewing { padding: 0 !important; max-width: 760px !important; margin: 0 auto !important; }</style>
 </head>
 <body class="${document.body.className}">
 <main class="viewing">${body}</main>
@@ -2113,17 +2134,14 @@ function wireSettingsPanel(): void {
   const resetBtn = document.getElementById('settings-reset') as HTMLButtonElement;
 
   const syncFromSettings = (): void => {
-    // Repopulate theme options every time the panel opens so we recover
-    // from any earlier load failure (and so a future hot reload of THEMES
-    // would surface immediately).
-    if (themeSel.options.length < 4 + THEMES.length) {
-      themeSel.replaceChildren();
-      try {
-        populateThemeOptions(themeSel);
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error('[mid] populateThemeOptions failed', err);
-      }
+    // Always rebuild — the prior guard could fail silently if a stale
+    // option set existed; an unconditional rebuild is robust + cheap.
+    themeSel.replaceChildren();
+    try {
+      populateThemeOptions(themeSel);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[mid] populateThemeOptions failed', err);
     }
     themeSel.value = settings.theme;
     fontSel.value = settings.fontFamily;


### PR DESCRIPTION
Six tightly-scoped fixes shipped together so the user can verify all at once.

- **#174 Theme picker** — drop the `options.length` guard; `syncFromSettings` always rebuilds the dropdown so a stale set can't survive.
- **#175 DOCX table** — set `columnWidths` + per-cell `width: 100/cols PERCENTAGE` + 0.5pt zinc-300 borders + zinc-100 header shading. Cells no longer collapse to 1-char-wide.
- **#176 HTML export** — new `mid:read-renderer-styles` IPC reads the actual CSS files from `out/electron/renderer` and inlines them. `Array.from(sheet.cssRules)` was failing silently on cross-origin sheets.
- **#177 PDF chrome** — `body.is-printing` class hides title bar / sidebar / status bar / settings / dialogs, expands the preview to 760 px centered. Added before `webContents.printToPDF()`, removed after.
- **#178 Table header v2** — uppercase, 0.06em letter-spacing, semibold, surface bg on `<thead>`, muted-fg color, tighter padding.
- **#179 Filter** — drops the 280 px max-width so the input spans the available width; bigger padding (8px) for a more present input.

Closes #174 #175 #176 #177 #178 #179.