### PR TITLE
feat(desktop): gh CLI repo picker + create + file history (#217 #218 #219)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -292,6 +292,45 @@ async function runGit(workspace: string, args: string[]): Promise<{ stdout: stri
   return execFileP('git', args, { cwd: workspace });
 }
 
+ipcMain.handle('mid:gh-repo-list', async (): Promise<{ repos: { nameWithOwner: string; description: string; visibility: string }[]; ok: boolean; error?: string }> => {
+  try {
+    const { stdout } = await execFileP('gh', ['repo', 'list', '--limit', '200', '--json', 'nameWithOwner,description,visibility']);
+    const repos = JSON.parse(stdout) as { nameWithOwner: string; description: string; visibility: string }[];
+    return { repos, ok: true };
+  } catch (err) {
+    return { repos: [], ok: false, error: (err as { stderr?: string; message: string }).stderr ?? (err as Error).message };
+  }
+});
+
+ipcMain.handle('mid:gh-repo-create', async (_e, slug: string, visibility: 'private' | 'public'): Promise<{ ok: boolean; url?: string; error?: string }> => {
+  try {
+    const { stdout } = await execFileP('gh', ['repo', 'create', slug, `--${visibility}`, '--confirm']);
+    return { ok: true, url: stdout.trim() };
+  } catch (err) {
+    return { ok: false, error: (err as { stderr?: string; message: string }).stderr ?? (err as Error).message };
+  }
+});
+
+ipcMain.handle('mid:file-history', async (_e, workspace: string, filePath: string): Promise<{ commits: { hash: string; date: string; author: string; message: string; diff: string }[]; ok: boolean; error?: string }> => {
+  try {
+    const rel = path.relative(workspace, filePath);
+    const { stdout } = await execFileP('git', ['log', '--follow', '--pretty=format:%H%x1f%an%x1f%ad%x1f%s%x1e', '--date=iso-strict', '--', rel], { cwd: workspace });
+    const entries = stdout.split('').filter(Boolean);
+    const commits = await Promise.all(entries.slice(0, 50).map(async raw => {
+      const [hash, author, date, message] = raw.replace(/^\n+/, '').split('');
+      let diff = '';
+      try {
+        const r = await execFileP('git', ['show', '--no-color', '--pretty=', hash, '--', rel], { cwd: workspace });
+        diff = r.stdout;
+      } catch { /* ignore */ }
+      return { hash, author, date, message, diff };
+    }));
+    return { commits, ok: true };
+  } catch (err) {
+    return { commits: [], ok: false, error: (err as { stderr?: string; message: string }).stderr ?? (err as Error).message };
+  }
+});
+
 ipcMain.handle('mid:gh-auth-status', async () => {
   try {
     const { stdout } = await execFileP('gh', ['auth', 'status']);

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -80,6 +80,12 @@ contextBridge.exposeInMainWorld('mid', {
     ipcRenderer.invoke('mid:notes-mark-pushed', workspace, id),
   ghAuthStatus: (): Promise<{ authenticated: boolean; output: string }> =>
     ipcRenderer.invoke('mid:gh-auth-status'),
+  ghRepoList: (): Promise<{ repos: { nameWithOwner: string; description: string; visibility: string }[]; ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('mid:gh-repo-list'),
+  ghRepoCreate: (slug: string, visibility: 'private' | 'public'): Promise<{ ok: boolean; url?: string; error?: string }> =>
+    ipcRenderer.invoke('mid:gh-repo-create', slug, visibility),
+  fileHistory: (workspace: string, filePath: string): Promise<{ commits: { hash: string; date: string; author: string; message: string; diff: string }[]; ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('mid:file-history', workspace, filePath),
   repoStatus: (workspace: string): Promise<{ initialized: boolean; branch: string; ahead: number; behind: number; dirty: number; remote: string }> =>
     ipcRenderer.invoke('mid:repo-status', workspace),
   repoConnect: (workspace: string, repoSlug: string): Promise<{ url: string }> =>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -390,6 +390,29 @@ body.has-sidebar .mid-shell {
 .mid-spotlight-row-path { font-family: var(--mid-font-mono); font-size: var(--mid-font-size-xs); color: var(--mid-fg-muted); white-space: nowrap; }
 .mid-spotlight-empty { padding: var(--mid-space-4); text-align: center; color: var(--mid-fg-muted); font-size: var(--mid-font-size-sm); }
 
+/* File history viewer (#219) */
+.mid-fh-row {
+  border-bottom: 1px solid var(--mid-border);
+  padding: var(--mid-space-3) var(--mid-space-4);
+}
+.mid-fh-row:last-child { border-bottom: 0; }
+.mid-fh-head { display: flex; flex-direction: column; gap: 2px; margin-bottom: var(--mid-space-2); }
+.mid-fh-msg { font-weight: var(--mid-weight-medium); color: var(--mid-fg); font-size: var(--mid-font-size-sm); }
+.mid-fh-meta { font-family: var(--mid-font-mono); font-size: var(--mid-font-size-xs); color: var(--mid-fg-muted); }
+.mid-fh-hash { color: var(--mid-link); }
+.mid-fh-diff {
+  margin: 0;
+  padding: var(--mid-space-2);
+  font-family: var(--mid-font-mono);
+  font-size: 11px;
+  background: var(--mid-code-bg);
+  color: var(--mid-fg);
+  border-radius: var(--mid-radius-sm);
+  white-space: pre;
+  overflow-x: auto;
+  max-height: 220px;
+}
+
 /* Mermaid editor modal — split textarea + live preview */
 .mid-mermaid-editor {
   width: min(1100px, 92vw);

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -116,6 +116,9 @@ interface Mid {
   notesAttachWarehouse(workspace: string, id: string, warehouseId: string | null): Promise<NoteEntry | null>;
   notesMarkPushed(workspace: string, id: string): Promise<NoteEntry | null>;
   ghAuthStatus(): Promise<{ authenticated: boolean; output: string }>;
+  ghRepoList(): Promise<{ repos: { nameWithOwner: string; description: string; visibility: string }[]; ok: boolean; error?: string }>;
+  ghRepoCreate(slug: string, visibility: 'private' | 'public'): Promise<{ ok: boolean; url?: string; error?: string }>;
+  fileHistory(workspace: string, filePath: string): Promise<{ commits: { hash: string; date: string; author: string; message: string; diff: string }[]; ok: boolean; error?: string }>;
   repoStatus(workspace: string): Promise<{ initialized: boolean; branch: string; ahead: number; behind: number; dirty: number; remote: string }>;
   repoConnect(workspace: string, repoSlug: string): Promise<{ url: string }>;
   repoSync(workspace: string, message: string): Promise<{ steps: string[]; ok: boolean; error?: string }>;
@@ -1676,11 +1679,135 @@ async function promptConnectRepo(): Promise<void> {
     );
     if (!proceed) return;
   }
-  const slug = await midPrompt('Connect GitHub repo', 'owner/name', '');
-  if (!slug || !/^[^/]+\/[^/]+$/.test(slug)) return;
+  // Pull list of user's repos via gh CLI for picker; fall back to free-text on failure.
+  const listResult = await window.mid.ghRepoList();
+  const slug = await openRepoPicker(listResult.repos, listResult.ok);
+  if (!slug) return;
   await window.mid.repoConnect(currentFolder, slug);
   flashStatus(`Connected to ${slug}`);
   await refreshRepoStatus();
+}
+
+function openRepoPicker(repos: { nameWithOwner: string; description: string; visibility: string }[], gotList: boolean): Promise<string | null> {
+  return new Promise(resolve => {
+    const dlg = document.getElementById('mid-spotlight') as HTMLDialogElement;
+    const input = document.getElementById('mid-spotlight-input') as HTMLInputElement;
+    const results = document.getElementById('mid-spotlight-results') as HTMLDivElement;
+    const tabs = dlg.querySelectorAll<HTMLButtonElement>('.mid-spotlight-tab');
+    tabs.forEach(t => { t.style.display = 'none'; });
+
+    const render = (): void => {
+      const q = input.value.trim().toLowerCase();
+      results.replaceChildren();
+      if (!gotList) {
+        results.innerHTML = '<div class="mid-spotlight-empty">gh repo list failed — type owner/name manually and press Enter.</div>';
+        return;
+      }
+      const matches = q ? repos.filter(r => r.nameWithOwner.toLowerCase().includes(q) || (r.description ?? '').toLowerCase().includes(q)) : repos;
+      // Always offer "Create new repo…" at the top
+      const createRow = document.createElement('button');
+      createRow.className = 'mid-spotlight-row';
+      createRow.innerHTML = `${iconHTML('plus', 'mid-icon--sm mid-icon--muted')}<span class="mid-spotlight-row-name">Create new repo…</span><span class="mid-spotlight-row-path">${q ? escapeHTML(q) : 'enter name'}</span>`;
+      createRow.addEventListener('click', () => { void onCreateNew(q || ''); });
+      results.appendChild(createRow);
+      for (const r of matches.slice(0, 50)) {
+        const row = document.createElement('button');
+        row.className = 'mid-spotlight-row';
+        row.innerHTML = `${iconHTML('github', 'mid-icon--sm mid-icon--muted')}<span class="mid-spotlight-row-name">${escapeHTML(r.nameWithOwner)}</span><span class="mid-spotlight-row-path">${escapeHTML(r.visibility?.toLowerCase() ?? '')}</span>`;
+        if (r.description) row.title = r.description;
+        row.addEventListener('click', () => { close(r.nameWithOwner); });
+        results.appendChild(row);
+      }
+    };
+
+    const onCreateNew = async (defaultSlug: string): Promise<void> => {
+      close(null);
+      const slug = await midPrompt('Create GitHub repo', 'owner/name (no spaces)', defaultSlug);
+      if (!slug || !/^[^/]+\/[^/]+$/.test(slug)) return;
+      const visConfirm = await midConfirm('Visibility', `Create ${slug} as PRIVATE? Cancel for public.`);
+      const result = await window.mid.ghRepoCreate(slug, visConfirm ? 'private' : 'public');
+      if (!result.ok) {
+        await midConfirm('gh repo create failed', result.error ?? 'unknown');
+        return;
+      }
+      if (currentFolder) {
+        await window.mid.repoConnect(currentFolder, slug);
+        flashStatus(`Created + connected ${slug}`);
+        await refreshRepoStatus();
+      }
+    };
+
+    let closed = false;
+    function close(value: string | null): void {
+      if (closed) return;
+      closed = true;
+      input.removeEventListener('input', onInput);
+      input.removeEventListener('keydown', onKey);
+      dlg.removeEventListener('click', onBackdrop);
+      tabs.forEach(t => { t.style.display = ''; });
+      if (dlg.open) dlg.close();
+      resolve(value);
+    }
+    const onInput = (): void => render();
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') close(null);
+      if (e.key === 'Enter') {
+        const v = input.value.trim();
+        if (v && /^[^/]+\/[^/]+$/.test(v)) close(v);
+      }
+    };
+    const onBackdrop = (e: MouseEvent): void => { if (e.target === dlg) close(null); };
+
+    input.value = '';
+    input.placeholder = gotList ? 'Search your repos or type owner/name…' : 'Type owner/name…';
+    input.addEventListener('input', onInput);
+    input.addEventListener('keydown', onKey);
+    dlg.addEventListener('click', onBackdrop);
+    dlg.showModal();
+    render();
+    input.focus();
+  });
+}
+
+async function showFileHistory(filePath: string): Promise<void> {
+  if (!currentFolder) return;
+  const result = await window.mid.fileHistory(currentFolder, filePath);
+  if (!result.ok || result.commits.length === 0) {
+    flashStatus(result.error ? `History failed: ${result.error.split('\n')[0]}` : 'No history');
+    return;
+  }
+  // Render history into the spotlight modal repurposed as a viewer.
+  const dlg = document.getElementById('mid-spotlight') as HTMLDialogElement;
+  const input = document.getElementById('mid-spotlight-input') as HTMLInputElement;
+  const results = document.getElementById('mid-spotlight-results') as HTMLDivElement;
+  const tabs = dlg.querySelectorAll<HTMLButtonElement>('.mid-spotlight-tab');
+  tabs.forEach(t => { t.style.display = 'none'; });
+  input.value = '';
+  input.placeholder = `History — ${filePath.split('/').pop()}`;
+  results.replaceChildren();
+  for (const c of result.commits) {
+    const row = document.createElement('div');
+    row.className = 'mid-fh-row';
+    const head = document.createElement('div');
+    head.className = 'mid-fh-head';
+    head.innerHTML = `<span class="mid-fh-msg">${escapeHTML(c.message)}</span><span class="mid-fh-meta">${escapeHTML(c.author)} · ${new Date(c.date).toLocaleDateString()} · <span class="mid-fh-hash">${escapeHTML(c.hash.slice(0, 7))}</span></span>`;
+    const diff = document.createElement('pre');
+    diff.className = 'mid-fh-diff';
+    diff.textContent = c.diff;
+    row.append(head, diff);
+    results.appendChild(row);
+  }
+  const close = (): void => {
+    tabs.forEach(t => { t.style.display = ''; });
+    if (dlg.open) dlg.close();
+    document.removeEventListener('keydown', onKey);
+    dlg.removeEventListener('click', onBackdrop);
+  };
+  const onKey = (e: KeyboardEvent): void => { if (e.key === 'Escape') close(); };
+  const onBackdrop = (e: MouseEvent): void => { if (e.target === dlg) close(); };
+  document.addEventListener('keydown', onKey);
+  dlg.addEventListener('click', onBackdrop);
+  dlg.showModal();
 }
 
 async function syncRepo(): Promise<void> {
@@ -1774,6 +1901,7 @@ function renderTreeEntry(entry: TreeEntry): HTMLElement {
       const baseItems: MenuItem[] = [
         { icon: 'show', label: 'Open', action: () => void selectTreeFile(entry.path) },
         { icon: 'folder-open', label: 'Reveal in Finder', action: () => void window.mid.openExternal(`file://${entry.path.replace(/\/[^/]+$/, '')}`) },
+        { icon: 'refresh', label: 'View history…', action: () => void showFileHistory(entry.path) },
       ];
       if (!isMd) {
         openContextMenu(baseItems, e.clientX, e.clientY);


### PR DESCRIPTION
**#217 Repo picker** — Connect Repo flow now pulls `gh repo list --json nameWithOwner,description,visibility` and renders a searchable list inside the spotlight dialog. Free-text fallback when `gh repo list` fails (Enter still accepts `owner/name`).

**#218 Create new repo** — top row of the picker is "Create new repo…". Click → midPrompt for slug → midConfirm asks PRIVATE vs public → `gh repo create` → auto-connects current workspace.

**#219 File history viewer** — right-click any file in the tree → "View history…". Spotlight dialog reused as a viewer; lists up to 50 commits via `git log --follow --pretty` with per-commit diff via `git show`. Esc / backdrop click closes.

New IPCs: `mid:gh-repo-list`, `mid:gh-repo-create`, `mid:file-history`.

Closes #217 #218 #219.