### PR TITLE
fix(desktop): MCP start race + header v3 + activity bar v1 (#183 #184 #185)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -558,7 +558,14 @@ function setMCPStatus(s: MCPStatus, err?: string): void {
 }
 
 function startMCP(): void {
-  if (mcpProcess) return;
+  // Defensive: clear stale process refs from a prior failed start.
+  if (mcpProcess && (mcpProcess.killed || mcpProcess.exitCode !== null)) {
+    mcpProcess = null;
+  }
+  if (mcpProcess) {
+    setMCPStatus('running');
+    return;
+  }
   const script = resolveMCPServerScript();
   if (!script) {
     setMCPStatus('error', 'MCP server script not found');
@@ -575,7 +582,10 @@ function startMCP(): void {
     mcpProcess.stderr?.on('data', chunk => {
       stderrTail = (stderrTail + chunk.toString()).slice(-500);
     });
-    mcpProcess.on('error', e => setMCPStatus('error', e.message));
+    mcpProcess.on('error', e => {
+      mcpProcess = null;
+      setMCPStatus('error', e.message);
+    });
     mcpProcess.on('exit', code => {
       mcpProcess = null;
       if (code !== 0 && mcpStatus !== 'stopped') {
@@ -586,6 +596,7 @@ function startMCP(): void {
       }
     });
   } catch (err) {
+    mcpProcess = null;
     setMCPStatus('error', (err as Error).message);
   }
 }

--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -75,6 +75,14 @@
   </div>
 </aside>
 <div class="mid-shell">
+  <nav class="mid-activity-bar" id="activity-bar" aria-label="Activity bar">
+    <button id="activity-files" class="mid-activity-btn is-active" title="Files (toggle)" data-icon="folder"></button>
+    <button id="activity-notes" class="mid-activity-btn" title="Notes (toggle)" data-icon="bookmark"></button>
+    <button id="activity-search" class="mid-activity-btn" title="Search (toggle)" data-icon="search"></button>
+    <button id="activity-github" class="mid-activity-btn" title="GitHub (toggle)" data-icon="github"></button>
+    <span class="mid-activity-spacer"></span>
+    <button id="activity-settings" class="mid-activity-btn" title="Settings (Cmd/Ctrl+,)" data-icon="cog"></button>
+  </nav>
   <aside class="mid-sidebar" id="sidebar" hidden>
     <div class="mid-sidebar-mode" role="tablist">
       <button id="mode-files" class="mid-sidebar-mode-btn is-active" role="tab">Files</button>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -9,12 +9,53 @@ body {
 
 .mid-shell {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: 44px 1fr;
   min-height: 0;
   overflow: hidden;
 }
 body.has-sidebar .mid-shell {
-  grid-template-columns: var(--mid-sidebar-w) 1fr;
+  grid-template-columns: 44px var(--mid-sidebar-w) 1fr;
+}
+
+/* Activity bar — VSCode-style vertical icon tray */
+.mid-activity-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: var(--mid-space-2) 0;
+  background: var(--mid-bg);
+  border-right: 1px solid var(--mid-border);
+}
+.mid-activity-spacer { flex: 1; }
+.mid-activity-btn {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  color: var(--mid-fg-muted);
+  border-radius: var(--mid-radius-md);
+  cursor: pointer;
+  transition: background var(--mid-motion-fast), color var(--mid-motion-fast);
+}
+.mid-activity-btn:hover { background: var(--mid-surface); color: var(--mid-fg); }
+.mid-activity-btn.is-active {
+  color: var(--mid-fg);
+  background: var(--mid-surface);
+  position: relative;
+}
+.mid-activity-btn.is-active::before {
+  content: "";
+  position: absolute;
+  left: -1px;
+  top: 6px;
+  bottom: 6px;
+  width: 2px;
+  background: var(--mid-accent);
+  border-radius: 2px;
 }
 
 .mid-sidebar {
@@ -776,12 +817,12 @@ main.splitting .mid-preview {
 .mid-table-sort-indicator {
   margin-left: var(--mid-space-1);
   vertical-align: middle;
-  opacity: 0;
+  opacity: 0.35;
   transform: rotate(90deg);
   transition: opacity var(--mid-motion-fast) var(--mid-ease-out), transform var(--mid-motion-fast) var(--mid-ease-out);
 }
 .mid-table-sortable:hover { color: var(--mid-fg); }
-.mid-table-sortable:hover .mid-table-sort-indicator { opacity: 0.5; }
+.mid-table-sortable:hover .mid-table-sort-indicator { opacity: 0.7; }
 .mid-table-sortable.is-sort-asc { color: var(--mid-fg); }
 .mid-table-sortable.is-sort-asc .mid-table-sort-indicator { opacity: 1; transform: rotate(-90deg); }
 .mid-table-sortable.is-sort-desc { color: var(--mid-fg); }
@@ -887,7 +928,7 @@ main.splitting .mid-preview {
 }
 .mid-preview tr:last-child td { border-bottom: 0; }
 
-/* Header refinement v2 — uppercase tracking + subtle surface */
+/* Header refinement v3 — always-visible sort affordance, more presence */
 .mid-preview thead { background: var(--mid-surface); }
 .mid-preview th {
   text-transform: uppercase;
@@ -895,8 +936,8 @@ main.splitting .mid-preview {
   font-size: var(--mid-font-size-xs);
   font-weight: var(--mid-weight-semibold);
   color: var(--mid-fg-muted);
-  padding: var(--mid-space-2) var(--mid-space-4);
-  border-bottom: 1px solid var(--mid-border);
+  padding: var(--mid-space-3) var(--mid-space-4);
+  border-bottom: 1px solid var(--mid-border-strong);
 }
 
 /* Print mode — hides chrome so PDF export captures only the document */

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -111,6 +111,11 @@ const btnOpen = document.getElementById('open-btn') as HTMLButtonElement;
 const btnOpenFolder = document.getElementById('open-folder-btn') as HTMLButtonElement;
 const btnSave = document.getElementById('save-btn') as HTMLButtonElement;
 const sidebar = document.getElementById('sidebar') as HTMLElement;
+const activityFiles = document.getElementById('activity-files') as HTMLButtonElement;
+const activityNotes = document.getElementById('activity-notes') as HTMLButtonElement;
+const activitySearch = document.getElementById('activity-search') as HTMLButtonElement;
+const activityGithub = document.getElementById('activity-github') as HTMLButtonElement;
+const activitySettings = document.getElementById('activity-settings') as HTMLButtonElement;
 const sidebarFolderName = document.getElementById('sidebar-folder-name') as HTMLSpanElement;
 const sidebarRefresh = document.getElementById('sidebar-refresh') as HTMLButtonElement;
 const treeRoot = document.getElementById('tree-root') as HTMLDivElement;
@@ -1725,6 +1730,42 @@ btnSave.addEventListener('click', () => void saveFile());
 sidebarRefresh.addEventListener('click', () => void refreshFolder());
 modeFilesBtn.addEventListener('click', () => setSidebarMode('files'));
 modeNotesBtn.addEventListener('click', () => setSidebarMode('notes'));
+
+// Activity bar — VSCode-style icon tray. Clicking the active icon toggles the sidebar.
+type ActivityTarget = 'files' | 'notes' | 'search' | 'github';
+let activeActivity: ActivityTarget = 'files';
+function selectActivity(target: ActivityTarget): void {
+  if (target === activeActivity && !sidebar.hidden) {
+    // Re-click on active icon → collapse the sidebar
+    sidebar.hidden = true;
+    document.body.classList.remove('has-sidebar');
+    return;
+  }
+  activeActivity = target;
+  if (currentFolder) {
+    sidebar.hidden = false;
+    document.body.classList.add('has-sidebar');
+  }
+  for (const [t, btn] of [
+    ['files', activityFiles], ['notes', activityNotes],
+    ['search', activitySearch], ['github', activityGithub],
+  ] as const) {
+    btn.classList.toggle('is-active', t === target);
+  }
+  if (target === 'files') setSidebarMode('files');
+  else if (target === 'notes') setSidebarMode('notes');
+  else if (target === 'search') {
+    setSidebarMode('notes');
+    notesFilter.focus();
+  } else if (target === 'github') {
+    void promptConnectRepo();
+  }
+}
+activityFiles.addEventListener('click', () => selectActivity('files'));
+activityNotes.addEventListener('click', () => selectActivity('notes'));
+activitySearch.addEventListener('click', () => selectActivity('search'));
+activityGithub.addEventListener('click', () => selectActivity('github'));
+activitySettings.addEventListener('click', () => document.getElementById('settings-btn')?.dispatchEvent(new MouseEvent('click')));
 notesNewBtn.addEventListener('click', () => void promptCreateNote());
 notesFilter.addEventListener('input', () => {
   notesFilterText = notesFilter.value.trim().toLowerCase();


### PR DESCRIPTION
**#183 Start MCP doesn't start** — `startMCP()` early-returned on a stale `mcpProcess` ref left over from a previous failed start. Fix: clear the ref when `killed` or `exitCode !== null`; also clear in the error / catch branches.

**#185 Table header still broken** — sort chevrons were invisible until hover. Fix: always show at opacity 0.35; brighten on hover (0.7) / active (1.0). Header padding bumped to space-3 vertical, bottom border thickens to `border-strong`.

**#184 VSCode-style activity bar** — new vertical `<nav class="mid-activity-bar">` between window edge and sidebar (44 px wide). Five icons: Files / Notes / Search / GitHub / Settings. Clicking the active icon toggles the sidebar. Active icon gets accent-colored left rail. Body grid grows from 2 cols to 3 cols when sidebar is open.

Closes #183 #184 #185.