### PR TITLE
fix(desktop): close Cmd+K spotlight on backdrop click (#242)

### DIFF
--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -2853,9 +2853,13 @@ function openSpotlight(): void {
   const onKey = (e: KeyboardEvent): void => {
     if (e.key === 'Escape') { e.preventDefault(); close(); }
   };
+  const onBackdrop = (e: MouseEvent): void => {
+    if (e.target === dlg) close();
+  };
   const close = (): void => {
     input.removeEventListener('input', onInput);
     document.removeEventListener('keydown', onKey);
+    dlg.removeEventListener('click', onBackdrop);
     tabs.forEach(t => t.removeEventListener('click', onTab));
     if (dlg.open) dlg.close();
   };
@@ -2864,6 +2868,7 @@ function openSpotlight(): void {
   input.value = '';
   input.addEventListener('input', onInput);
   document.addEventListener('keydown', onKey);
+  dlg.addEventListener('click', onBackdrop);
   tabs.forEach(t => t.addEventListener('click', onTab));
   dlg.showModal();
   void collectWorkspaceFiles().then(renderResults);


### PR DESCRIPTION
## Summary
Fixes #242 — clicking outside the spotlight panel now dismisses it. Previously only \`Escape\` worked.

Adds a \`click\` listener on \`<dialog id=\"mid-spotlight\">\`. Because the panel content is wrapped in \`.mid-spotlight-frame\`, any event whose \`target === dialog\` was a click on the dim backdrop, so we close. Listener is torn down inside \`close()\` so repeated open/close doesn't leak handlers.

## Test plan
- [ ] Hit Cmd+K → click anywhere on the dim area outside the panel → modal closes.
- [ ] Click inside the panel (input, tabs, result rows) → modal stays open.
- [ ] Escape still closes.
- [ ] Open + close 5 times in a row — DevTools event listener panel shows no buildup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)