### PR TITLE
fix(desktop): rebuild better-sqlite3 against Electron ABI on install (#258)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
+        "@electron/rebuild": "^4.0.4",
         "@eslint/js": "^10.0.1",
         "@resvg/resvg-js": "^2.6.2",
         "@types/better-sqlite3": "^7.6.13",

--- a/package.json
+++ b/package.json
@@ -753,6 +753,8 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
+    "postinstall": "electron-rebuild -w better-sqlite3",
+    "rebuild:native": "electron-rebuild -f -w better-sqlite3",
     "compile": "npm run compile:extension && npm run compile:webview && npm run compile:mcp",
     "compile:extension": "tsc -p ./",
     "compile:webview": "esbuild src/webview/main.ts --bundle --outfile=out/webview/main.js --format=iife --target=es2020 --platform=browser",
@@ -801,6 +803,7 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
+    "@electron/rebuild": "^4.0.4",
     "@eslint/js": "^10.0.1",
     "@resvg/resvg-js": "^2.6.2",
     "@types/better-sqlite3": "^7.6.13",


### PR DESCRIPTION
## Summary
Hotfix for #258 — \`better-sqlite3\`'s native \`.node\` binary was built against the system Node ABI (\`NODE_MODULE_VERSION\` 127), but Electron embeds its own Node (ABI 145). Loading the module from \`main.ts\` crashed the store introduced in PR #257, and with it every \`readAppState\` / \`writeAppState\` call — the user couldn't even open a workspace.

Add \`@electron/rebuild\` as a devDependency and a \`postinstall\` script that recompiles \`better-sqlite3\` against Electron immediately after \`npm install\`. Also add an explicit \`rebuild:native\` script for forced re-runs.

Verified: \`./node_modules/.bin/electron out/electron/main.js\` now logs \`[mid] migrated legacy state.json into SQLite\` and proceeds normally.

Closes #258

## Test plan
- [ ] Fresh \`npm install\` ends with the native module rebuilt.
- [ ] \`npm run dev:electron\` opens a window with no \`NODE_MODULE_VERSION\` error in the console.
- [ ] Open a folder → settings persist → restart → settings still there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)