### PR TITLE
feat(desktop): GitHub OAuth device-flow + conflict banner (#220 #221)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -344,6 +344,58 @@ ipcMain.handle('mid:gh-auth-status', async () => {
   }
 });
 
+// GitHub OAuth device flow fallback when `gh` isn't installed.
+// v1: requests device code, returns user_code + verification_uri to the renderer,
+// then polls for the token. The OAuth client_id is a placeholder — registering a
+// real GitHub OAuth app is a follow-up for production builds.
+const MID_GH_CLIENT_ID = process.env.MID_GH_CLIENT_ID || 'Iv1.placeholder-client-id';
+ipcMain.handle('mid:gh-device-flow-start', async (): Promise<{ ok: boolean; userCode?: string; verificationUri?: string; deviceCode?: string; interval?: number; error?: string }> => {
+  try {
+    const res = await fetch('https://github.com/login/device/code', {
+      method: 'POST',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ client_id: MID_GH_CLIENT_ID, scope: 'repo read:user' }),
+    });
+    const data = await res.json() as { user_code?: string; verification_uri?: string; device_code?: string; interval?: number; error_description?: string };
+    if (data.error_description) return { ok: false, error: data.error_description };
+    return {
+      ok: true,
+      userCode: data.user_code,
+      verificationUri: data.verification_uri,
+      deviceCode: data.device_code,
+      interval: data.interval ?? 5,
+    };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+});
+
+ipcMain.handle('mid:gh-device-flow-poll', async (_e, deviceCode: string): Promise<{ ok: boolean; token?: string; pending?: boolean; error?: string }> => {
+  try {
+    const res = await fetch('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: MID_GH_CLIENT_ID,
+        device_code: deviceCode,
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      }),
+    });
+    const data = await res.json() as { access_token?: string; error?: string; error_description?: string };
+    if (data.access_token) {
+      // v1: persist alongside app state (a real app should use keytar). Documented as follow-up.
+      await writeAppState({ ghToken: data.access_token } as Partial<AppState>);
+      return { ok: true, token: data.access_token };
+    }
+    if (data.error === 'authorization_pending' || data.error === 'slow_down') {
+      return { ok: true, pending: true };
+    }
+    return { ok: false, error: data.error_description ?? data.error ?? 'unknown' };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+});
+
 ipcMain.handle('mid:repo-status', async (_e, workspace: string) => {
   try {
     const { stdout } = await runGit(workspace, ['status', '--porcelain=v2', '--branch']);
@@ -591,9 +643,10 @@ interface AppState {
   previewMaxWidth?: number;
   recentFiles?: string[];
   codeExportGradient?: string;
-  pinnedFolders?: { path: string; name: string; icon: string; color: string }[];
+  pinnedFolders?: { path: string; name: string; icon: string; color: string; files?: string[] }[];
   workspaces?: { id: string; name: string; path: string }[];
   activeWorkspace?: string;
+  ghToken?: string;
 }
 
 function resolveMCPServerScript(): string {

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -84,6 +84,10 @@ contextBridge.exposeInMainWorld('mid', {
     ipcRenderer.invoke('mid:gh-repo-list'),
   ghRepoCreate: (slug: string, visibility: 'private' | 'public'): Promise<{ ok: boolean; url?: string; error?: string }> =>
     ipcRenderer.invoke('mid:gh-repo-create', slug, visibility),
+  ghDeviceFlowStart: (): Promise<{ ok: boolean; userCode?: string; verificationUri?: string; deviceCode?: string; interval?: number; error?: string }> =>
+    ipcRenderer.invoke('mid:gh-device-flow-start'),
+  ghDeviceFlowPoll: (deviceCode: string): Promise<{ ok: boolean; token?: string; pending?: boolean; error?: string }> =>
+    ipcRenderer.invoke('mid:gh-device-flow-poll', deviceCode),
   fileHistory: (workspace: string, filePath: string): Promise<{ commits: { hash: string; date: string; author: string; message: string; diff: string }[]; ok: boolean; error?: string }> =>
     ipcRenderer.invoke('mid:file-history', workspace, filePath),
   repoStatus: (workspace: string): Promise<{ initialized: boolean; branch: string; ahead: number; behind: number; dirty: number; remote: string }> =>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -488,6 +488,39 @@ body.has-sidebar .mid-shell {
   color: var(--mid-fg-muted);
 }
 
+/* Conflict banner — shown above the preview on pull-rebase failures (#221) */
+.mid-conflict-banner {
+  position: fixed;
+  bottom: var(--mid-space-6);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: var(--mid-space-3);
+  padding: var(--mid-space-3) var(--mid-space-4);
+  background: var(--mid-bg);
+  border: 1px solid var(--mid-danger);
+  border-left-width: 4px;
+  border-radius: var(--mid-radius-lg);
+  box-shadow: var(--mid-shadow-lg);
+  z-index: var(--mid-z-modal);
+  max-width: 760px;
+}
+.mid-conflict-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: var(--mid-danger);
+  color: #fff;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.mid-conflict-text { flex: 1; min-width: 0; }
+.mid-conflict-title { font-weight: var(--mid-weight-semibold); font-size: var(--mid-font-size-sm); }
+.mid-conflict-msg { font-family: var(--mid-font-mono); font-size: var(--mid-font-size-xs); color: var(--mid-fg-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
 /* Cursor-aware mermaid popout (#222) */
 .mid-mermaid-popout {
   position: fixed;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -119,6 +119,8 @@ interface Mid {
   ghRepoList(): Promise<{ repos: { nameWithOwner: string; description: string; visibility: string }[]; ok: boolean; error?: string }>;
   ghRepoCreate(slug: string, visibility: 'private' | 'public'): Promise<{ ok: boolean; url?: string; error?: string }>;
   fileHistory(workspace: string, filePath: string): Promise<{ commits: { hash: string; date: string; author: string; message: string; diff: string }[]; ok: boolean; error?: string }>;
+  ghDeviceFlowStart(): Promise<{ ok: boolean; userCode?: string; verificationUri?: string; deviceCode?: string; interval?: number; error?: string }>;
+  ghDeviceFlowPoll(deviceCode: string): Promise<{ ok: boolean; token?: string; pending?: boolean; error?: string }>;
   repoStatus(workspace: string): Promise<{ initialized: boolean; branch: string; ahead: number; behind: number; dirty: number; remote: string }>;
   repoConnect(workspace: string, repoSlug: string): Promise<{ url: string }>;
   repoSync(workspace: string, message: string): Promise<{ steps: string[]; ok: boolean; error?: string }>;
@@ -1753,11 +1755,14 @@ async function promptConnectRepo(): Promise<void> {
   if (!currentFolder) return;
   const auth = await window.mid.ghAuthStatus();
   if (!auth.authenticated) {
-    const proceed = await midConfirm(
+    const useDeviceFlow = await midConfirm(
       'gh CLI not authenticated',
-      `${auth.output.split('\n')[0]}\n\nRun "gh auth login" in a terminal first, then retry. Continue anyway?`,
+      `${auth.output.split('\n')[0]}\n\nClick OK to authenticate via GitHub device-flow in your browser, or Cancel to type a slug manually.`,
     );
-    if (!proceed) return;
+    if (useDeviceFlow) {
+      const ok = await runGhDeviceFlow();
+      if (!ok) return;
+    }
   }
   // Pull list of user's repos via gh CLI for picker; fall back to free-text on failure.
   const listResult = await window.mid.ghRepoList();
@@ -1849,6 +1854,61 @@ function openRepoPicker(repos: { nameWithOwner: string; description: string; vis
   });
 }
 
+async function runGhDeviceFlow(): Promise<boolean> {
+  const start = await window.mid.ghDeviceFlowStart();
+  if (!start.ok || !start.userCode || !start.verificationUri || !start.deviceCode) {
+    await midConfirm('Device flow failed to start', start.error ?? 'Unknown error');
+    return false;
+  }
+  await navigator.clipboard.writeText(start.userCode).catch(() => undefined);
+  await window.mid.openExternal(start.verificationUri);
+  flashStatus(`Code ${start.userCode} copied — paste it in the browser`);
+  // Poll until token or timeout (5 minutes max).
+  const maxAttempts = Math.ceil((5 * 60) / (start.interval ?? 5));
+  for (let i = 0; i < maxAttempts; i++) {
+    await new Promise(r => setTimeout(r, (start.interval ?? 5) * 1000));
+    const result = await window.mid.ghDeviceFlowPoll(start.deviceCode);
+    if (result.ok && result.token) { flashStatus('GitHub authenticated'); return true; }
+    if (!result.ok) { await midConfirm('Auth failed', result.error ?? 'Unknown'); return false; }
+  }
+  await midConfirm('Auth timed out', 'No token received within 5 minutes.');
+  return false;
+}
+
+// Conflict banner for git pull --rebase failures
+let conflictBanner: HTMLDivElement | null = null;
+function showConflictBanner(message: string): void {
+  hideConflictBanner();
+  const banner = document.createElement('div');
+  banner.className = 'mid-conflict-banner';
+  banner.innerHTML = `
+    <span class="mid-conflict-icon">${iconHTML('x', 'mid-icon--sm')}</span>
+    <div class="mid-conflict-text">
+      <div class="mid-conflict-title">Merge conflict during pull-rebase</div>
+      <div class="mid-conflict-msg">${escapeHTML(message)}</div>
+    </div>
+    <button class="mid-btn mid-btn--secondary" data-conflict="abort">Abort rebase</button>
+    <button class="mid-btn mid-btn--secondary" data-conflict="keep-mine">Keep mine</button>
+    <button class="mid-btn mid-btn--secondary" data-conflict="keep-theirs">Keep theirs</button>
+    <button class="mid-btn mid-btn--ghost mid-btn--icon" data-conflict="dismiss" title="Dismiss">${iconHTML('x', 'mid-icon--sm')}</button>
+  `;
+  banner.addEventListener('click', e => {
+    const action = (e.target as HTMLElement).closest<HTMLElement>('[data-conflict]')?.dataset.conflict;
+    if (!action) return;
+    void handleConflictAction(action as 'abort' | 'keep-mine' | 'keep-theirs' | 'dismiss');
+  });
+  document.body.appendChild(banner);
+  conflictBanner = banner;
+}
+function hideConflictBanner(): void {
+  if (conflictBanner) { conflictBanner.remove(); conflictBanner = null; }
+}
+async function handleConflictAction(action: 'abort' | 'keep-mine' | 'keep-theirs' | 'dismiss'): Promise<void> {
+  if (action === 'dismiss') { hideConflictBanner(); return; }
+  flashStatus(`Conflict action: ${action} — run from terminal: git rebase --${action === 'abort' ? 'abort' : 'continue'}`);
+  hideConflictBanner();
+}
+
 async function showFileHistory(filePath: string): Promise<void> {
   if (!currentFolder) return;
   const result = await window.mid.fileHistory(currentFolder, filePath);
@@ -1896,8 +1956,15 @@ async function syncRepo(): Promise<void> {
   const message = (await midPrompt('Sync repo', 'Commit message (blank = auto)', '')) ?? '';
   const result = await window.mid.repoSync(currentFolder, message);
   repoSyncBtn.disabled = false;
-  if (result.ok) flashStatus(`Synced — ${result.steps.join(', ')}`);
-  else flashStatus(`Sync failed: ${result.error?.split('\n')[0] ?? 'unknown'}`);
+  if (result.ok) {
+    flashStatus(`Synced — ${result.steps.join(', ')}`);
+    hideConflictBanner();
+  } else {
+    flashStatus(`Sync failed: ${result.error?.split('\n')[0] ?? 'unknown'}`);
+    if (result.error && /conflict|merge/i.test(result.error)) {
+      showConflictBanner(result.error.split('\n')[0]);
+    }
+  }
   await refreshRepoStatus();
 }
 


### PR DESCRIPTION
**#220 Device-flow OAuth** — when `gh` CLI isn't authenticated, Connect Repo offers GitHub device-flow as a fallback. `mid:gh-device-flow-start` requests a device code; renderer copies `user_code` to clipboard and opens `verification_uri` in browser. `mid:gh-device-flow-poll` polls every `interval` seconds (default 5) for up to 5 minutes. Token persists in app state (production builds should swap to keytar — flagged as follow-up). Real OAuth client_id needs registration; defaults to placeholder via `MID_GH_CLIENT_ID` env var.

**#221 Conflict banner** — when `mid:repo-sync` fails with text matching `/conflict|merge/i`, a fixed-position banner overlays the preview with the error line + Abort rebase / Keep mine / Keep theirs / dismiss buttons. v1 actions flash a status hint pointing to the terminal command (real conflict-resolution wiring is a v2 follow-up).

Closes #220 #221.