### PR TITLE
feat(desktop): mermaid v2 — cursor popout + .mmd standalone (#222 #223)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -112,7 +112,10 @@ ipcMain.handle('mid:write-file', async (_e, filePath: string, content: string) =
 ipcMain.handle('mid:open-file-dialog', async () => {
   const result = await dialog.showOpenDialog({
     properties: ['openFile'],
-    filters: [{ name: 'Markdown', extensions: ['md', 'mdx', 'markdown'] }],
+    filters: [
+      { name: 'Markdown', extensions: ['md', 'mdx', 'markdown'] },
+      { name: 'Mermaid', extensions: ['mmd', 'mermaid'] },
+    ],
   });
   if (result.canceled || result.filePaths.length === 0) return null;
   const filePath = result.filePaths[0];

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -488,6 +488,33 @@ body.has-sidebar .mid-shell {
   color: var(--mid-fg-muted);
 }
 
+/* Cursor-aware mermaid popout (#222) */
+.mid-mermaid-popout {
+  position: fixed;
+  bottom: var(--mid-space-6);
+  right: var(--mid-space-6);
+  width: 320px;
+  max-height: 320px;
+  padding: var(--mid-space-3);
+  background: var(--mid-bg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-lg);
+  box-shadow: var(--mid-shadow-lg);
+  z-index: var(--mid-z-modal);
+  overflow: auto;
+  pointer-events: none;
+}
+.mid-mermaid-popout svg { max-width: 100%; height: auto; }
+
+/* Standalone .mmd file mode (#223) */
+.mid-mermaid-standalone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--mid-code-bg);
+}
+.mid-mermaid-standalone svg { max-width: 100%; max-height: 100%; }
+
 /* Launch loader overlay */
 .mid-loader {
   position: fixed;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -585,10 +585,84 @@ function renderView(): void {
     attachWelcomeHandlers(root);
     return;
   }
+  if (isMermaidFile(currentPath)) {
+    renderMermaidStandalone();
+    return;
+  }
   const preview = document.createElement('div');
   preview.className = 'mid-preview';
   populatePreview(preview);
   root.replaceChildren(preview);
+}
+
+function renderMermaidStandalone(): void {
+  // Standalone .mmd / .mermaid file: editor on left + live diagram on right.
+  root.classList.remove('viewing');
+  root.classList.add('splitting');
+  const wrap = document.createElement('div');
+  wrap.className = 'mid-split';
+  wrap.style.gridTemplateColumns = `${splitRatio * 100}% 6px 1fr`;
+  const editor = buildEditor();
+  editor.classList.add('mid-split-editor');
+  const handle = document.createElement('div');
+  handle.className = 'mid-split-handle';
+  handle.addEventListener('mousedown', e => beginSplitDrag(e, wrap));
+  const preview = document.createElement('div');
+  preview.className = 'mid-preview mid-split-preview mid-mermaid-standalone';
+
+  const renderDiagram = (): void => {
+    const code = currentText.trim();
+    if (!code) { preview.innerHTML = '<div class="mid-mermaid-editor-empty">empty</div>'; return; }
+    const id = `mermaid-standalone-${Date.now()}`;
+    mermaid.render(id, code).then(({ svg }) => {
+      preview.innerHTML = svg;
+    }).catch(err => {
+      preview.innerHTML = `<pre class="mid-mermaid-editor-error">${escapeHTML(String((err as Error)?.message ?? err))}</pre>`;
+    });
+  };
+  renderDiagram();
+  let timer: number | null = null;
+  editor.addEventListener('input', () => {
+    currentText = editor.value;
+    if (timer !== null) window.clearTimeout(timer);
+    timer = window.setTimeout(renderDiagram, 120);
+  });
+  wrap.append(editor, handle, preview);
+  root.replaceChildren(wrap);
+}
+
+let mermaidPopout: HTMLDivElement | null = null;
+function maybeShowMermaidPopout(editor: HTMLTextAreaElement): void {
+  // Cursor-aware mermaid popout — when caret is inside a ```mermaid fence,
+  // render that block in a docked overlay.
+  const value = editor.value;
+  const caret = editor.selectionStart;
+  const before = value.slice(0, caret);
+  const fenceStart = before.lastIndexOf('```mermaid');
+  if (fenceStart === -1) { hideMermaidPopout(); return; }
+  const afterFence = before.slice(fenceStart);
+  if (/```\s*$/m.test(afterFence.slice(10))) { hideMermaidPopout(); return; } // closed before caret
+  const remainder = value.slice(fenceStart + 10);
+  const closeIdx = remainder.indexOf('```');
+  if (closeIdx === -1) { hideMermaidPopout(); return; } // unterminated
+  const source = remainder.slice(0, closeIdx).replace(/^\n+/, '').trimEnd();
+  if (!source) { hideMermaidPopout(); return; }
+
+  if (!mermaidPopout) {
+    mermaidPopout = document.createElement('div');
+    mermaidPopout.className = 'mid-mermaid-popout';
+    document.body.appendChild(mermaidPopout);
+  }
+  const id = `mermaid-popout-${Date.now()}`;
+  mermaid.render(id, source).then(({ svg }) => {
+    if (mermaidPopout) mermaidPopout.innerHTML = svg;
+  }).catch(err => {
+    if (mermaidPopout) mermaidPopout.innerHTML = `<pre class="mid-mermaid-editor-error">${escapeHTML(String((err as Error)?.message ?? err))}</pre>`;
+  });
+}
+
+function hideMermaidPopout(): void {
+  if (mermaidPopout) { mermaidPopout.remove(); mermaidPopout = null; }
 }
 
 function populatePreview(preview: HTMLElement): void {
@@ -1532,16 +1606,18 @@ function buildEditor(): HTMLTextAreaElement {
     currentText = ta.value;
     updateWordCount();
     updateSaveIndicator(false);
+    maybeShowMermaidPopout(ta);
   });
   const onCursor = (): void => {
     const before = ta.value.slice(0, ta.selectionStart);
     const lines = before.split('\n');
     updateCursor(lines.length, lines[lines.length - 1].length + 1);
+    maybeShowMermaidPopout(ta);
   };
   ta.addEventListener('keyup', onCursor);
   ta.addEventListener('click', onCursor);
   ta.addEventListener('focus', onCursor);
-  ta.addEventListener('blur', hideCursor);
+  ta.addEventListener('blur', () => { hideCursor(); hideMermaidPopout(); });
   return ta;
 }
 
@@ -1585,6 +1661,10 @@ async function openFile(): Promise<void> {
   const result = await window.mid.openFileDialog();
   if (!result) return;
   loadFileContent(result.filePath, result.content);
+}
+
+function isMermaidFile(filePath: string | null): boolean {
+  return !!filePath && /\.(mmd|mermaid)$/i.test(filePath);
 }
 
 function loadFileContent(filePath: string, content: string): void {


### PR DESCRIPTION
**#222 Cursor-aware popout** — while typing in Edit/Split mode, if the caret sits inside a ```mermaid fence, a 320 px popout docks bottom-right showing the live diagram. Hides automatically when caret leaves the fence or the textarea loses focus.

**#223 Standalone `.mmd` / `.mermaid`** — Open dialog now lists Mermaid as a file type. Opening a `.mmd` file shows split editor + live diagram preview without the markdown pipeline.

Closes #222 #223.