### PR TITLE
feat(desktop): SQLite-backed settings + app state (#239)

### DIFF
--- a/apps/electron/db.ts
+++ b/apps/electron/db.ts
@@ -1,0 +1,348 @@
+/**
+ * SQLite-backed app state.
+ *
+ * One database per install at `<userData>/mid.sqlite`, opened with WAL.
+ * The migration story (see `migrateLegacyState`) is intentionally one-shot
+ * and defensive: if the user upgrades from a JSON-state build, the JSON file
+ * is hydrated into SQLite and renamed to `state.json.migrated`. We keep the
+ * file rather than deleting it so a panicked rollback still has the original
+ * blob to read from.
+ *
+ * All settings keys are stored as JSON blobs in the `settings` table — that
+ * keeps the schema stable while letting individual values evolve their shape
+ * (arrays, nested objects, etc.) without further migrations.
+ */
+
+import Database from 'better-sqlite3';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+let db: Database.Database | null = null;
+let dbPath = '';
+
+export interface PinnedFolderRow {
+  id: string;
+  path: string;
+  name: string;
+  icon: string;
+  color: string;
+  files?: string[];
+  sort?: number;
+}
+
+export interface WorkspaceRow {
+  id: string;
+  name: string;
+  path: string;
+}
+
+export interface WarehouseRow {
+  id: string;
+  workspace: string;
+  repo: string;
+  branch: string | null;
+  subdir: string | null;
+}
+
+export interface ExportHistoryRow {
+  id: string;
+  source_path: string;
+  format: string;
+  file_path: string;
+  exported_at: number;
+}
+
+export function openDB(userDataDir: string): Database.Database {
+  if (db) return db;
+  dbPath = path.join(userDataDir, 'mid.sqlite');
+  // better-sqlite3 will create the file if it doesn't exist.
+  db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  applySchema(db);
+  return db;
+}
+
+export function getDB(): Database.Database {
+  if (!db) throw new Error('SQLite db not initialized — call openDB(userDataDir) at startup');
+  return db;
+}
+
+export function closeDB(): void {
+  if (db) {
+    try { db.close(); } catch { /* ignore */ }
+    db = null;
+  }
+}
+
+export function getDBPath(): string {
+  return dbPath;
+}
+
+function applySchema(d: Database.Database): void {
+  d.exec(`
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS recent_files (
+      path TEXT PRIMARY KEY,
+      opened_at INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS pinned_folders (
+      id TEXT PRIMARY KEY,
+      path TEXT NOT NULL,
+      name TEXT NOT NULL,
+      icon TEXT NOT NULL,
+      color TEXT NOT NULL,
+      files_json TEXT,
+      sort INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE IF NOT EXISTS workspaces (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      path TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS warehouses (
+      id TEXT PRIMARY KEY,
+      workspace TEXT NOT NULL,
+      repo TEXT NOT NULL,
+      branch TEXT,
+      subdir TEXT
+    );
+    CREATE TABLE IF NOT EXISTS export_history (
+      id TEXT PRIMARY KEY,
+      source_path TEXT,
+      format TEXT NOT NULL,
+      file_path TEXT NOT NULL,
+      exported_at INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_recent_files_opened ON recent_files(opened_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_export_history_exported ON export_history(exported_at DESC);
+  `);
+}
+
+/* ── settings (JSON-blob valued) ────────────────────────── */
+
+export function getSetting<T = unknown>(key: string): T | undefined {
+  const row = getDB().prepare('SELECT value FROM settings WHERE key = ?').get(key) as { value: string } | undefined;
+  if (!row) return undefined;
+  try {
+    return JSON.parse(row.value) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+export function setSetting(key: string, value: unknown): void {
+  const json = JSON.stringify(value);
+  getDB().prepare('INSERT INTO settings(key, value) VALUES(?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value').run(key, json);
+}
+
+export function getAllSettings(): Record<string, unknown> {
+  const rows = getDB().prepare('SELECT key, value FROM settings').all() as { key: string; value: string }[];
+  const out: Record<string, unknown> = {};
+  for (const r of rows) {
+    try { out[r.key] = JSON.parse(r.value); } catch { /* skip bad row */ }
+  }
+  return out;
+}
+
+/* ── recent files ───────────────────────────────────────── */
+
+export function listRecentFiles(limit = 20): string[] {
+  const rows = getDB().prepare('SELECT path FROM recent_files ORDER BY opened_at DESC LIMIT ?').all(limit) as { path: string }[];
+  return rows.map(r => r.path);
+}
+
+export function pushRecentFile(filePath: string): void {
+  const now = Date.now();
+  getDB().prepare('INSERT INTO recent_files(path, opened_at) VALUES(?, ?) ON CONFLICT(path) DO UPDATE SET opened_at = excluded.opened_at').run(filePath, now);
+  // Trim to 50 most recent — desktop apps don't need unbounded history.
+  getDB().prepare('DELETE FROM recent_files WHERE path NOT IN (SELECT path FROM recent_files ORDER BY opened_at DESC LIMIT 50)').run();
+}
+
+export function clearRecentFiles(): void {
+  getDB().prepare('DELETE FROM recent_files').run();
+}
+
+/* ── pinned folders ─────────────────────────────────────── */
+
+export function listPinnedFolders(): PinnedFolderRow[] {
+  const rows = getDB().prepare('SELECT id, path, name, icon, color, files_json, sort FROM pinned_folders ORDER BY sort ASC, name ASC').all() as { id: string; path: string; name: string; icon: string; color: string; files_json: string | null; sort: number }[];
+  return rows.map(r => ({
+    id: r.id,
+    path: r.path,
+    name: r.name,
+    icon: r.icon,
+    color: r.color,
+    files: r.files_json ? safeParseArray(r.files_json) : undefined,
+    sort: r.sort,
+  }));
+}
+
+export function replacePinnedFolders(folders: PinnedFolderRow[]): void {
+  const d = getDB();
+  const tx = d.transaction((rows: PinnedFolderRow[]) => {
+    d.prepare('DELETE FROM pinned_folders').run();
+    const stmt = d.prepare('INSERT INTO pinned_folders(id, path, name, icon, color, files_json, sort) VALUES(?, ?, ?, ?, ?, ?, ?)');
+    rows.forEach((r, idx) => {
+      stmt.run(
+        r.id ?? `pin-${Date.now()}-${idx}`,
+        r.path,
+        r.name,
+        r.icon,
+        r.color,
+        r.files ? JSON.stringify(r.files) : null,
+        r.sort ?? idx,
+      );
+    });
+  });
+  tx(folders);
+}
+
+/* ── workspaces ─────────────────────────────────────────── */
+
+export function listWorkspaces(): WorkspaceRow[] {
+  return getDB().prepare('SELECT id, name, path FROM workspaces').all() as WorkspaceRow[];
+}
+
+export function replaceWorkspaces(rows: WorkspaceRow[]): void {
+  const d = getDB();
+  const tx = d.transaction((all: WorkspaceRow[]) => {
+    d.prepare('DELETE FROM workspaces').run();
+    const stmt = d.prepare('INSERT INTO workspaces(id, name, path) VALUES(?, ?, ?)');
+    for (const r of all) stmt.run(r.id, r.name, r.path);
+  });
+  tx(rows);
+}
+
+/* ── warehouses ─────────────────────────────────────────── */
+
+export function listWarehouses(workspace?: string): WarehouseRow[] {
+  if (workspace) {
+    return getDB().prepare('SELECT id, workspace, repo, branch, subdir FROM warehouses WHERE workspace = ?').all(workspace) as WarehouseRow[];
+  }
+  return getDB().prepare('SELECT id, workspace, repo, branch, subdir FROM warehouses').all() as WarehouseRow[];
+}
+
+export function upsertWarehouse(row: WarehouseRow): void {
+  getDB()
+    .prepare('INSERT INTO warehouses(id, workspace, repo, branch, subdir) VALUES(?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET workspace = excluded.workspace, repo = excluded.repo, branch = excluded.branch, subdir = excluded.subdir')
+    .run(row.id, row.workspace, row.repo, row.branch ?? null, row.subdir ?? null);
+}
+
+export function deleteWarehouse(id: string): void {
+  getDB().prepare('DELETE FROM warehouses WHERE id = ?').run(id);
+}
+
+/* ── export history ─────────────────────────────────────── */
+
+export function recordExport(row: ExportHistoryRow): void {
+  getDB()
+    .prepare('INSERT INTO export_history(id, source_path, format, file_path, exported_at) VALUES(?, ?, ?, ?, ?)')
+    .run(row.id, row.source_path ?? null, row.format, row.file_path, row.exported_at);
+}
+
+export function listExportHistory(limit = 50): ExportHistoryRow[] {
+  return getDB().prepare('SELECT id, source_path, format, file_path, exported_at FROM export_history ORDER BY exported_at DESC LIMIT ?').all(limit) as ExportHistoryRow[];
+}
+
+/* ── one-shot legacy migration ──────────────────────────── */
+
+interface LegacyAppState {
+  lastFolder?: string;
+  splitRatio?: number;
+  fontFamily?: string;
+  fontSize?: number;
+  theme?: string;
+  previewMaxWidth?: number;
+  recentFiles?: string[];
+  codeExportGradient?: string;
+  pinnedFolders?: { path: string; name: string; icon: string; color: string; files?: string[] }[];
+  workspaces?: { id: string; name: string; path: string }[];
+  activeWorkspace?: string;
+  ghToken?: string;
+}
+
+/**
+ * If `<userData>/state.json` exists, copy its contents into SQLite and rename
+ * the original to `state.json.migrated`. Idempotent: re-runs are no-ops because
+ * the rename moves the source file out of the way.
+ *
+ * The migration is wrapped in a transaction so a partial write doesn't leave
+ * the DB half-populated.
+ */
+export async function migrateLegacyState(userDataDir: string): Promise<{ migrated: boolean; error?: string }> {
+  const file = path.join(userDataDir, 'state.json');
+  let raw: string;
+  try {
+    raw = await fs.readFile(file, 'utf8');
+  } catch {
+    return { migrated: false };
+  }
+  let parsed: LegacyAppState;
+  try {
+    parsed = JSON.parse(raw) as LegacyAppState;
+  } catch (err) {
+    // Malformed JSON: leave the file alone, surface the error so the caller logs it.
+    return { migrated: false, error: `state.json is not valid JSON: ${(err as Error).message}` };
+  }
+  const d = getDB();
+  const tx = d.transaction(() => {
+    const setStmt = d.prepare('INSERT INTO settings(key, value) VALUES(?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value');
+    const setKey = (k: string, v: unknown): void => { setStmt.run(k, JSON.stringify(v)); };
+    if (parsed.lastFolder !== undefined) setKey('lastFolder', parsed.lastFolder);
+    if (parsed.splitRatio !== undefined) setKey('splitRatio', parsed.splitRatio);
+    if (parsed.fontFamily !== undefined) setKey('fontFamily', parsed.fontFamily);
+    if (parsed.fontSize !== undefined) setKey('fontSize', parsed.fontSize);
+    if (parsed.theme !== undefined) setKey('theme', parsed.theme);
+    if (parsed.previewMaxWidth !== undefined) setKey('previewMaxWidth', parsed.previewMaxWidth);
+    if (parsed.codeExportGradient !== undefined) setKey('codeExportGradient', parsed.codeExportGradient);
+    if (parsed.activeWorkspace !== undefined) setKey('activeWorkspace', parsed.activeWorkspace);
+    if (parsed.ghToken !== undefined) setKey('ghToken', parsed.ghToken);
+
+    if (Array.isArray(parsed.recentFiles)) {
+      const recentStmt = d.prepare('INSERT OR IGNORE INTO recent_files(path, opened_at) VALUES(?, ?)');
+      const now = Date.now();
+      // Preserve ordering by deducting indices from `now` so the head of the
+      // legacy array is the most-recently-opened file in SQLite.
+      parsed.recentFiles.forEach((p, idx) => recentStmt.run(p, now - idx));
+    }
+
+    if (Array.isArray(parsed.pinnedFolders)) {
+      const pinStmt = d.prepare('INSERT INTO pinned_folders(id, path, name, icon, color, files_json, sort) VALUES(?, ?, ?, ?, ?, ?, ?)');
+      parsed.pinnedFolders.forEach((p, idx) => {
+        pinStmt.run(`pin-legacy-${idx}`, p.path, p.name, p.icon, p.color, p.files ? JSON.stringify(p.files) : null, idx);
+      });
+    }
+
+    if (Array.isArray(parsed.workspaces)) {
+      const wsStmt = d.prepare('INSERT OR REPLACE INTO workspaces(id, name, path) VALUES(?, ?, ?)');
+      for (const w of parsed.workspaces) wsStmt.run(w.id, w.name, w.path);
+    }
+
+    setKey('migrationVersion', 1);
+  });
+  try {
+    tx();
+  } catch (err) {
+    return { migrated: false, error: (err as Error).message };
+  }
+  // Rename the original so re-runs short-circuit at readFile.
+  try {
+    await fs.rename(file, `${file}.migrated`);
+  } catch {
+    // Couldn't rename — not fatal; settings now live in SQLite either way.
+  }
+  return { migrated: true };
+}
+
+function safeParseArray(json: string): string[] | undefined {
+  try {
+    const v = JSON.parse(json);
+    return Array.isArray(v) ? (v as string[]) : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -5,6 +5,21 @@ import * as path from 'path';
 import { fork, ChildProcess, execFile } from 'child_process';
 import * as os from 'os';
 import { promisify } from 'util';
+import {
+  openDB,
+  closeDB,
+  migrateLegacyState,
+  getAllSettings,
+  setSetting,
+  listRecentFiles,
+  pushRecentFile,
+  listPinnedFolders,
+  replacePinnedFolders,
+  listWorkspaces,
+  replaceWorkspaces,
+  recordExport,
+  listExportHistory,
+} from './db';
 
 const execFileP = promisify(execFile);
 
@@ -83,6 +98,15 @@ app.whenReady().then(async () => {
       try { app.dock.setIcon(dockIcon); } catch { /* ignore dev convenience */ }
     }
   }
+  // Open SQLite first; everything else may want to read settings.
+  try {
+    openDB(app.getPath('userData'));
+    const result = await migrateLegacyState(app.getPath('userData'));
+    if (result.error) console.warn('[mid] state.json migration warning:', result.error);
+    else if (result.migrated) console.log('[mid] migrated legacy state.json into SQLite');
+  } catch (err) {
+    console.error('[mid] failed to open SQLite:', err);
+  }
   await createWindow();
   Menu.setApplicationMenu(buildMenu());
   buildTray();
@@ -93,7 +117,7 @@ app.whenReady().then(async () => {
   setupAutoUpdate();
 });
 
-app.on('before-quit', () => stopMCP());
+app.on('before-quit', () => { stopMCP(); closeDB(); });
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();
@@ -487,6 +511,25 @@ ipcMain.handle('mid:patch-app-state', async (_e, patch: Partial<AppState>) => {
   await writeAppState(patch);
 });
 
+ipcMain.handle('mid:record-export', async (_e, row: { id: string; sourcePath?: string; format: string; filePath: string }) => {
+  try {
+    recordExport({
+      id: row.id,
+      source_path: row.sourcePath ?? '',
+      format: row.format,
+      file_path: row.filePath,
+      exported_at: Date.now(),
+    });
+  } catch (err) {
+    console.warn('[mid] record-export failed:', (err as Error).message);
+  }
+});
+
+ipcMain.handle('mid:list-export-history', async (_e, limit?: number) => {
+  try { return listExportHistory(typeof limit === 'number' ? limit : 50); }
+  catch { return []; }
+});
+
 ipcMain.handle('mid:save-as', async (_e, defaultName: string, content: string | ArrayBuffer, filters: Electron.FileFilter[]) => {
   const result = await dialog.showSaveDialog({ defaultPath: defaultName, filters });
   if (result.canceled || !result.filePath) return null;
@@ -835,22 +878,59 @@ async function listMarkdownTree(folderPath: string): Promise<TreeEntry[]> {
   return out;
 }
 
+/**
+ * Project the SQLite-backed settings + recent_files + pinned_folders +
+ * workspaces tables back into the AppState shape the renderer expects.
+ * `readAppState` and `writeAppState` are the only seam — everything else
+ * keeps using AppState so the renderer doesn't need to change.
+ */
 async function readAppState(): Promise<AppState> {
-  const file = path.join(app.getPath('userData'), 'state.json');
   try {
-    const raw = await fs.readFile(file, 'utf8');
-    return JSON.parse(raw) as AppState;
-  } catch {
+    const settings = getAllSettings() as Partial<AppState>;
+    const recentFiles = listRecentFiles(50);
+    const pinnedFolders = listPinnedFolders().map(p => ({
+      path: p.path, name: p.name, icon: p.icon, color: p.color,
+      ...(p.files ? { files: p.files } : {}),
+    }));
+    const workspaces = listWorkspaces();
+    return {
+      ...settings,
+      ...(recentFiles.length ? { recentFiles } : {}),
+      ...(pinnedFolders.length ? { pinnedFolders } : {}),
+      ...(workspaces.length ? { workspaces } : {}),
+    } as AppState;
+  } catch (err) {
+    console.error('[mid] readAppState (sqlite) failed:', err);
     return {};
   }
 }
 
 async function writeAppState(patch: Partial<AppState>): Promise<void> {
-  const file = path.join(app.getPath('userData'), 'state.json');
-  const current = await readAppState();
-  const next = { ...current, ...patch };
-  await fs.mkdir(path.dirname(file), { recursive: true });
-  await fs.writeFile(file, JSON.stringify(next, null, 2), 'utf8');
+  // Settings keys land in the settings table; arrays land in their own tables.
+  const { recentFiles, pinnedFolders, workspaces, ...rest } = patch;
+  for (const [k, v] of Object.entries(rest)) {
+    if (v === undefined) continue;
+    setSetting(k, v);
+  }
+  if (Array.isArray(recentFiles)) {
+    // `pushRecentFile` upserts + trims. Push in reverse so the head of the
+    // array ends up most-recent in the table.
+    [...recentFiles].reverse().forEach(p => pushRecentFile(p));
+  }
+  if (Array.isArray(pinnedFolders)) {
+    replacePinnedFolders(pinnedFolders.map((p, idx) => ({
+      id: `pin-${idx}`,
+      path: p.path,
+      name: p.name,
+      icon: p.icon,
+      color: p.color,
+      files: p.files,
+      sort: idx,
+    })));
+  }
+  if (Array.isArray(workspaces)) {
+    replaceWorkspaces(workspaces);
+  }
 }
 
 function buildMenu(): Menu {

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -62,6 +62,10 @@ contextBridge.exposeInMainWorld('mid', {
   readRendererStyles: (): Promise<string> => ipcRenderer.invoke('mid:read-renderer-styles'),
   patchAppState: (patch: Partial<AppState>): Promise<void> =>
     ipcRenderer.invoke('mid:patch-app-state', patch),
+  recordExport: (row: { id: string; sourcePath?: string; format: string; filePath: string }): Promise<void> =>
+    ipcRenderer.invoke('mid:record-export', row),
+  listExportHistory: (limit?: number): Promise<{ id: string; source_path: string; format: string; file_path: string; exported_at: number }[]> =>
+    ipcRenderer.invoke('mid:list-export-history', limit),
   notesList: (workspace: string): Promise<NoteEntry[]> =>
     ipcRenderer.invoke('mid:notes-list', workspace),
   notesCreate: (workspace: string, title: string): Promise<{ entry: NoteEntry; fullPath: string }> =>

--- a/docs/sqlite-store.md
+++ b/docs/sqlite-store.md
@@ -1,0 +1,121 @@
+# SQLite settings & app-state store
+
+Mark It Down's main process keeps all persistent app state in a SQLite database at `<userData>/mid.sqlite`. Settings, recent files, pinned folders, workspaces, warehouse links, and an exports audit log all flow through this single file. The renderer never sees the DB — it talks to the existing `mid:read-app-state` / `mid:patch-app-state` IPCs, which are now backed by the database.
+
+## Why SQLite (vs. JSON file)
+
+The previous store was a single `<userData>/state.json` blob. That worked while the surface was small but had three problems:
+
+1. **No concurrency story.** Multiple writes from different IPC handlers (notes, settings, repo sync) would race each other on the JSON file.
+2. **Listing/filtering required loading everything.** Recent-files and pinned-folders queries forced a full read+parse on every call.
+3. **No history.** We can now record every export to `export_history` so the unique-id story from #238 is queryable ("what did I export last week?").
+
+SQLite gives us atomic writes, indexed lookups, transactions for the migration step, and zero extra runtime dependencies on macOS / Windows / Linux. WAL journaling means the DB file stays usable even if the process crashes mid-write.
+
+## Schema
+
+```sql
+-- key/value JSON blobs for arbitrary settings
+CREATE TABLE settings (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL          -- JSON-stringified
+);
+
+-- ordered MRU list of opened files
+CREATE TABLE recent_files (
+  path      TEXT PRIMARY KEY,
+  opened_at INTEGER NOT NULL   -- ms epoch
+);
+CREATE INDEX idx_recent_files_opened ON recent_files(opened_at DESC);
+
+-- pinned folders shown in the activity bar
+CREATE TABLE pinned_folders (
+  id         TEXT PRIMARY KEY,
+  path       TEXT NOT NULL,
+  name       TEXT NOT NULL,
+  icon       TEXT NOT NULL,
+  color      TEXT NOT NULL,
+  files_json TEXT,             -- nullable JSON array of paths
+  sort       INTEGER NOT NULL DEFAULT 0
+);
+
+-- saved workspaces shown in the workspace switcher
+CREATE TABLE workspaces (
+  id   TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  path TEXT NOT NULL
+);
+
+-- GitHub warehouses linked to a workspace
+CREATE TABLE warehouses (
+  id        TEXT PRIMARY KEY,
+  workspace TEXT NOT NULL,
+  repo      TEXT NOT NULL,
+  branch    TEXT,
+  subdir    TEXT
+);
+
+-- audit log of every export the renderer issues (#238)
+CREATE TABLE export_history (
+  id          TEXT PRIMARY KEY,   -- the same short id from uniqueExportName()
+  source_path TEXT,
+  format      TEXT NOT NULL,
+  file_path   TEXT NOT NULL,
+  exported_at INTEGER NOT NULL
+);
+CREATE INDEX idx_export_history_exported ON export_history(exported_at DESC);
+```
+
+Settings rows store JSON blobs so individual keys can evolve their shape (object → array, scalar → object) without further DB migrations. Trade-off: you can't query *inside* a setting from SQL — but settings are read in bulk by `getAllSettings()` and parsed in JS, so it's not a real loss.
+
+## Lifecycle
+
+```
+app.whenReady()
+  └─ openDB(userDataDir)              // creates mid.sqlite if missing
+  └─ migrateLegacyState(userDataDir)  // one-shot import from state.json (idempotent)
+
+app.before-quit
+  └─ closeDB()                        // flush WAL, close handle
+```
+
+`openDB` is called exactly once at startup and the handle is cached as a module singleton. `getDB()` returns the cached handle and throws if called before `openDB`.
+
+## Migration from `state.json`
+
+`migrateLegacyState(userDataDir)` is the bridge for users upgrading from the JSON-state build:
+
+1. If `<userData>/state.json` does not exist → no-op, returns `{ migrated: false }`.
+2. If it exists but is malformed → log a warning, leave the file in place, return `{ migrated: false, error }`.
+3. Otherwise, in a single transaction:
+   - Settings keys (`lastFolder`, `splitRatio`, `fontFamily`, `fontSize`, `theme`, `previewMaxWidth`, `codeExportGradient`, `activeWorkspace`, `ghToken`) → `settings` table.
+   - `recentFiles` array → `recent_files` (timestamps reverse-deduced from array order so head = most recent).
+   - `pinnedFolders` array → `pinned_folders` with stable `pin-legacy-<idx>` ids.
+   - `workspaces` array → `workspaces`.
+   - A `migrationVersion = 1` setting marker is written.
+4. `state.json` is renamed to `state.json.migrated` (kept, not deleted, so a panicked rollback can still see the original blob).
+
+The rename is what makes the migration idempotent: the next launch's `readFile` short-circuits before doing any work. Re-running `migrateLegacyState` is safe even if the rename fails — the transaction uses `INSERT … ON CONFLICT DO UPDATE` for settings.
+
+## API surface
+
+Everything lives in `apps/electron/db.ts`:
+
+| Group       | Functions |
+|-------------|-----------|
+| Lifecycle   | `openDB(userDataDir)`, `closeDB()`, `getDB()`, `getDBPath()`, `migrateLegacyState(userDataDir)` |
+| Settings    | `getSetting<T>(key)`, `setSetting(key, value)`, `getAllSettings()` |
+| Recent files | `listRecentFiles(limit?)`, `pushRecentFile(path)`, `clearRecentFiles()` |
+| Pinned folders | `listPinnedFolders()`, `replacePinnedFolders(rows)` |
+| Workspaces | `listWorkspaces()`, `replaceWorkspaces(rows)` |
+| Warehouses | `listWarehouses(workspace?)`, `upsertWarehouse(row)`, `deleteWarehouse(id)` |
+| Export history | `recordExport(row)`, `listExportHistory(limit?)` |
+
+`apps/electron/main.ts` keeps its existing `readAppState()` / `writeAppState(patch)` helpers as the only seam — they project the DB into the AppState shape the renderer expects, and the renderer never had to change.
+
+## New IPCs (#238 follow-up)
+
+- `mid:record-export` — `{ id, sourcePath?, format, filePath }` → inserts into `export_history`.
+- `mid:list-export-history` — `(limit?: number)` → returns the last N exports for "Recent exports" UI surfaces.
+
+These are exposed on `window.mid` as `recordExport(...)` and `listExportHistory(limit)`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@sentry/node": "^10.50.0",
         "@types/pdfkit": "^0.17.6",
+        "better-sqlite3": "^12.9.0",
         "boxicons": "^2.1.4",
         "codemirror": "^6.0.2",
         "docx": "^9.6.1",
@@ -35,6 +36,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@resvg/resvg-js": "^2.6.2",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/dompurify": "^3.2.0",
         "@types/lunr": "^2.3.7",
         "@types/mocha": "^10.0.10",
@@ -3524,6 +3526,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -5274,6 +5286,20 @@
       ],
       "license": "MIT"
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/binaryextensions": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
@@ -5290,13 +5316,20 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -5433,7 +5466,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5449,7 +5481,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -5760,9 +5791,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/chromium-pickle-js": {
       "version": "0.2.0",
@@ -6735,7 +6764,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -6751,9 +6779,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -6906,7 +6932,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -7508,7 +7533,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -7996,9 +8020,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "dev": true,
       "license": "(MIT OR WTFPL)",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -8235,6 +8257,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/filelist": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
@@ -8438,9 +8466,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "11.3.4",
@@ -8568,9 +8594,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "13.0.6",
@@ -9042,7 +9066,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9057,8 +9080,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "7.0.5",
@@ -9136,9 +9158,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/internmap": {
       "version": "2.0.3",
@@ -10456,7 +10476,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -10488,7 +10507,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10535,9 +10553,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.8.2",
@@ -10820,9 +10836,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -10844,9 +10858,7 @@
       "version": "3.89.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
       "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -11799,9 +11811,7 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -11920,7 +11930,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -12050,9 +12059,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -12238,9 +12245,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -12556,7 +12561,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12890,7 +12894,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12905,14 +12908,12 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12928,7 +12929,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -13128,9 +13128,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -13256,9 +13254,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13389,9 +13385,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -13403,9 +13397,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -13730,9 +13722,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -785,6 +785,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@sentry/node": "^10.50.0",
     "@types/pdfkit": "^0.17.6",
+    "better-sqlite3": "^12.9.0",
     "boxicons": "^2.1.4",
     "codemirror": "^6.0.2",
     "docx": "^9.6.1",
@@ -802,6 +803,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@resvg/resvg-js": "^2.6.2",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/dompurify": "^3.2.0",
     "@types/lunr": "^2.3.7",
     "@types/mocha": "^10.0.10",


### PR DESCRIPTION
## Summary
Closes #239 — replaces the \`<userData>/state.json\` blob with a per-install SQLite database at \`<userData>/mid.sqlite\`.

- Schema: \`settings\` (JSON-blob valued) · \`recent_files\` · \`pinned_folders\` · \`workspaces\` · \`warehouses\` · \`export_history\` (foundation for #238 history UI).
- One-shot migration: if \`state.json\` exists, hydrate every key into SQLite in a single transaction, rename to \`state.json.migrated\` (kept, not deleted, for defensive rollback). Idempotent.
- Renderer is untouched — \`readAppState\` / \`writeAppState\` project the DB into the existing \`AppState\` shape so \`mid:read-app-state\` and \`mid:patch-app-state\` keep their signatures.
- Two new IPCs: \`mid:record-export\` and \`mid:list-export-history\`.
- Docs: \`docs/sqlite-store.md\` covers schema, lifecycle, migration, and API.

## Test plan
- [ ] First launch on a clean profile: \`mid.sqlite\` created in \`<userData>\`, no \`state.json\` written.
- [ ] First launch with an existing \`state.json\`: settings/recents/pins/workspaces appear identical; \`state.json\` renamed to \`state.json.migrated\`.
- [ ] Second launch on a migrated profile: short-circuits (no work), settings persist.
- [ ] Open + close app — recent-files list survives.
- [ ] Toggle theme + change settings + restart — everything persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)