### PR TITLE
feat(desktop): unique-id suffix on every export filename (#238)

### DIFF
--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -873,7 +873,7 @@ function downloadMermaidSVG(host: HTMLDivElement, _source: string): void {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = 'diagram.svg';
+  a.download = uniqueExportName('diagram', 'svg');
   a.click();
   setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
@@ -888,7 +888,7 @@ async function downloadMermaidPNG(host: HTMLDivElement): Promise<void> {
   });
   const a = document.createElement('a');
   a.href = dataUrl;
-  a.download = 'diagram.png';
+  a.download = uniqueExportName('diagram', 'png');
   a.click();
 }
 
@@ -1079,6 +1079,7 @@ function downloadCode(text: string, lang?: string): void {
 
 async function exportCodeBlockAsPNG(target: HTMLElement): Promise<void> {
   const gradient = CODE_EXPORT_GRADIENTS[settings.codeExportGradient];
+  const filename = uniqueExportName('code', 'png');
   if (!gradient) {
     const dataUrl = await toPng(target, {
       pixelRatio: 2,
@@ -1086,7 +1087,7 @@ async function exportCodeBlockAsPNG(target: HTMLElement): Promise<void> {
     });
     const a = document.createElement('a');
     a.href = dataUrl;
-    a.download = 'code.png';
+    a.download = filename;
     a.click();
     return;
   }
@@ -1113,7 +1114,7 @@ async function exportCodeBlockAsPNG(target: HTMLElement): Promise<void> {
     });
     const a = document.createElement('a');
     a.href = dataUrl;
-    a.download = 'code.png';
+    a.download = filename;
     a.click();
   } finally {
     backdrop.remove();
@@ -1481,7 +1482,7 @@ async function shareTableToSheets(headers: HTMLTableCellElement[], rows: HTMLTab
   const wb = XLSX.utils.book_new();
   XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
   const arr = XLSX.write(wb, { bookType: 'xlsx', type: 'array' }) as ArrayBuffer;
-  const saved = await window.mid.saveAs('table.xlsx', arr, [{ name: 'Excel', extensions: ['xlsx'] }]);
+  const saved = await window.mid.saveAs(uniqueExportName('table', 'xlsx'), arr, [{ name: 'Excel', extensions: ['xlsx'] }]);
   if (saved) {
     await navigator.clipboard.writeText(saved).catch(() => undefined);
     await window.mid.openExternal('https://drive.google.com/drive/u/0/upload');
@@ -1497,14 +1498,14 @@ function downloadTable(headers: HTMLTableCellElement[], rows: HTMLTableRowElemen
     const escape = (v: string): string => /[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v;
     const lines = [head.map(escape).join(','), ...rows.map(r => rowToValues(r).map(escape).join(','))];
     blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8' });
-    filename = 'table.csv';
+    filename = uniqueExportName('table', 'csv');
   } else if (format === 'json') {
     const objs = rows.map(r => {
       const vals = rowToValues(r);
       return Object.fromEntries(head.map((h, i) => [h, vals[i] ?? '']));
     });
     blob = new Blob([JSON.stringify(objs, null, 2)], { type: 'application/json' });
-    filename = 'table.json';
+    filename = uniqueExportName('table', 'json');
   } else {
     // xlsx — single sheet, header row + data, frozen first row
     const aoa = [head, ...rows.map(r => rowToValues(r))];
@@ -1515,7 +1516,7 @@ function downloadTable(headers: HTMLTableCellElement[], rows: HTMLTableRowElemen
     XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
     const arr = XLSX.write(wb, { bookType: 'xlsx', type: 'array' }) as ArrayBuffer;
     blob = new Blob([arr], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
-    filename = 'table.xlsx';
+    filename = uniqueExportName('table', 'xlsx');
   }
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -2102,9 +2103,18 @@ async function saveFile(): Promise<void> {
   }
 }
 
+function shortExportId(): string {
+  return crypto.randomUUID().replace(/-/g, '').slice(0, 8);
+}
+
+function uniqueExportName(base: string, ext: string): string {
+  const safe = base.replace(/\.[^.]+$/, '').replace(/[^a-zA-Z0-9-_.]/g, '_') || 'export';
+  return `${safe}--${shortExportId()}.${ext}`;
+}
+
 function defaultExportName(ext: string): string {
   const base = currentPath ? currentPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? 'document' : 'document';
-  return `${base}.${ext}`;
+  return uniqueExportName(base, ext);
 }
 
 async function exportAs(format: ExportFormat): Promise<void> {
@@ -3106,7 +3116,7 @@ async function exportFile(filePath: string, format: ExportFormat): Promise<void>
     const text = format === 'md' ? content : markdownToPlainText(content);
     const ext = format;
     const filterName = format === 'md' ? 'Markdown' : 'Plain text';
-    await window.mid.saveAs(`${baseName}.${ext}`, text, [{ name: filterName, extensions: [ext] }]);
+    await window.mid.saveAs(uniqueExportName(baseName, ext), text, [{ name: filterName, extensions: [ext] }]);
     flashStatus(`Exported ${format.toUpperCase()}`);
     return;
   }
@@ -3141,7 +3151,7 @@ async function exportNote(note: NoteEntry, format: ExportFormat): Promise<void> 
     const text = format === 'md' ? content : markdownToPlainText(content);
     const ext = format;
     const filterName = format === 'md' ? 'Markdown' : 'Plain text';
-    await window.mid.saveAs(`${baseName}.${ext}`, text, [{ name: filterName, extensions: [ext] }]);
+    await window.mid.saveAs(uniqueExportName(baseName, ext), text, [{ name: filterName, extensions: [ext] }]);
     flashStatus(`Exported ${format.toUpperCase()}`);
     return;
   }

--- a/docs/export-filenames.md
+++ b/docs/export-filenames.md
@@ -1,0 +1,49 @@
+# Export filenames
+
+Every export action in Mark It Down stamps its output filename with a short unique id, so re-exporting the same document never overwrites a prior file and you can copy-paste the suffix to refer back to a specific run.
+
+## Format
+
+```
+<basename>--<id>.<ext>
+```
+
+- `<basename>` — derived from the source file's name (or a fixed label like `code`, `diagram`, `table` for non-document exports). Sanitized to `[A-Za-z0-9._-]`, falling back to `export` if empty.
+- `<id>` — first 8 hex characters of `crypto.randomUUID()` (~32 bits of entropy, ~4 billion values).
+- `<ext>` — the export format: `md`, `txt`, `html`, `pdf`, `png`, `docx`, `csv`, `json`, `xlsx`, `svg`.
+
+## Examples
+
+| Action                               | Filename                              |
+| ------------------------------------ | ------------------------------------- |
+| Export PDF on `roadmap.md`           | `roadmap--3a7f0c19.pdf`                |
+| Export PNG on `roadmap.md`           | `roadmap--c4e6810b.png`                |
+| Export DOCX on `roadmap.md`          | `roadmap--98a142f7.docx`               |
+| Code-block PNG export                 | `code--71ed4f02.png`                   |
+| Mermaid SVG export                    | `diagram--0bf81d77.svg`                |
+| Mermaid PNG export                    | `diagram--be20a1c5.png`                |
+| Table → CSV                           | `table--5dd9a206.csv`                  |
+| Table → Excel (xlsx)                  | `table--5dd9a206.xlsx`                 |
+| Table → JSON                          | `table--5dd9a206.json`                 |
+
+## What this does NOT affect
+
+- **Save** / **Save As** keep using the source filename (or `untitled.md` for a brand-new doc) — they're authoring actions, not exports, so the user picks the final name.
+- The system Save dialog still appears for every export and the user can override the suggested name before writing.
+
+## Implementation
+
+Helpers live in `apps/electron/renderer/renderer.ts`:
+
+```ts
+function shortExportId(): string {
+  return crypto.randomUUID().replace(/-/g, '').slice(0, 8);
+}
+
+function uniqueExportName(base: string, ext: string): string {
+  const safe = base.replace(/\.[^.]+$/, '').replace(/[^a-zA-Z0-9-_.]/g, '_') || 'export';
+  return `${safe}--${shortExportId()}.${ext}`;
+}
+```
+
+`defaultExportName(ext)` (the helper used by every `exportAs(format)` branch) is now a thin wrapper around `uniqueExportName` so PDF, PNG, DOCX, HTML, MD, TXT all flow through the same path. Code-block, mermaid, and table exports call `uniqueExportName` directly.


### PR DESCRIPTION
## Summary
Closes #238 — every export now writes \`<basename>--<id>.<ext>\` so re-exporting the same document never silently overwrites a prior file.

\`<id>\` is the first 8 hex characters of \`crypto.randomUUID()\` — short enough to copy-paste, ~32 bits of entropy so collisions are effectively impossible.

Touches:
- \`defaultExportName(ext)\` (used by \`exportAs(md|txt|html|pdf|png|docx|docx-gdocs)\`)
- \`exportFile\` / \`exportNote\` text-only fast path (md/txt)
- Mermaid SVG + PNG downloads
- Code-block PNG export (both gradient + no-gradient branches)
- DataTable CSV / JSON / XLSX downloads + Google Sheets share path

Save / Save As intentionally untouched (those are authoring, the user picks the name).

Docs: \`docs/export-filenames.md\`.

## Test plan
- [ ] Export a doc to PDF twice in a row — two distinct files with different ids land in the destination folder.
- [ ] Export same doc to PNG, DOCX, MD, TXT, HTML — each filename suffixed differently.
- [ ] Code-block → Export as PNG twice — two unique \`code--xxxxxxxx.png\` files.
- [ ] Mermaid → Export SVG + PNG — \`diagram--xxxxxxxx.svg\` / \`.png\`.
- [ ] DataTable → CSV / Excel / JSON — \`table--xxxxxxxx.csv\` etc.
- [ ] Save / Save As still uses the source filename (not suffixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)