### PR TITLE
feat(desktop): title-bar search + pinned drag-drop + table refinement (#198 #199)

### DIFF
--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -37,7 +37,11 @@
     <button id="save-btn" class="mid-btn mid-btn--icon mid-btn--ghost" title="Save (Cmd/Ctrl+S)" data-icon="save"></button>
   </div>
   <div class="mid-titlebar-center">
-    <span id="filename" class="mid-filename">Untitled</span>
+    <button id="titlebar-search" class="mid-titlebar-search" title="Search (Cmd/Ctrl+K)">
+      <span class="mid-titlebar-search-icon" data-icon="search"></span>
+      <span id="filename" class="mid-filename">Untitled</span>
+      <span class="mid-titlebar-search-kbd"><kbd class="mid-kbd">⌘K</kbd></span>
+    </button>
   </div>
   <div class="mid-titlebar-right">
     <div class="mid-mode-toggle" role="tablist" aria-label="Render mode">
@@ -94,8 +98,6 @@
 </aside>
 <div class="mid-shell">
   <nav class="mid-activity-bar" id="activity-bar" aria-label="Activity bar">
-    <button id="activity-spotlight" class="mid-activity-btn" title="Spotlight search (Cmd/Ctrl+K)" data-icon="search"></button>
-    <span class="mid-activity-divider"></span>
     <button id="activity-files" class="mid-activity-btn is-active" title="Files (toggle)" data-icon="folder"></button>
     <button id="activity-notes" class="mid-activity-btn" title="Notes (toggle)" data-icon="bookmark"></button>
     <div id="activity-pinned" class="mid-activity-pinned"></div>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -44,6 +44,8 @@ body.has-sidebar .mid-shell {
   border-top: 1px solid var(--mid-border);
 }
 .mid-activity-btn--pinned { color: inherit; }
+.mid-activity-btn.is-dragging { opacity: 0.4; }
+.mid-activity-btn.is-drop-target { background: var(--mid-accent); color: var(--mid-accent-fg); }
 .mid-activity-btn {
   width: 36px;
   height: 36px;
@@ -527,14 +529,36 @@ body.is-mac .mid-titlebar { padding-left: 80px; }
 .mid-titlebar-right { justify-self: end; }
 .mid-titlebar-center {
   text-align: center;
-  color: var(--mid-fg);
+  padding: 0 var(--mid-space-3);
+}
+
+/* Title-bar search — clickable filename pill that opens spotlight */
+.mid-titlebar-search {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mid-space-2);
+  padding: 4px var(--mid-space-3);
+  font-family: inherit;
   font-size: var(--mid-font-size-sm);
   font-weight: var(--mid-weight-medium);
+  color: var(--mid-fg);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-md);
+  cursor: pointer;
+  -webkit-app-region: no-drag;
+  max-width: min(420px, 50vw);
+}
+.mid-titlebar-search:hover { background: var(--mid-surface-hover); }
+.mid-titlebar-search .mid-filename {
+  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  padding: 0 var(--mid-space-3);
+  text-align: left;
 }
+.mid-titlebar-search-icon { display: inline-flex; align-items: center; }
+.mid-titlebar-search-kbd { color: var(--mid-fg-muted); }
 
 /* Segmented mode toggle (View / Split / Edit) */
 .mid-mode-toggle {
@@ -960,6 +984,7 @@ main.splitting .mid-preview {
   font-size: var(--mid-font-size-xs);
   color: var(--mid-fg-muted);
   white-space: nowrap;
+  padding-right: var(--mid-space-1);
 }
 
 /* Sort affordances on each header cell — Boxicons chevron */
@@ -1061,10 +1086,10 @@ main.splitting .mid-preview {
   font-size: 0.95em;
 }
 .mid-preview th, .mid-preview td {
-  padding: var(--mid-space-3) var(--mid-space-4);
+  padding: var(--mid-space-2) var(--mid-space-4);
   text-align: left;
   border-bottom: 1px solid var(--mid-border);
-  vertical-align: top;
+  vertical-align: middle;
 }
 .mid-preview th {
   background: transparent;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -135,9 +135,10 @@ const btnSave = document.getElementById('save-btn') as HTMLButtonElement;
 const sidebar = document.getElementById('sidebar') as HTMLElement;
 const activityFiles = document.getElementById('activity-files') as HTMLButtonElement;
 const activityNotes = document.getElementById('activity-notes') as HTMLButtonElement;
-const activitySpotlight = document.getElementById('activity-spotlight') as HTMLButtonElement;
 const activitySettings = document.getElementById('activity-settings') as HTMLButtonElement;
 const activityPinned = document.getElementById('activity-pinned') as HTMLDivElement;
+const titlebarSearchBtn = document.getElementById('titlebar-search') as HTMLButtonElement;
+const titlebarSearchIcon = document.querySelector('.mid-titlebar-search-icon') as HTMLSpanElement;
 const sidebarFolderName = document.getElementById('sidebar-folder-name') as HTMLSpanElement;
 const sidebarRefresh = document.getElementById('sidebar-refresh') as HTMLButtonElement;
 const treeRoot = document.getElementById('tree-root') as HTMLDivElement;
@@ -1827,11 +1828,13 @@ async function loadPinnedTree(folderPath: string): Promise<void> {
 
 function renderActivityPinned(): void {
   activityPinned.replaceChildren();
-  for (const pin of pinnedFolders) {
+  pinnedFolders.forEach((pin, idx) => {
     const btn = document.createElement('button');
     btn.className = 'mid-activity-btn mid-activity-btn--pinned';
     btn.title = `${pin.name} (${pin.path})`;
     btn.dataset.path = pin.path;
+    btn.dataset.index = String(idx);
+    btn.draggable = true;
     btn.style.color = pin.color;
     btn.innerHTML = iconHTML((pin.icon as IconName) ?? 'folder');
     btn.addEventListener('click', () => selectActivity(`pinned:${pin.path}`));
@@ -1844,8 +1847,28 @@ function renderActivityPinned(): void {
         { icon: 'trash', label: 'Unpin', action: () => unpinFolder(pin.path) },
       ], e.clientX, e.clientY);
     });
+    btn.addEventListener('dragstart', e => {
+      e.dataTransfer?.setData('text/plain', String(idx));
+      btn.classList.add('is-dragging');
+    });
+    btn.addEventListener('dragend', () => btn.classList.remove('is-dragging'));
+    btn.addEventListener('dragover', e => { e.preventDefault(); btn.classList.add('is-drop-target'); });
+    btn.addEventListener('dragleave', () => btn.classList.remove('is-drop-target'));
+    btn.addEventListener('drop', e => {
+      e.preventDefault();
+      btn.classList.remove('is-drop-target');
+      const fromIdx = Number(e.dataTransfer?.getData('text/plain') ?? '');
+      const toIdx = Number(btn.dataset.index ?? '');
+      if (Number.isNaN(fromIdx) || Number.isNaN(toIdx) || fromIdx === toIdx) return;
+      const next = pinnedFolders.slice();
+      const [moved] = next.splice(fromIdx, 1);
+      next.splice(toIdx, 0, moved);
+      pinnedFolders = next;
+      void window.mid.patchAppState({ pinnedFolders });
+      renderActivityPinned();
+    });
     activityPinned.appendChild(btn);
-  }
+  });
 }
 
 async function pinFolder(folderPath: string, defaultName: string): Promise<void> {
@@ -1987,8 +2010,10 @@ async function editPinAppearance(pin: PinnedFolder): Promise<void> {
 
 activityFiles.addEventListener('click', () => selectActivity('files'));
 activityNotes.addEventListener('click', () => selectActivity('notes'));
-activitySpotlight.addEventListener('click', () => openSpotlight());
 activitySettings.addEventListener('click', () => document.getElementById('settings-btn')?.dispatchEvent(new MouseEvent('click')));
+titlebarSearchBtn.addEventListener('click', () => openSpotlight());
+// Hydrate the search-icon span (title-bar uses a custom layout, not data-icon hydration)
+if (titlebarSearchIcon) titlebarSearchIcon.innerHTML = iconHTML('search', 'mid-icon--sm mid-icon--muted');
 
 document.addEventListener('keydown', e => {
   if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k' && !e.shiftKey) {


### PR DESCRIPTION
**#198 Search → title bar**
- Search icon removed from the activity bar.
- Title bar's filename becomes a clickable **search pill**: leading magnifier icon, filename, trailing `⌘K` kbd hint. Click anywhere on the pill or hit `Cmd/Ctrl+K` → spotlight opens.

**#198 Drag-drop reorder**
- Pinned folder buttons in the activity bar are now `draggable`. Drop on another pinned button → array re-orders, persisted via `patchAppState`. Visual: `is-dragging` faded, `is-drop-target` accent-highlighted.

**#199 Data table refinement**
- Filter row uses `grid-template-columns: 1fr auto` so the row counter has a guaranteed slot — no more cropped '6 rows' text.
- Body cell padding tightened from `space-3` to `space-2` vertical → less air, more shadcn-DataTable density.
- Cells now `vertical-align: middle` (was top) so single-line content sits centered.

Closes #198 #199.