### PR TITLE
feat(desktop): spec view templates for .claude/{agents,skills,rules,commands} (#201)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -720,6 +720,85 @@ main.splitting .mid-preview {
   box-shadow: 0 0 0 1px var(--mid-fg);
 }
 
+/* Spec card — custom view template for .claude/* files */
+.mid-spec-card {
+  --mid-spec-accent: var(--mid-accent);
+  margin: 0 0 var(--mid-space-6);
+  padding: var(--mid-space-5);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-left: 4px solid var(--mid-spec-accent);
+  border-radius: var(--mid-radius-lg);
+}
+.mid-spec-card-head {
+  display: flex;
+  align-items: center;
+  gap: var(--mid-space-3);
+  margin-bottom: var(--mid-space-2);
+}
+.mid-spec-card-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: var(--mid-bg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-md);
+  color: var(--mid-spec-accent);
+}
+.mid-spec-card-titles { display: flex; flex-direction: column; gap: 2px; }
+.mid-spec-card-name {
+  margin: 0;
+  font-size: var(--mid-font-size-xl);
+  font-weight: var(--mid-weight-semibold);
+  border: 0 !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+}
+.mid-spec-card-kind {
+  font-family: var(--mid-font-mono);
+  font-size: var(--mid-font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--mid-fg-muted);
+}
+.mid-spec-card-desc {
+  margin: 0 0 var(--mid-space-3) !important;
+  color: var(--mid-fg);
+  font-size: var(--mid-font-size-base);
+}
+.mid-spec-card-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--mid-space-2);
+}
+.mid-spec-chip {
+  display: inline-flex;
+  align-items: center;
+  background: var(--mid-bg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-pill);
+  font-size: var(--mid-font-size-xs);
+  overflow: hidden;
+}
+.mid-spec-chip-key {
+  padding: 2px var(--mid-space-2);
+  background: var(--mid-surface);
+  color: var(--mid-fg-muted);
+  font-family: var(--mid-font-mono);
+  border-right: 1px solid var(--mid-border);
+}
+.mid-spec-chip-val {
+  padding: 2px var(--mid-space-2);
+  color: var(--mid-fg);
+  font-family: var(--mid-font-mono);
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Frontmatter meta block */
 .mid-frontmatter {
   display: grid;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -295,12 +295,58 @@ function escapeHTML(s: string): string {
     .replace(/'/g, '&#39;');
 }
 
+type SpecKind = 'agent' | 'skill' | 'rule' | 'command';
+const SPEC_PATH_PATTERNS: Array<{ kind: SpecKind; rx: RegExp; icon: IconName }> = [
+  { kind: 'agent',   rx: /\/\.claude\/agents\//i,   icon: 'bookmark' },
+  { kind: 'skill',   rx: /\/\.claude\/skills\//i,   icon: 'tag' },
+  { kind: 'rule',    rx: /\/\.claude\/rules\//i,    icon: 'list-ul' },
+  { kind: 'command', rx: /\/\.claude\/commands\//i, icon: 'cog' },
+];
+
+function detectSpecKind(path: string | null): { kind: SpecKind; icon: IconName } | null {
+  if (!path) return null;
+  for (const p of SPEC_PATH_PATTERNS) {
+    if (p.rx.test(path)) return { kind: p.kind, icon: p.icon };
+  }
+  return null;
+}
+
+function renderSpecCardHTML(meta: Record<string, unknown>, kind: SpecKind, icon: IconName): string {
+  const name = String(meta.name ?? meta.title ?? 'Untitled');
+  const description = meta.description ? String(meta.description) : '';
+  const accent = typeof meta.color === 'string' ? meta.color : '';
+  const skipKeys = new Set(['name', 'title', 'description', 'color']);
+  const chips = Object.entries(meta)
+    .filter(([k]) => !skipKeys.has(k))
+    .map(([k, v]) => {
+      const valueText = Array.isArray(v) ? v.join(', ') : typeof v === 'object' && v !== null ? JSON.stringify(v) : String(v);
+      return `<span class="mid-spec-chip"><span class="mid-spec-chip-key">${escapeHTML(k)}</span><span class="mid-spec-chip-val">${escapeHTML(valueText)}</span></span>`;
+    })
+    .join('');
+  const accentStyle = accent ? ` style="--mid-spec-accent: ${escapeHTML(accent)}"` : '';
+  return `<aside class="mid-spec-card mid-spec-card--${kind}"${accentStyle}>
+    <div class="mid-spec-card-head">
+      <span class="mid-spec-card-icon">${iconHTML(icon, 'mid-icon--lg')}</span>
+      <div class="mid-spec-card-titles">
+        <h1 class="mid-spec-card-name">${escapeHTML(name)}</h1>
+        <div class="mid-spec-card-kind">${kind}</div>
+      </div>
+    </div>
+    ${description ? `<p class="mid-spec-card-desc">${escapeHTML(description)}</p>` : ''}
+    ${chips ? `<div class="mid-spec-card-chips">${chips}</div>` : ''}
+  </aside>`;
+}
+
 function renderMarkdown(md: string): string {
   const { meta, body } = extractFrontmatter(md);
   const { html, mermaidBlocks } = coreRenderMarkdown(body);
   const container = document.createElement('div');
   container.innerHTML = html;
   applyMermaidPlaceholders(container, mermaidBlocks);
+  const spec = detectSpecKind(currentPath);
+  if (spec && meta) {
+    return renderSpecCardHTML(meta, spec.kind, spec.icon) + container.innerHTML;
+  }
   const fmHTML = meta ? renderFrontmatterHTML(meta) : '';
   return fmHTML + container.innerHTML;
 }


### PR DESCRIPTION
Files whose path matches `/.claude/{agents,skills,rules,commands}/` now render with a **spec card** header above the body markdown:

- Path-based template detection: agent / skill / rule / command (`detectSpecKind`).
- Header card pulls the frontmatter: `name` (or `title`) as h1, `description` as the sub, `color` as the left rail accent, all other keys rendered as monospace chip pairs (`key | value`).
- Body markdown renders as normal underneath.
- Falls back to the standard frontmatter panel for non-spec markdown.

Closes #201.