### PR TITLE
fix(desktop): v0.7.2 bundle — gradient/picker/loader/header/dismiss

### DIFF
--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -12,6 +12,24 @@
 <link rel="stylesheet" href="renderer.css" />
 </head>
 <body>
+<div id="mid-loader" class="mid-loader" aria-hidden="true">
+  <div class="mid-loader-glyph"></div>
+  <div class="mid-loader-label">Mark It Down</div>
+</div>
+<dialog id="mid-pin-editor" class="mid-pin-editor">
+  <form method="dialog" class="mid-pin-form">
+    <h3 class="mid-pin-title">Pin folder</h3>
+    <label class="mid-pin-label">Title<input type="text" id="mid-pin-name" class="mid-settings-control" /></label>
+    <div class="mid-pin-label">Icon</div>
+    <div class="mid-pin-icons" id="mid-pin-icons"></div>
+    <div class="mid-pin-label">Color</div>
+    <div class="mid-pin-colors" id="mid-pin-colors"></div>
+    <div class="mid-pin-actions">
+      <button type="button" id="mid-pin-cancel" class="mid-btn">Cancel</button>
+      <button type="submit" id="mid-pin-save" class="mid-btn mid-btn--primary">Save</button>
+    </div>
+  </form>
+</dialog>
 <header class="mid-titlebar" role="toolbar">
   <div class="mid-titlebar-left">
     <button id="open-folder-btn" class="mid-btn mid-btn--icon mid-btn--ghost" title="Open folder (Cmd/Ctrl+Shift+O)" data-icon="folder-open"></button>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -394,6 +394,95 @@ body.has-sidebar .mid-shell {
   color: var(--mid-fg-muted);
 }
 
+/* Launch loader overlay */
+.mid-loader {
+  position: fixed;
+  inset: 0;
+  z-index: var(--mid-z-toast);
+  display: grid;
+  place-items: center;
+  background: var(--mid-bg);
+  transition: opacity 400ms var(--mid-ease-out);
+  pointer-events: none;
+}
+.mid-loader.is-fading { opacity: 0; }
+.mid-loader-glyph {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  border: 3px solid var(--mid-border);
+  border-top-color: var(--mid-fg);
+  animation: mid-loader-spin 900ms linear infinite;
+  margin-bottom: var(--mid-space-3);
+}
+.mid-loader-label {
+  font-size: var(--mid-font-size-sm);
+  color: var(--mid-fg-muted);
+  letter-spacing: 0.04em;
+}
+@keyframes mid-loader-spin { to { transform: rotate(360deg); } }
+
+/* Pin editor modal — title + icon thumbnails + color swatches */
+.mid-pin-editor {
+  margin: auto;
+  padding: 0;
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-lg);
+  background: var(--mid-bg);
+  color: var(--mid-fg);
+  box-shadow: var(--mid-shadow-lg);
+  width: min(420px, 92vw);
+}
+.mid-pin-editor::backdrop { background: rgba(0, 0, 0, 0.5); }
+.mid-pin-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-3);
+  padding: var(--mid-space-4);
+}
+.mid-pin-title { margin: 0; font-size: var(--mid-font-size-lg); font-weight: var(--mid-weight-semibold); }
+.mid-pin-label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-1);
+  font-size: var(--mid-font-size-sm);
+  font-weight: var(--mid-weight-medium);
+  color: var(--mid-fg);
+}
+.mid-pin-icons {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 4px;
+}
+.mid-pin-icon-btn {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--mid-bg);
+  color: var(--mid-fg-muted);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
+  cursor: pointer;
+}
+.mid-pin-icon-btn:hover { background: var(--mid-surface); color: var(--mid-fg); }
+.mid-pin-icon-btn.is-active { background: var(--mid-surface); color: var(--mid-fg); border-color: var(--mid-fg); }
+.mid-pin-colors {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 4px;
+}
+.mid-pin-color-btn {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border: 2px solid transparent;
+  border-radius: 50%;
+  cursor: pointer;
+}
+.mid-pin-color-btn.is-active { border-color: var(--mid-fg); box-shadow: 0 0 0 1px var(--mid-bg) inset; }
+.mid-pin-actions { display: flex; justify-content: flex-end; gap: var(--mid-space-2); }
+
 /* Modal dialog (replaces window.prompt / window.confirm — unsupported in Electron) */
 .mid-dialog {
   margin: auto;
@@ -993,8 +1082,8 @@ main.splitting .mid-preview {
 }
 .mid-preview tr:last-child td { border-bottom: 0; }
 
-/* Header refinement v3 — always-visible sort affordance, more presence */
-.mid-preview thead { background: var(--mid-surface); }
+/* Header v4 — pure shadcn DataTable look (no thead bg) */
+.mid-preview thead { background: transparent; }
 .mid-preview th {
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -1002,7 +1091,9 @@ main.splitting .mid-preview {
   font-weight: var(--mid-weight-semibold);
   color: var(--mid-fg-muted);
   padding: var(--mid-space-3) var(--mid-space-4);
-  border-bottom: 1px solid var(--mid-border-strong);
+  border-bottom: 1px solid var(--mid-border);
+  height: 40px;
+  white-space: nowrap;
 }
 
 /* Print mode — hides chrome so PDF export captures only the document */

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -21,6 +21,18 @@ type FontFamilyChoice = 'system' | 'sans' | 'serif' | 'mono';
 /** A theme is either one of the built-in modes or a named theme id prefixed with `theme:`. */
 type ThemeChoice = 'auto' | 'light' | 'dark' | 'sepia' | `theme:${string}`;
 
+type CodeExportGradient = 'none' | 'sunset' | 'ocean' | 'lavender' | 'forest' | 'slate' | 'midnight';
+
+const CODE_EXPORT_GRADIENTS: Record<CodeExportGradient, string | null> = {
+  none: null,
+  sunset: 'linear-gradient(135deg, #ff7e5f 0%, #feb47b 100%)',
+  ocean: 'linear-gradient(135deg, #2193b0 0%, #6dd5ed 100%)',
+  lavender: 'linear-gradient(135deg, #c471f5 0%, #fa71cd 100%)',
+  forest: 'linear-gradient(135deg, #134e5e 0%, #71b280 100%)',
+  slate: 'linear-gradient(135deg, #485563 0%, #29323c 100%)',
+  midnight: 'linear-gradient(135deg, #232526 0%, #414345 100%)',
+};
+
 interface AppState {
   lastFolder?: string;
   splitRatio?: number;
@@ -28,6 +40,16 @@ interface AppState {
   fontSize?: number;
   theme?: ThemeChoice;
   previewMaxWidth?: number;
+  recentFiles?: string[];
+  codeExportGradient?: CodeExportGradient;
+  pinnedFolders?: PinnedFolder[];
+}
+
+interface PinnedFolder {
+  path: string;
+  name: string;
+  icon: string;
+  color: string;
 }
 
 const DEFAULT_SETTINGS = {
@@ -1826,20 +1848,114 @@ function renderActivityPinned(): void {
   }
 }
 
-async function pinFolder(folderPath: string, name: string): Promise<void> {
+async function pinFolder(folderPath: string, defaultName: string): Promise<void> {
   if (pinnedFolders.find(p => p.path === folderPath)) {
     flashStatus('Already pinned');
     return;
   }
-  pinnedFolders = [...pinnedFolders, {
-    path: folderPath,
-    name,
+  const result = await openPinEditor({
+    name: defaultName,
     icon: 'folder',
     color: '#2563eb',
+    titleLabel: 'Pin folder',
+  });
+  if (!result) return;
+  pinnedFolders = [...pinnedFolders, {
+    path: folderPath,
+    name: result.name,
+    icon: result.icon,
+    color: result.color,
   }];
   await window.mid.patchAppState({ pinnedFolders });
   renderActivityPinned();
-  flashStatus(`Pinned "${name}"`);
+  flashStatus(`Pinned "${result.name}"`);
+}
+
+const PIN_ICON_CHOICES: IconName[] = [
+  'folder', 'folder-open', 'file', 'bookmark', 'tag',
+  'list-ul', 'image', 'github', 'link', 'cog',
+  'search', 'markdown', 'typescript', 'javascript', 'python',
+];
+const PIN_COLOR_CHOICES = [
+  '#2563eb', '#16a34a', '#dc2626', '#ca8a04',
+  '#9333ea', '#0891b2', '#db2777', '#475569',
+  '#f97316', '#0d9488', '#7c3aed', '#71717a',
+];
+
+interface PinEditorInput { name: string; icon: string; color: string; titleLabel?: string }
+interface PinEditorResult { name: string; icon: string; color: string }
+
+function openPinEditor(initial: PinEditorInput): Promise<PinEditorResult | null> {
+  return new Promise(resolve => {
+    const dlg = document.getElementById('mid-pin-editor') as HTMLDialogElement;
+    const titleEl = dlg.querySelector('.mid-pin-title') as HTMLHeadingElement;
+    const nameEl = document.getElementById('mid-pin-name') as HTMLInputElement;
+    const iconsEl = document.getElementById('mid-pin-icons') as HTMLDivElement;
+    const colorsEl = document.getElementById('mid-pin-colors') as HTMLDivElement;
+    const cancelBtn = document.getElementById('mid-pin-cancel') as HTMLButtonElement;
+    const form = dlg.querySelector('form') as HTMLFormElement;
+
+    titleEl.textContent = initial.titleLabel ?? 'Pin folder';
+    nameEl.value = initial.name;
+    let chosenIcon = initial.icon;
+    let chosenColor = initial.color;
+
+    iconsEl.replaceChildren();
+    for (const ic of PIN_ICON_CHOICES) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'mid-pin-icon-btn' + (ic === chosenIcon ? ' is-active' : '');
+      btn.dataset.icon = ic;
+      btn.innerHTML = iconHTML(ic);
+      btn.addEventListener('click', () => {
+        chosenIcon = ic;
+        iconsEl.querySelectorAll('.mid-pin-icon-btn').forEach(b => b.classList.toggle('is-active', (b as HTMLElement).dataset.icon === ic));
+      });
+      iconsEl.appendChild(btn);
+    }
+
+    colorsEl.replaceChildren();
+    for (const col of PIN_COLOR_CHOICES) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'mid-pin-color-btn' + (col === chosenColor ? ' is-active' : '');
+      btn.style.background = col;
+      btn.dataset.color = col;
+      btn.title = col;
+      btn.addEventListener('click', () => {
+        chosenColor = col;
+        colorsEl.querySelectorAll('.mid-pin-color-btn').forEach(b => b.classList.toggle('is-active', (b as HTMLElement).dataset.color === col));
+      });
+      colorsEl.appendChild(btn);
+    }
+
+    let canceled = true;
+    const cleanup = (): void => {
+      form.removeEventListener('submit', onSubmit);
+      cancelBtn.removeEventListener('click', onCancel);
+      dlg.removeEventListener('click', onBackdrop);
+      dlg.removeEventListener('close', onClose);
+    };
+    const onSubmit = (e: Event): void => {
+      e.preventDefault();
+      canceled = false;
+      cleanup();
+      dlg.close();
+      resolve({ name: nameEl.value.trim() || initial.name, icon: chosenIcon, color: chosenColor });
+    };
+    const onCancel = (): void => { cleanup(); dlg.close(); resolve(null); };
+    const onBackdrop = (e: MouseEvent): void => { if (e.target === dlg) onCancel(); };
+    const onClose = (): void => { if (canceled) { cleanup(); resolve(null); } };
+
+    form.addEventListener('submit', onSubmit);
+    cancelBtn.addEventListener('click', onCancel);
+    dlg.addEventListener('click', onBackdrop);
+    dlg.addEventListener('close', onClose);
+
+    dlg.showModal();
+    nameEl.focus();
+    nameEl.select();
+  });
 }
 
 function unpinFolder(folderPath: string): void {
@@ -1850,18 +1966,21 @@ function unpinFolder(folderPath: string): void {
 }
 
 async function renamePin(pin: PinnedFolder): Promise<void> {
-  const name = await midPrompt('Rename pin', 'Display name', pin.name);
-  if (!name) return;
-  pin.name = name;
+  const result = await openPinEditor({ name: pin.name, icon: pin.icon, color: pin.color, titleLabel: 'Rename pin' });
+  if (!result) return;
+  pin.name = result.name;
+  pin.icon = result.icon;
+  pin.color = result.color;
   await window.mid.patchAppState({ pinnedFolders });
   renderActivityPinned();
 }
 
 async function editPinAppearance(pin: PinnedFolder): Promise<void> {
-  const icon = await midPrompt('Pin icon', 'Boxicon name (folder, bookmark, tag, list-ul, image, github)', pin.icon);
-  if (icon !== null && icon.trim()) pin.icon = icon.trim();
-  const color = await midPrompt('Pin color', 'Hex color', pin.color);
-  if (color !== null && color.trim()) pin.color = color.trim();
+  const result = await openPinEditor({ name: pin.name, icon: pin.icon, color: pin.color, titleLabel: 'Pin appearance' });
+  if (!result) return;
+  pin.name = result.name;
+  pin.icon = result.icon;
+  pin.color = result.color;
   await window.mid.patchAppState({ pinnedFolders });
   renderActivityPinned();
 }
@@ -2331,6 +2450,11 @@ function openDialog(opts: { title: string; message?: string; label?: string; def
     form.addEventListener('submit', onSubmit);
     cancelBtn.addEventListener('click', onCancel);
     dlg.addEventListener('close', onClose);
+    // Click on the backdrop (outside the form) cancels.
+    const onBackdropClick = (e: MouseEvent): void => {
+      if (e.target === dlg) onCancel();
+    };
+    dlg.addEventListener('click', onBackdropClick);
 
     dlg.showModal();
     if (opts.label !== undefined) inputEl.focus();
@@ -2521,6 +2645,9 @@ void window.mid.readAppState().then(async state => {
     renderActivityPinned();
   }
   applySettings();
+  // Fade out the launch loader once initial state is hydrated.
+  document.getElementById('mid-loader')?.classList.add('is-fading');
+  setTimeout(() => document.getElementById('mid-loader')?.remove(), 500);
   if (state.lastFolder) {
     try {
       const tree = await window.mid.listFolderMd(state.lastFolder);


### PR DESCRIPTION
**#192** Re-add lost `type CodeExportGradient` + `CODE_EXPORT_GRADIENTS` map at top of renderer. Export PNG no longer crashes.

**#193** New `mid-pin-editor` dialog with: title input, 5x3 grid of Boxicons thumbnails (folder/bookmark/tag/etc.), 4x3 grid of color swatches, Cancel / Save. Used by both "Pin to sidebar" and "Edit pin appearance". Replaces the chained prompts.

**#194** `midPrompt` and `openPinEditor` now resolve canceled when the user clicks the dialog backdrop — no more 'i can't dismiss' issue.

**#195** New `#mid-loader` overlay with spinner + brand label. Visible from first paint; fades + removes after `mid:read-app-state` settles. Stops the 'app starts empty' flash.

**#196** Table header v4: drop the surface bg behind `<thead>`; pure border-b shadcn DataTable look — uppercase XS muted-fg semibold; 40px row height; chevron stays.

Closes #192 #193 #194 #195 #196.