### PR TITLE
feat(desktop): real shadcn DataTable rebuild (#210)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -1049,73 +1049,153 @@ main.splitting .mid-preview {
 }
 
 
-/* Data-table viewer (sort / filter / export) */
-.mid-table {
+/* ========================================================================
+ * shadcn DataTable — full rebuild (#210). Replaces 9 prior CSS patches.
+ * Card shell + toolbar + sticky header + pagination + density + columns.
+ * ======================================================================== */
+
+.mid-data-table {
   margin: 1.2em 0;
-  border-radius: var(--mid-radius-md);
-  overflow: hidden;
   background: var(--mid-bg);
-  box-shadow: inset 0 0 0 1px var(--mid-border);
-}
-.mid-table table { margin: 0; border: 0; border-radius: 0; min-width: max-content; width: 100%; }
-.mid-table th { position: sticky; top: 0; z-index: 1; background: var(--mid-bg); }
-.mid-table-scroll {
-  overflow-x: auto;
   border: 1px solid var(--mid-border);
-  border-radius: var(--mid-radius-md);
+  border-radius: var(--mid-radius-lg);
+  box-shadow: var(--mid-shadow-sm);
+  overflow: hidden;
 }
 
-/* Filter chip strip above the table — clear separation from sort indicators */
-.mid-table-chip {
+.mid-dt-toolbar {
   display: flex;
   align-items: center;
-  gap: var(--mid-space-3);
-  margin-bottom: var(--mid-space-3);
-  padding: 0;
-  background: transparent;
-  border: 0;
+  gap: var(--mid-space-2);
+  padding: var(--mid-space-3);
+  border-bottom: 1px solid var(--mid-border);
 }
-.mid-table-chip[hidden] { display: none; }
-.mid-table-filter {
+.mid-dt-search-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mid-space-2);
+  flex: 1;
+  max-width: 320px;
+  padding: 0 var(--mid-space-3);
+  background: var(--mid-bg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-md);
+  transition: border-color var(--mid-motion-fast), box-shadow var(--mid-motion-fast);
+}
+.mid-dt-search-wrap:focus-within {
+  border-color: var(--mid-fg);
+  box-shadow: 0 0 0 1px var(--mid-fg);
+}
+.mid-dt-search {
   flex: 1;
   min-width: 0;
-  padding: 8px var(--mid-space-3);
+  padding: 7px 0;
   font-family: inherit;
   font-size: var(--mid-font-size-sm);
   color: var(--mid-fg);
-  background: var(--mid-bg);
-  border: 1px solid var(--mid-border);
-  border-radius: var(--mid-radius-sm);
+  background: transparent;
+  border: 0;
   outline: none;
 }
-.mid-table-filter:focus-visible { border-color: var(--mid-accent); box-shadow: 0 0 0 2px rgba(9, 105, 218, 0.15); }
-.mid-table-counter {
+.mid-dt-search::placeholder { color: var(--mid-fg-subtle); }
+.mid-dt-counter {
   font-family: var(--mid-font-mono);
   font-size: var(--mid-font-size-xs);
   color: var(--mid-fg-muted);
   white-space: nowrap;
-  padding-right: var(--mid-space-1);
 }
+.mid-dt-spacer { flex: 1; }
+.mid-dt-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  color: var(--mid-fg-muted);
+  border: 1px solid transparent;
+  border-radius: var(--mid-radius-md);
+  cursor: pointer;
+  transition: background var(--mid-motion-fast), color var(--mid-motion-fast);
+}
+.mid-dt-action:hover { background: var(--mid-surface); color: var(--mid-fg); border-color: var(--mid-border); }
 
-/* Sort affordances on each header cell — Boxicons chevron */
-.mid-table-sortable {
+/* Scroll area + table */
+.mid-dt-scroll { overflow: auto; max-height: 70vh; }
+.mid-dt-table {
+  margin: 0;
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  min-width: max-content;
+}
+.mid-dt-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--mid-bg);
+  text-align: left;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: var(--mid-font-size-xs);
+  font-weight: var(--mid-weight-semibold);
+  color: var(--mid-fg-muted);
+  border-bottom: 1px solid var(--mid-border);
+  white-space: nowrap;
   cursor: pointer;
   user-select: none;
 }
-.mid-table-sortable .mid-table-th-label { vertical-align: middle; }
-.mid-table-sort-indicator {
+.mid-dt-th-label { vertical-align: middle; }
+.mid-dt-sort {
   margin-left: var(--mid-space-1);
   vertical-align: middle;
   opacity: 0.35;
   transform: rotate(90deg);
   transition: opacity var(--mid-motion-fast) var(--mid-ease-out), transform var(--mid-motion-fast) var(--mid-ease-out);
 }
-.mid-table-sortable:hover { color: var(--mid-fg); }
-.mid-table-sortable:hover .mid-table-sort-indicator { opacity: 0.7; }
-.mid-table-sortable.is-sort-asc { color: var(--mid-fg); }
-.mid-table-sortable.is-sort-asc .mid-table-sort-indicator { opacity: 1; transform: rotate(-90deg); }
-.mid-table-sortable.is-sort-desc { color: var(--mid-fg); }
-.mid-table-sortable.is-sort-desc .mid-table-sort-indicator { opacity: 1; transform: rotate(90deg); }
+.mid-dt-table thead th:hover { color: var(--mid-fg); }
+.mid-dt-table thead th:hover .mid-dt-sort { opacity: 0.7; }
+.mid-dt-table thead th.is-sort-asc { color: var(--mid-fg); }
+.mid-dt-table thead th.is-sort-asc .mid-dt-sort { opacity: 1; transform: rotate(-90deg); }
+.mid-dt-table thead th.is-sort-desc { color: var(--mid-fg); }
+.mid-dt-table thead th.is-sort-desc .mid-dt-sort { opacity: 1; transform: rotate(90deg); }
+
+.mid-dt-table tbody tr {
+  transition: background-color var(--mid-motion-fast) var(--mid-ease-out);
+}
+.mid-dt-table tbody tr:hover { background: var(--mid-surface); }
+.mid-dt-table td {
+  border-bottom: 1px solid var(--mid-border);
+  vertical-align: middle;
+  color: var(--mid-fg);
+}
+.mid-dt-table tbody tr:last-child td { border-bottom: 0; }
+.mid-dt-table .is-hidden { display: none !important; }
+
+/* Density modes */
+.mid-data-table[data-density="comfy"]    .mid-dt-table th,
+.mid-data-table[data-density="comfy"]    .mid-dt-table td { padding: 10px var(--mid-space-4); }
+.mid-data-table[data-density="compact"]  .mid-dt-table th,
+.mid-data-table[data-density="compact"]  .mid-dt-table td { padding: 4px var(--mid-space-3); font-size: 13px; }
+.mid-data-table[data-density="spacious"] .mid-dt-table th,
+.mid-data-table[data-density="spacious"] .mid-dt-table td { padding: 14px var(--mid-space-4); }
+
+/* Footer / pagination */
+.mid-dt-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--mid-space-2) var(--mid-space-3);
+  border-top: 1px solid var(--mid-border);
+}
+.mid-dt-footer[hidden] { display: none; }
+.mid-dt-page-info {
+  font-family: var(--mid-font-mono);
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+}
+.mid-dt-pager { display: flex; gap: 4px; }
+.mid-dt-pager .mid-btn { width: 28px; height: 28px; }
 
 /* Heading anchors (#) shown on hover */
 .mid-preview h1, .mid-preview h2, .mid-preview h3,

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -1059,10 +1059,17 @@ function renderKatex(expr: string, displayMode: boolean): string {
   }
 }
 
-interface TableState {
+// (Old TableState/applyTableState removed in #210 in favor of the DataTable component below.)
+
+type Density = 'comfy' | 'compact' | 'spacious';
+interface DataTableState {
+  filter: string;
   sortColumn: number | null;
   sortDir: 'asc' | 'desc' | null;
-  filter: string;
+  page: number;
+  pageSize: number;
+  density: Density;
+  hidden: Set<number>;
 }
 
 function attachTableTools(scope: HTMLElement): void {
@@ -1072,46 +1079,116 @@ function attachTableTools(scope: HTMLElement): void {
     const tbody = table.querySelector('tbody');
     if (!thead || !tbody) return;
     const headers = Array.from(thead.querySelectorAll<HTMLTableCellElement>('th'));
-    const rows = Array.from(tbody.querySelectorAll<HTMLTableRowElement>('tr'));
-    if (headers.length === 0 || rows.length === 0) return;
+    const allRows = Array.from(tbody.querySelectorAll<HTMLTableRowElement>('tr'));
+    if (headers.length === 0 || allRows.length === 0) return;
     table.dataset.midTable = '1';
+    table.classList.add('mid-dt-table');
 
-    const wrapper = document.createElement('div');
-    wrapper.className = 'mid-table';
-    table.replaceWith(wrapper);
-    const scroller = document.createElement('div');
-    scroller.className = 'mid-table-scroll';
+    // Card shell
+    const card = document.createElement('div');
+    card.className = 'mid-data-table';
+    table.replaceWith(card);
 
-    // Compact filter chip — only shown for tables with > 5 rows so small tables stay clean.
-    const showChip = rows.length > 5;
-    const chip = document.createElement('div');
-    chip.className = 'mid-table-chip';
+    const state: DataTableState = {
+      filter: '',
+      sortColumn: null,
+      sortDir: null,
+      page: 0,
+      pageSize: 20,
+      density: 'comfy',
+      hidden: new Set(),
+    };
+    card.dataset.density = state.density;
+
+    // ===== Toolbar =====
+    const toolbar = document.createElement('div');
+    toolbar.className = 'mid-dt-toolbar';
+
+    const searchWrap = document.createElement('div');
+    searchWrap.className = 'mid-dt-search-wrap';
+    searchWrap.innerHTML = iconHTML('search', 'mid-icon--sm mid-icon--muted');
     const filterInput = document.createElement('input');
     filterInput.type = 'search';
-    filterInput.className = 'mid-table-filter';
+    filterInput.className = 'mid-dt-search';
     filterInput.placeholder = 'Filter…';
+    searchWrap.appendChild(filterInput);
+
     const counter = document.createElement('span');
-    counter.className = 'mid-table-counter';
-    chip.append(filterInput, counter);
-    if (!showChip) chip.hidden = true;
+    counter.className = 'mid-dt-counter';
 
-    scroller.appendChild(table);
-    wrapper.append(chip, scroller);
+    const spacer = document.createElement('div');
+    spacer.className = 'mid-dt-spacer';
 
-    const state: TableState = { sortColumn: null, sortDir: null, filter: '' };
-    const getVisible = (): HTMLTableRowElement[] => rows.filter(r => !r.hidden);
-    const apply = (): void => applyTableState(headers, rows, state, counter);
-    apply();
+    const densityBtn = makeIconActionButton('list-ul', 'Density', e => openContextMenu([
+      { icon: 'list-ul', label: 'Comfortable', action: () => { state.density = 'comfy'; card.dataset.density = 'comfy'; } },
+      { icon: 'list-ul', label: 'Compact', action: () => { state.density = 'compact'; card.dataset.density = 'compact'; } },
+      { icon: 'list-ul', label: 'Spacious', action: () => { state.density = 'spacious'; card.dataset.density = 'spacious'; } },
+    ], (e.currentTarget as HTMLElement).getBoundingClientRect().left, (e.currentTarget as HTMLElement).getBoundingClientRect().bottom + 4));
 
+    const columnsBtn = makeIconActionButton('columns', 'Columns', e => {
+      const items: MenuItem[] = headers.map((th, idx) => ({
+        icon: state.hidden.has(idx) ? 'x' : 'show',
+        label: cleanText(th.textContent ?? `Column ${idx + 1}`),
+        action: () => {
+          if (state.hidden.has(idx)) state.hidden.delete(idx);
+          else state.hidden.add(idx);
+          render();
+        },
+      }));
+      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+      openContextMenu(items, rect.left, rect.bottom + 4);
+    });
+
+    const exportBtn = makeIconActionButton('download', 'Export', e => {
+      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+      openContextMenu([
+        { icon: 'copy', label: 'Copy as Markdown', action: () => copyTableAsMarkdown(headers, getFiltered()) },
+        { icon: 'download', label: 'Download CSV', action: () => downloadTable(headers, getFiltered(), 'csv') },
+        { icon: 'download', label: 'Download Excel (.xlsx)', action: () => downloadTable(headers, getFiltered(), 'xlsx') },
+        { icon: 'github', label: 'Share to Google Sheets', action: () => void shareTableToSheets(headers, getFiltered()) },
+        { icon: 'list-ul', label: 'Download JSON', action: () => downloadTable(headers, getFiltered(), 'json') },
+      ], rect.left, rect.bottom + 4);
+    });
+
+    toolbar.append(searchWrap, counter, spacer, densityBtn, columnsBtn, exportBtn);
+
+    // ===== Scroll area =====
+    const scroll = document.createElement('div');
+    scroll.className = 'mid-dt-scroll';
+    scroll.appendChild(table);
+
+    // ===== Footer =====
+    const footer = document.createElement('div');
+    footer.className = 'mid-dt-footer';
+    const pageInfo = document.createElement('span');
+    pageInfo.className = 'mid-dt-page-info';
+    const pager = document.createElement('div');
+    pager.className = 'mid-dt-pager';
+    const prevBtn = document.createElement('button');
+    prevBtn.className = 'mid-btn mid-btn--icon mid-btn--ghost';
+    prevBtn.innerHTML = iconHTML('chevron-right', 'mid-icon--sm');
+    prevBtn.style.transform = 'rotate(180deg)';
+    prevBtn.title = 'Previous page';
+    const nextBtn = document.createElement('button');
+    nextBtn.className = 'mid-btn mid-btn--icon mid-btn--ghost';
+    nextBtn.innerHTML = iconHTML('chevron-right', 'mid-icon--sm');
+    nextBtn.title = 'Next page';
+    pager.append(prevBtn, nextBtn);
+    footer.append(pageInfo, pager);
+
+    card.append(toolbar, scroll, footer);
+
+    // ===== Headers (sortable) =====
     headers.forEach((th, idx) => {
-      th.classList.add('mid-table-sortable');
+      th.classList.add('mid-dt-th');
       const labelText = th.innerHTML;
-      th.innerHTML = `<span class="mid-table-th-label">${labelText}</span>${iconHTML('chevron-right', 'mid-icon--sm mid-table-sort-indicator')}`;
+      th.innerHTML = `<span class="mid-dt-th-label">${labelText}</span>${iconHTML('chevron-right', 'mid-icon--sm mid-dt-sort')}`;
       th.addEventListener('click', () => {
         if (state.sortColumn !== idx) { state.sortColumn = idx; state.sortDir = 'asc'; }
         else if (state.sortDir === 'asc') { state.sortDir = 'desc'; }
         else { state.sortColumn = null; state.sortDir = null; }
-        apply();
+        state.page = 0;
+        render();
       });
     });
 
@@ -1120,80 +1197,101 @@ function attachTableTools(scope: HTMLElement): void {
       window.clearTimeout(debounce);
       debounce = window.setTimeout(() => {
         state.filter = filterInput.value.trim().toLowerCase();
-        apply();
+        state.page = 0;
+        render();
       }, 120);
     });
+    prevBtn.addEventListener('click', () => { if (state.page > 0) { state.page--; render(); } });
+    nextBtn.addEventListener('click', () => { state.page++; render(); });
 
-    wrapper.addEventListener('contextmenu', e => {
+    function getFiltered(): HTMLTableRowElement[] {
+      const q = state.filter;
+      let out = q ? allRows.filter(r => (r.textContent ?? '').toLowerCase().includes(q)) : allRows.slice();
+      if (state.sortColumn !== null && state.sortDir !== null) {
+        const col = state.sortColumn;
+        const t = (r: HTMLTableRowElement): string => r.children[col]?.textContent?.trim() ?? '';
+        const numeric = allRows.every(r => {
+          const x = t(r);
+          return x === '' || !Number.isNaN(Number(x.replace(/[$,%\s]/g, '')));
+        });
+        out.sort((a, b) => {
+          const av = t(a), bv = t(b);
+          const cmp = numeric
+            ? (Number(av.replace(/[$,%\s]/g, '')) || 0) - (Number(bv.replace(/[$,%\s]/g, '')) || 0)
+            : av.localeCompare(bv, undefined, { numeric: true, sensitivity: 'base' });
+          return state.sortDir === 'asc' ? cmp : -cmp;
+        });
+      }
+      return out;
+    }
+
+    function render(): void {
+      // Sort indicator state on headers
+      headers.forEach((th, idx) => {
+        th.classList.remove('is-sort-asc', 'is-sort-desc', 'is-hidden');
+        if (state.sortColumn === idx && state.sortDir === 'asc') th.classList.add('is-sort-asc');
+        if (state.sortColumn === idx && state.sortDir === 'desc') th.classList.add('is-sort-desc');
+        if (state.hidden.has(idx)) th.classList.add('is-hidden');
+      });
+      // Apply column visibility on cells
+      allRows.forEach(r => {
+        Array.from(r.children).forEach((c, idx) => {
+          (c as HTMLElement).classList.toggle('is-hidden', state.hidden.has(idx));
+        });
+      });
+
+      const filtered = getFiltered();
+      const totalPages = Math.max(1, Math.ceil(filtered.length / state.pageSize));
+      if (state.page >= totalPages) state.page = totalPages - 1;
+      const pageStart = state.page * state.pageSize;
+      const pageRows = filtered.slice(pageStart, pageStart + state.pageSize);
+      const pageRowsSet = new Set(pageRows);
+
+      // Reorder + hide rows
+      tbody!.replaceChildren(...pageRows);
+      allRows.forEach(r => { r.hidden = !pageRowsSet.has(r); });
+
+      // Counter
+      counter.textContent = state.filter
+        ? `${filtered.length} of ${allRows.length}`
+        : `${allRows.length} ${allRows.length === 1 ? 'row' : 'rows'}`;
+
+      // Footer
+      const showFooter = filtered.length > state.pageSize;
+      footer.hidden = !showFooter;
+      pageInfo.textContent = showFooter ? `Page ${state.page + 1} of ${totalPages}` : '';
+      prevBtn.disabled = state.page <= 0;
+      nextBtn.disabled = state.page >= totalPages - 1;
+    }
+    render();
+
+    card.addEventListener('contextmenu', e => {
       if ((e.target as HTMLElement).closest('input, button')) return;
       e.preventDefault();
       e.stopPropagation();
       openContextMenu([
-        { icon: 'copy', label: 'Copy as Markdown', action: () => copyTableAsMarkdown(headers, getVisible()) },
-        { icon: 'download', label: 'Download CSV', action: () => downloadTable(headers, getVisible(), 'csv') },
-        { icon: 'download', label: 'Download Excel (.xlsx)', action: () => downloadTable(headers, getVisible(), 'xlsx') },
-        { icon: 'github', label: 'Share to Google Sheets', action: () => void shareTableToSheets(headers, getVisible()) },
-        { icon: 'list-ul', label: 'Download JSON', action: () => downloadTable(headers, getVisible(), 'json') },
+        { icon: 'copy', label: 'Copy as Markdown', action: () => copyTableAsMarkdown(headers, getFiltered()) },
+        { icon: 'download', label: 'Download CSV', action: () => downloadTable(headers, getFiltered(), 'csv') },
+        { icon: 'download', label: 'Download Excel (.xlsx)', action: () => downloadTable(headers, getFiltered(), 'xlsx') },
+        { icon: 'github', label: 'Share to Google Sheets', action: () => void shareTableToSheets(headers, getFiltered()) },
+        { icon: 'list-ul', label: 'Download JSON', action: () => downloadTable(headers, getFiltered(), 'json') },
         { separator: true, label: '' },
-        { icon: state.sortColumn === null ? 'x' : 'refresh', label: state.sortColumn === null ? 'No sort active' : 'Reset sort', disabled: state.sortColumn === null, action: () => { state.sortColumn = null; state.sortDir = null; apply(); } },
+        { icon: state.sortColumn === null ? 'x' : 'refresh', label: state.sortColumn === null ? 'No sort active' : 'Reset sort', disabled: state.sortColumn === null, action: () => { state.sortColumn = null; state.sortDir = null; render(); } },
       ], e.clientX, e.clientY);
     });
   });
 }
 
-function applyTableState(
-  headers: HTMLTableCellElement[],
-  rows: HTMLTableRowElement[],
-  state: TableState,
-  counter: HTMLSpanElement,
-): void {
-  headers.forEach((th, idx) => {
-    th.classList.remove('is-sort-asc', 'is-sort-desc');
-    if (state.sortColumn === idx && state.sortDir === 'asc') th.classList.add('is-sort-asc');
-    if (state.sortColumn === idx && state.sortDir === 'desc') th.classList.add('is-sort-desc');
-  });
-
-  const tbody = rows[0]?.parentElement;
-  if (!tbody) return;
-
-  const sorted = [...rows];
-  if (state.sortColumn !== null && state.sortDir !== null) {
-    const col = state.sortColumn;
-    const cellText = (r: HTMLTableRowElement): string => r.children[col]?.textContent?.trim() ?? '';
-    const allNumeric = rows.every(r => {
-      const t = cellText(r);
-      return t === '' || !Number.isNaN(Number(t.replace(/[$,%\s]/g, '')));
-    });
-    sorted.sort((a, b) => {
-      const av = cellText(a);
-      const bv = cellText(b);
-      let cmp: number;
-      if (allNumeric) {
-        cmp = (Number(av.replace(/[$,%\s]/g, '')) || 0) - (Number(bv.replace(/[$,%\s]/g, '')) || 0);
-      } else {
-        cmp = av.localeCompare(bv, undefined, { numeric: true, sensitivity: 'base' });
-      }
-      return state.sortDir === 'asc' ? cmp : -cmp;
-    });
-  }
-
-  for (const r of sorted) tbody.appendChild(r);
-
-  let visible = 0;
-  rows.forEach(r => {
-    if (!state.filter) {
-      r.hidden = false;
-      visible++;
-      return;
-    }
-    const haystack = (r.textContent ?? '').toLowerCase();
-    const match = haystack.includes(state.filter);
-    r.hidden = !match;
-    if (match) visible++;
-  });
-
-  counter.textContent = state.filter ? `${visible} of ${rows.length} rows` : `${rows.length} rows`;
+function makeIconActionButton(icon: IconName, title: string, onClick: (e: MouseEvent) => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'mid-dt-action';
+  btn.title = title;
+  btn.innerHTML = iconHTML(icon, 'mid-icon--sm');
+  btn.addEventListener('click', onClick);
+  return btn;
 }
+
 
 function rowToValues(row: HTMLTableRowElement): string[] {
   return Array.from(row.children).map(c => c.textContent?.trim() ?? '');


### PR DESCRIPTION
**Full DataTable rebuild — replaces 9 prior CSS patches.**

Drops the markdown-rendered `<table>` with surrounding chip strip in favor of a card-shelled DataTable component:

- `.mid-data-table` card: bg + 1px border + lg radius + sm shadow.
- **Toolbar** row: search input with leading magnifier (max-width 320px, focus ring), live counter ("42 of 100" while filtering), spacer, Density / Columns / Export icon-only ghost actions.
- **Density** modes: Comfy (default 10px) / Compact (4px, smaller font) / Spacious (14px). Toggled via the toolbar Density menu.
- **Column visibility** menu: each header listed with show/hide eye icon — clicking toggles `is-hidden` on the matching th + every row's nth cell.
- **Sticky header** that survives scroll inside the card (`max-height: 70vh` on the scroll area).
- Sort: 3-state click cycle on `<th>`; Boxicons chevron at 0.35 opacity at rest, 1.0 active.
- **Pagination footer**: visible only for tables > 20 rows. Page info + prev/next buttons using `mid-btn--icon mid-btn--ghost`.
- Filter still searches across rows (case-insensitive substring) and resets pagination on input.
- Old `TableState` interface and `applyTableState` removed — entirely replaced by the new `DataTableState` and inline `render()` closure.

Closes #210.