### PR TITLE
fix(desktop): code-block PNG export blank with gradient backdrop (#237)

### DIFF
--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -1080,7 +1080,6 @@ function downloadCode(text: string, lang?: string): void {
 async function exportCodeBlockAsPNG(target: HTMLElement): Promise<void> {
   const gradient = CODE_EXPORT_GRADIENTS[settings.codeExportGradient];
   if (!gradient) {
-    // No backdrop — capture the chromed window directly.
     const dataUrl = await toPng(target, {
       pixelRatio: 2,
       backgroundColor: getComputedStyle(document.documentElement).getPropertyValue('--mid-bg').trim() || '#0d1117',
@@ -1091,26 +1090,27 @@ async function exportCodeBlockAsPNG(target: HTMLElement): Promise<void> {
     a.click();
     return;
   }
-  // Wrap the chromed window in a gradient backdrop + 60px padding so the export
-  // looks like a Carbon-style screenshot.
+  // Wrap the chromed window in a gradient backdrop + padding so the export looks
+  // like a Carbon-style screenshot. Position offscreen via translate (not opacity)
+  // so the clone html-to-image takes is fully rendered — `opacity: 0` on the
+  // wrapper makes the cloned root invisible too, producing a blank PNG (#237).
   const backdrop = document.createElement('div');
   backdrop.className = 'mid-code-export-bg';
   backdrop.style.background = gradient;
-  // The wrapper sits next to the target temporarily; clone the chrome so we
-  // don't visually disturb the live preview.
   const clone = target.cloneNode(true) as HTMLElement;
   backdrop.appendChild(clone);
-  // Position off-screen but in-document so html-to-image picks up styles.
   backdrop.style.position = 'fixed';
   backdrop.style.left = '0';
   backdrop.style.top = '0';
-  backdrop.style.zIndex = '-1';
-  backdrop.style.opacity = '0';
+  backdrop.style.transform = 'translate(-200vw, 0)';
+  backdrop.style.pointerEvents = 'none';
   document.body.appendChild(backdrop);
   try {
-    // Force a frame so layout settles.
     await new Promise(resolve => requestAnimationFrame(() => resolve(null)));
-    const dataUrl = await toPng(backdrop, { pixelRatio: 2 });
+    const dataUrl = await toPng(backdrop, {
+      pixelRatio: 2,
+      style: { transform: 'none' },
+    });
     const a = document.createElement('a');
     a.href = dataUrl;
     a.download = 'code.png';


### PR DESCRIPTION
## Summary
- Fixes #237 — exporting a code block to PNG produced an empty / fully-transparent image whenever a gradient backdrop was selected (the default).
- Root cause: the temporary wrapper used `opacity: 0` to hide itself off-screen. `html-to-image` clones the wrapper's inline styles onto the captured root, so the rendered SVG was painted with `opacity: 0` and the resulting canvas was fully transparent.
- Fix: hide via offscreen `transform: translate(-200vw, 0)` + `pointer-events: none`, then pass `style: { transform: 'none' }` to `toPng()` so the captured clone renders at its natural position inside the SVG `foreignObject`.

## Test plan
- [ ] Open any markdown file with a code block in the preview pane.
- [ ] Right-click the code block → **Export as PNG** (with the default gradient backdrop on).
- [ ] PNG opens with the chrome + code visible on the gradient (was: blank).
- [ ] Switch the code-export gradient to **None** in Settings → export again → still works (no backdrop, no flash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)