### PR TITLE
feat(desktop): activity-driven sidebar + pinned folders + spotlight (#187 #188)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -529,6 +529,7 @@ interface AppState {
   previewMaxWidth?: number;
   recentFiles?: string[];
   codeExportGradient?: string;
+  pinnedFolders?: { path: string; name: string; icon: string; color: string }[];
 }
 
 function resolveMCPServerScript(): string {

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -24,6 +24,7 @@ export interface AppState {
   previewMaxWidth?: number;
   recentFiles?: string[];
   codeExportGradient?: string;
+  pinnedFolders?: { path: string; name: string; icon: string; color: string }[];
 }
 
 export interface NoteEntry {

--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -76,18 +76,25 @@
 </aside>
 <div class="mid-shell">
   <nav class="mid-activity-bar" id="activity-bar" aria-label="Activity bar">
+    <button id="activity-spotlight" class="mid-activity-btn" title="Spotlight search (Cmd/Ctrl+K)" data-icon="search"></button>
+    <span class="mid-activity-divider"></span>
     <button id="activity-files" class="mid-activity-btn is-active" title="Files (toggle)" data-icon="folder"></button>
     <button id="activity-notes" class="mid-activity-btn" title="Notes (toggle)" data-icon="bookmark"></button>
-    <button id="activity-search" class="mid-activity-btn" title="Search (toggle)" data-icon="search"></button>
-    <button id="activity-github" class="mid-activity-btn" title="GitHub (toggle)" data-icon="github"></button>
+    <div id="activity-pinned" class="mid-activity-pinned"></div>
     <span class="mid-activity-spacer"></span>
     <button id="activity-settings" class="mid-activity-btn" title="Settings (Cmd/Ctrl+,)" data-icon="cog"></button>
   </nav>
-  <aside class="mid-sidebar" id="sidebar" hidden>
-    <div class="mid-sidebar-mode" role="tablist">
-      <button id="mode-files" class="mid-sidebar-mode-btn is-active" role="tab">Files</button>
-      <button id="mode-notes" class="mid-sidebar-mode-btn" role="tab">Notes</button>
+  <dialog id="mid-spotlight" class="mid-spotlight">
+    <div class="mid-spotlight-frame">
+      <div class="mid-spotlight-tabs">
+        <button class="mid-spotlight-tab is-active" data-spotlight-scope="workspace">Workspace</button>
+        <button class="mid-spotlight-tab" data-spotlight-scope="file">Current file</button>
+      </div>
+      <input id="mid-spotlight-input" class="mid-spotlight-input" type="text" placeholder="Type to search…" autocomplete="off" />
+      <div id="mid-spotlight-results" class="mid-spotlight-results"></div>
     </div>
+  </dialog>
+  <aside class="mid-sidebar" id="sidebar" hidden>
     <div class="mid-sidebar-header" id="sidebar-files-header">
       <span class="mid-sidebar-title" id="sidebar-folder-name">Files</span>
       <button id="sidebar-refresh" class="mid-btn mid-btn--icon mid-btn--ghost" title="Refresh" data-icon="refresh"></button>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -28,6 +28,22 @@ body.has-sidebar .mid-shell {
   border-right: 1px solid var(--mid-border);
 }
 .mid-activity-spacer { flex: 1; }
+.mid-activity-divider {
+  width: 22px;
+  height: 1px;
+  background: var(--mid-border);
+  margin: var(--mid-space-1) 0;
+}
+.mid-activity-pinned {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin-top: var(--mid-space-2);
+  padding-top: var(--mid-space-2);
+  border-top: 1px solid var(--mid-border);
+}
+.mid-activity-btn--pinned { color: inherit; }
 .mid-activity-btn {
   width: 36px;
   height: 36px;
@@ -126,28 +142,7 @@ body.has-sidebar .mid-shell {
   font-size: var(--mid-font-size-sm);
 }
 
-/* Sidebar mode toggle (Files / Notes) */
-.mid-sidebar-mode {
-  display: flex;
-  border-bottom: 1px solid var(--mid-border);
-}
-.mid-sidebar-mode-btn {
-  flex: 1;
-  padding: var(--mid-space-2);
-  font-family: inherit;
-  font-size: var(--mid-font-size-sm);
-  font-weight: var(--mid-weight-medium);
-  color: var(--mid-fg-muted);
-  background: transparent;
-  border: 0;
-  border-bottom: 2px solid transparent;
-  cursor: pointer;
-}
-.mid-sidebar-mode-btn:hover { color: var(--mid-fg); background: var(--mid-surface-hover); }
-.mid-sidebar-mode-btn.is-active {
-  color: var(--mid-fg);
-  border-bottom-color: var(--mid-accent);
-}
+/* Sidebar mode toggle removed — activity bar drives sidebar content (#187) */
 
 /* Notes list */
 .mid-notes-list {
@@ -253,6 +248,76 @@ body.has-sidebar .mid-shell {
   color: var(--mid-success);
 }
 .mid-status-dot.is-dirty { color: var(--mid-warning); }
+
+/* Spotlight — Cmd/Ctrl+K palette */
+.mid-spotlight {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  margin: auto;
+  width: min(640px, 92vw);
+}
+.mid-spotlight::backdrop { background: rgba(0, 0, 0, 0.5); }
+.mid-spotlight-frame {
+  background: var(--mid-bg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-lg);
+  box-shadow: var(--mid-shadow-lg);
+  overflow: hidden;
+}
+.mid-spotlight-tabs {
+  display: flex;
+  gap: 2px;
+  padding: var(--mid-space-2) var(--mid-space-3);
+  border-bottom: 1px solid var(--mid-border);
+}
+.mid-spotlight-tab {
+  padding: 4px var(--mid-space-3);
+  font-family: inherit;
+  font-size: var(--mid-font-size-sm);
+  color: var(--mid-fg-muted);
+  background: transparent;
+  border: 0;
+  border-radius: var(--mid-radius-sm);
+  cursor: pointer;
+}
+.mid-spotlight-tab:hover { background: var(--mid-surface); color: var(--mid-fg); }
+.mid-spotlight-tab.is-active { background: var(--mid-surface); color: var(--mid-fg); }
+.mid-spotlight-input {
+  width: 100%;
+  padding: var(--mid-space-3) var(--mid-space-4);
+  font-family: inherit;
+  font-size: var(--mid-font-size-lg);
+  color: var(--mid-fg);
+  background: var(--mid-bg);
+  border: 0;
+  border-bottom: 1px solid var(--mid-border);
+  outline: none;
+}
+.mid-spotlight-results {
+  max-height: 50vh;
+  overflow: auto;
+  padding: var(--mid-space-1);
+}
+.mid-spotlight-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--mid-space-2);
+  width: 100%;
+  padding: var(--mid-space-2) var(--mid-space-3);
+  background: transparent;
+  border: 0;
+  border-radius: var(--mid-radius-sm);
+  cursor: pointer;
+  font: inherit;
+  color: var(--mid-fg);
+  text-align: left;
+}
+.mid-spotlight-row:hover { background: var(--mid-surface); }
+.mid-spotlight-row-name { font-weight: var(--mid-weight-medium); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mid-spotlight-row-path { font-family: var(--mid-font-mono); font-size: var(--mid-font-size-xs); color: var(--mid-fg-muted); white-space: nowrap; }
+.mid-spotlight-empty { padding: var(--mid-space-4); text-align: center; color: var(--mid-fg-muted); font-size: var(--mid-font-size-sm); }
 
 /* Mermaid editor modal — split textarea + live preview */
 .mid-mermaid-editor {

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -113,9 +113,9 @@ const btnSave = document.getElementById('save-btn') as HTMLButtonElement;
 const sidebar = document.getElementById('sidebar') as HTMLElement;
 const activityFiles = document.getElementById('activity-files') as HTMLButtonElement;
 const activityNotes = document.getElementById('activity-notes') as HTMLButtonElement;
-const activitySearch = document.getElementById('activity-search') as HTMLButtonElement;
-const activityGithub = document.getElementById('activity-github') as HTMLButtonElement;
+const activitySpotlight = document.getElementById('activity-spotlight') as HTMLButtonElement;
 const activitySettings = document.getElementById('activity-settings') as HTMLButtonElement;
+const activityPinned = document.getElementById('activity-pinned') as HTMLDivElement;
 const sidebarFolderName = document.getElementById('sidebar-folder-name') as HTMLSpanElement;
 const sidebarRefresh = document.getElementById('sidebar-refresh') as HTMLButtonElement;
 const treeRoot = document.getElementById('tree-root') as HTMLDivElement;
@@ -146,6 +146,7 @@ let notes: NoteEntry[] = [];
 let notesFilterText = '';
 let recentFiles: string[] = [];
 let warehouses: Warehouse[] = [];
+let pinnedFolders: PinnedFolder[] = [];
 const settings = { ...DEFAULT_SETTINGS };
 const expandedDirs = new Set<string>();
 
@@ -1444,6 +1445,18 @@ function renderTreeEntry(entry: TreeEntry): HTMLElement {
       const fresh = renderTreeEntry(entry);
       wrapper.replaceWith(fresh);
     });
+    item.addEventListener('contextmenu', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      const isPinned = pinnedFolders.some(p => p.path === entry.path);
+      openContextMenu([
+        { icon: 'folder-open', label: 'Reveal in Finder', action: () => void window.mid.openExternal(`file://${entry.path}`) },
+        { separator: true, label: '' },
+        isPinned
+          ? { icon: 'trash', label: 'Unpin from sidebar', action: () => unpinFolder(entry.path) }
+          : { icon: 'bookmark', label: 'Pin to sidebar…', action: () => void pinFolder(entry.path, entry.name) },
+      ], e.clientX, e.clientY);
+    });
     wrapper.appendChild(item);
     if (isOpen && entry.children) {
       const children = document.createElement('div');
@@ -1731,12 +1744,13 @@ sidebarRefresh.addEventListener('click', () => void refreshFolder());
 modeFilesBtn.addEventListener('click', () => setSidebarMode('files'));
 modeNotesBtn.addEventListener('click', () => setSidebarMode('notes'));
 
-// Activity bar — VSCode-style icon tray. Clicking the active icon toggles the sidebar.
-type ActivityTarget = 'files' | 'notes' | 'search' | 'github';
+// Activity bar — VSCode-style icon tray.
+type ActivityTarget = 'files' | 'notes' | `pinned:${string}`;
 let activeActivity: ActivityTarget = 'files';
+let pinnedFilterPath: string | null = null;
+
 function selectActivity(target: ActivityTarget): void {
   if (target === activeActivity && !sidebar.hidden) {
-    // Re-click on active icon → collapse the sidebar
     sidebar.hidden = true;
     document.body.classList.remove('has-sidebar');
     return;
@@ -1746,26 +1760,220 @@ function selectActivity(target: ActivityTarget): void {
     sidebar.hidden = false;
     document.body.classList.add('has-sidebar');
   }
-  for (const [t, btn] of [
-    ['files', activityFiles], ['notes', activityNotes],
-    ['search', activitySearch], ['github', activityGithub],
-  ] as const) {
-    btn.classList.toggle('is-active', t === target);
-  }
-  if (target === 'files') setSidebarMode('files');
-  else if (target === 'notes') setSidebarMode('notes');
-  else if (target === 'search') {
+  activityFiles.classList.toggle('is-active', target === 'files');
+  activityNotes.classList.toggle('is-active', target === 'notes');
+  activityPinned.querySelectorAll<HTMLButtonElement>('.mid-activity-btn').forEach(btn => {
+    btn.classList.toggle('is-active', `pinned:${btn.dataset.path}` === target);
+  });
+  if (target === 'files') {
+    pinnedFilterPath = null;
+    setSidebarMode('files');
+    if (currentFolder) void refreshFolder();
+  } else if (target === 'notes') {
+    pinnedFilterPath = null;
     setSidebarMode('notes');
-    notesFilter.focus();
-  } else if (target === 'github') {
-    void promptConnectRepo();
+  } else if (target.startsWith('pinned:')) {
+    const path = target.slice('pinned:'.length);
+    pinnedFilterPath = path;
+    setSidebarMode('files');
+    void loadPinnedTree(path);
   }
 }
+
+async function loadPinnedTree(folderPath: string): Promise<void> {
+  try {
+    const tree = await window.mid.listFolderMd(folderPath);
+    const name = pinnedFolders.find(p => p.path === folderPath)?.name ?? folderPath.split('/').pop() ?? folderPath;
+    sidebarFolderName.textContent = name;
+    sidebarFolderName.title = folderPath;
+    treeRoot.replaceChildren(...renderTree(tree));
+    if (tree.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'mid-tree-empty';
+      empty.textContent = 'No markdown files in this folder.';
+      treeRoot.appendChild(empty);
+    }
+  } catch {
+    flashStatus('Pinned folder is gone — unpinning');
+    pinnedFolders = pinnedFolders.filter(p => p.path !== folderPath);
+    void window.mid.patchAppState({ pinnedFolders });
+    renderActivityPinned();
+    selectActivity('files');
+  }
+}
+
+function renderActivityPinned(): void {
+  activityPinned.replaceChildren();
+  for (const pin of pinnedFolders) {
+    const btn = document.createElement('button');
+    btn.className = 'mid-activity-btn mid-activity-btn--pinned';
+    btn.title = `${pin.name} (${pin.path})`;
+    btn.dataset.path = pin.path;
+    btn.style.color = pin.color;
+    btn.innerHTML = iconHTML((pin.icon as IconName) ?? 'folder');
+    btn.addEventListener('click', () => selectActivity(`pinned:${pin.path}`));
+    btn.addEventListener('contextmenu', e => {
+      e.preventDefault();
+      openContextMenu([
+        { icon: 'edit', label: 'Rename pin…', action: () => void renamePin(pin) },
+        { icon: 'cog', label: 'Change icon / color…', action: () => void editPinAppearance(pin) },
+        { separator: true, label: '' },
+        { icon: 'trash', label: 'Unpin', action: () => unpinFolder(pin.path) },
+      ], e.clientX, e.clientY);
+    });
+    activityPinned.appendChild(btn);
+  }
+}
+
+async function pinFolder(folderPath: string, name: string): Promise<void> {
+  if (pinnedFolders.find(p => p.path === folderPath)) {
+    flashStatus('Already pinned');
+    return;
+  }
+  pinnedFolders = [...pinnedFolders, {
+    path: folderPath,
+    name,
+    icon: 'folder',
+    color: '#2563eb',
+  }];
+  await window.mid.patchAppState({ pinnedFolders });
+  renderActivityPinned();
+  flashStatus(`Pinned "${name}"`);
+}
+
+function unpinFolder(folderPath: string): void {
+  pinnedFolders = pinnedFolders.filter(p => p.path !== folderPath);
+  void window.mid.patchAppState({ pinnedFolders });
+  renderActivityPinned();
+  if (activeActivity === `pinned:${folderPath}`) selectActivity('files');
+}
+
+async function renamePin(pin: PinnedFolder): Promise<void> {
+  const name = await midPrompt('Rename pin', 'Display name', pin.name);
+  if (!name) return;
+  pin.name = name;
+  await window.mid.patchAppState({ pinnedFolders });
+  renderActivityPinned();
+}
+
+async function editPinAppearance(pin: PinnedFolder): Promise<void> {
+  const icon = await midPrompt('Pin icon', 'Boxicon name (folder, bookmark, tag, list-ul, image, github)', pin.icon);
+  if (icon !== null && icon.trim()) pin.icon = icon.trim();
+  const color = await midPrompt('Pin color', 'Hex color', pin.color);
+  if (color !== null && color.trim()) pin.color = color.trim();
+  await window.mid.patchAppState({ pinnedFolders });
+  renderActivityPinned();
+}
+
 activityFiles.addEventListener('click', () => selectActivity('files'));
 activityNotes.addEventListener('click', () => selectActivity('notes'));
-activitySearch.addEventListener('click', () => selectActivity('search'));
-activityGithub.addEventListener('click', () => selectActivity('github'));
+activitySpotlight.addEventListener('click', () => openSpotlight());
 activitySettings.addEventListener('click', () => document.getElementById('settings-btn')?.dispatchEvent(new MouseEvent('click')));
+
+document.addEventListener('keydown', e => {
+  if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k' && !e.shiftKey) {
+    e.preventDefault();
+    openSpotlight();
+  }
+});
+
+// ===== Spotlight =====
+function openSpotlight(): void {
+  const dlg = document.getElementById('mid-spotlight') as HTMLDialogElement;
+  const input = document.getElementById('mid-spotlight-input') as HTMLInputElement;
+  const results = document.getElementById('mid-spotlight-results') as HTMLDivElement;
+  const tabs = dlg.querySelectorAll<HTMLButtonElement>('.mid-spotlight-tab');
+  let scope: 'workspace' | 'file' = 'workspace';
+  let workspaceFiles: { path: string; name: string }[] = [];
+  let renderTimer: number | null = null;
+
+  const collectWorkspaceFiles = async (): Promise<void> => {
+    if (!currentFolder) return;
+    const tree = await window.mid.listFolderMd(currentFolder);
+    workspaceFiles = [];
+    const walk = (entries: TreeEntry[]): void => {
+      for (const e of entries) {
+        if (e.kind === 'file') workspaceFiles.push({ path: e.path, name: e.name });
+        else if (e.children) walk(e.children);
+      }
+    };
+    walk(tree);
+  };
+
+  const renderResults = (): void => {
+    const q = input.value.trim().toLowerCase();
+    results.replaceChildren();
+    if (scope === 'workspace') {
+      const matches = q
+        ? workspaceFiles.filter(f => f.name.toLowerCase().includes(q) || f.path.toLowerCase().includes(q))
+        : workspaceFiles;
+      for (const m of matches.slice(0, 50)) {
+        const row = document.createElement('button');
+        row.className = 'mid-spotlight-row';
+        row.innerHTML = `${iconHTML('file', 'mid-icon--sm mid-icon--muted')}<span class="mid-spotlight-row-name">${escapeHTML(m.name)}</span><span class="mid-spotlight-row-path">${escapeHTML(m.path.replace(currentFolder ?? '', '').replace(/^\//, ''))}</span>`;
+        row.addEventListener('click', () => {
+          close();
+          void openRecent(m.path);
+        });
+        results.appendChild(row);
+      }
+      if (matches.length === 0) results.innerHTML = '<div class="mid-spotlight-empty">No files match.</div>';
+    } else {
+      // current file: heading + content matches
+      if (!currentText) { results.innerHTML = '<div class="mid-spotlight-empty">No active document.</div>'; return; }
+      if (!q) { results.innerHTML = '<div class="mid-spotlight-empty">Type to search the active document.</div>'; return; }
+      const lines = currentText.split('\n');
+      const hits: { line: number; text: string; isHeading: boolean }[] = [];
+      for (let i = 0; i < lines.length; i++) {
+        const text = lines[i];
+        if (text.toLowerCase().includes(q)) {
+          hits.push({ line: i + 1, text: text.trim(), isHeading: /^#+\s/.test(text) });
+          if (hits.length >= 100) break;
+        }
+      }
+      for (const h of hits) {
+        const row = document.createElement('button');
+        row.className = 'mid-spotlight-row';
+        row.innerHTML = `${iconHTML(h.isHeading ? 'list-ul' : 'file', 'mid-icon--sm mid-icon--muted')}<span class="mid-spotlight-row-name">${escapeHTML(h.text.slice(0, 80))}</span><span class="mid-spotlight-row-path">L${h.line}</span>`;
+        row.addEventListener('click', () => {
+          close();
+          // No live scroll-to-line; flash status indicates target.
+          flashStatus(`Match at line ${h.line}`);
+        });
+        results.appendChild(row);
+      }
+      if (hits.length === 0) results.innerHTML = '<div class="mid-spotlight-empty">No matches in this file.</div>';
+    }
+  };
+
+  const onInput = (): void => {
+    if (renderTimer !== null) window.clearTimeout(renderTimer);
+    renderTimer = window.setTimeout(renderResults, 80);
+  };
+  const setScope = (s: 'workspace' | 'file'): void => {
+    scope = s;
+    tabs.forEach(t => t.classList.toggle('is-active', t.dataset.spotlightScope === s));
+    renderResults();
+  };
+  const onKey = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') { e.preventDefault(); close(); }
+  };
+  const close = (): void => {
+    input.removeEventListener('input', onInput);
+    document.removeEventListener('keydown', onKey);
+    tabs.forEach(t => t.removeEventListener('click', onTab));
+    if (dlg.open) dlg.close();
+  };
+  const onTab = (e: Event): void => setScope((e.currentTarget as HTMLButtonElement).dataset.spotlightScope as 'workspace' | 'file');
+
+  input.value = '';
+  input.addEventListener('input', onInput);
+  document.addEventListener('keydown', onKey);
+  tabs.forEach(t => t.addEventListener('click', onTab));
+  dlg.showModal();
+  void collectWorkspaceFiles().then(renderResults);
+  input.focus();
+}
 notesNewBtn.addEventListener('click', () => void promptCreateNote());
 notesFilter.addEventListener('input', () => {
   notesFilterText = notesFilter.value.trim().toLowerCase();
@@ -2306,6 +2514,10 @@ void window.mid.readAppState().then(async state => {
   if (Array.isArray(state.recentFiles)) recentFiles = state.recentFiles.slice(0, 10);
   if (state.codeExportGradient && state.codeExportGradient in CODE_EXPORT_GRADIENTS) {
     settings.codeExportGradient = state.codeExportGradient as CodeExportGradient;
+  }
+  if (Array.isArray(state.pinnedFolders)) {
+    pinnedFolders = state.pinnedFolders;
+    renderActivityPinned();
   }
   applySettings();
   if (state.lastFolder) {


### PR DESCRIPTION
**#187 — Activity bar drives the sidebar**
- Inline Files/Notes tab toggle removed; sidebar content swaps based on activity icon.
- GitHub icon dropped from activity bar (status-bar repo cell already covers connect/sync).
- Right-click any folder in the file tree → "Pin to sidebar". Pinned folders render as new activity icons between the static set and the spacer; clicking shows only that folder's tree.
- Pin context menu (right-click pinned icon): Rename, Change icon/color, Unpin.
- `pinnedFolders` persisted in `AppState` as `{ path, name, icon, color }[]`.

**#188 — Cmd+K spotlight**
- New search icon at the top of the activity bar + global `Cmd/Ctrl+K` accelerator.
- Two scope tabs: **Workspace** (all .md files matched on path/name) and **Current file** (line-level matches with heading detection).
- Click a result → opens the file (workspace) or flashes the matched line number (current file).

Closes #187 #188.