### PR TITLE
feat(desktop): looser code PNG padding + table-as-PNG export (#260, #261)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -1121,11 +1121,70 @@ select.mid-settings-control {
 /* Gradient backdrop for code-block PNG export (Carbon-style) */
 .mid-code-export-bg {
   display: inline-block;
-  padding: 60px;
+  padding: 96px;
   width: max-content;
 }
 .mid-code-export-bg .mid-code-window {
   box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+/* Loosen the inner code padding when captured for export — the live preview
+   keeps its tighter ~16px padding so terminal-feel reading isn't airy. */
+.mid-code-export-bg .mid-code-window > pre {
+  padding: 28px var(--mid-space-6);
+}
+
+/* Generic chrome window used by table-as-PNG export (#261). Mirrors
+   `.mid-code-window` visually so the brand stays consistent. */
+.mid-export-window {
+  position: relative;
+  border-radius: var(--mid-radius-md);
+  overflow: hidden;
+  background: var(--mid-bg);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+.mid-export-window-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: var(--mid-space-3);
+  padding: 8px var(--mid-space-3);
+  background: var(--mid-surface);
+  border-bottom: 1px solid var(--mid-border);
+  user-select: none;
+}
+.mid-export-window-dots { display: inline-flex; gap: 6px; align-items: center; }
+.mid-export-window-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.mid-export-window-dot--red { background: #ff5f57; }
+.mid-export-window-dot--amber { background: #febc2e; }
+.mid-export-window-dot--green { background: #28c840; }
+.mid-export-window-title {
+  text-align: center;
+  font-family: var(--mid-font-mono);
+  font-size: 12px;
+  color: var(--mid-fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mid-export-window-spacer { width: 60px; }
+.mid-export-window > .mid-export-window-body { padding: var(--mid-space-4); }
+/* When the table is rendered inside the export chrome it shouldn't scroll —
+   the full content needs to be in the snapshot. */
+.mid-export-window .mid-data-table {
+  margin: 0;
+  border: 0;
+  box-shadow: none;
+}
+.mid-export-window .mid-dt-toolbar,
+.mid-export-window .mid-dt-footer { display: none; }
+.mid-export-window .mid-dt-scroll {
+  overflow: visible !important;
+  max-height: none !important;
 }
 
 /* Code-block toolbar (Copy / Download / Image / Lines) + language badge */

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -1309,6 +1309,7 @@ function attachTableTools(scope: HTMLElement): void {
       const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
       openContextMenu([
         { icon: 'copy', label: 'Copy as Markdown', action: () => copyTableAsMarkdown(headers, getFiltered()) },
+        { icon: 'image', label: 'Export as PNG', action: () => void exportTableAsPNG(card) },
         { icon: 'download', label: 'Download CSV', action: () => downloadTable(headers, getFiltered(), 'csv') },
         { icon: 'download', label: 'Download Excel (.xlsx)', action: () => downloadTable(headers, getFiltered(), 'xlsx') },
         { icon: 'github', label: 'Share to Google Sheets', action: () => void shareTableToSheets(headers, getFiltered()) },
@@ -1437,6 +1438,7 @@ function attachTableTools(scope: HTMLElement): void {
       e.stopPropagation();
       openContextMenu([
         { icon: 'copy', label: 'Copy as Markdown', action: () => copyTableAsMarkdown(headers, getFiltered()) },
+        { icon: 'image', label: 'Export as PNG', action: () => void exportTableAsPNG(card) },
         { icon: 'download', label: 'Download CSV', action: () => downloadTable(headers, getFiltered(), 'csv') },
         { icon: 'download', label: 'Download Excel (.xlsx)', action: () => downloadTable(headers, getFiltered(), 'xlsx') },
         { icon: 'github', label: 'Share to Google Sheets', action: () => void shareTableToSheets(headers, getFiltered()) },
@@ -1471,6 +1473,65 @@ function copyTableAsMarkdown(headers: HTMLTableCellElement[], rows: HTMLTableRow
     ...rows.map(r => `| ${rowToValues(r).join(' | ')} |`),
   ];
   void navigator.clipboard.writeText(lines.join('\n'));
+}
+
+/**
+ * Snapshot the live DataTable card into a PNG. Wraps the card in chromed export
+ * window + (optional) gradient backdrop, off-screen, captures via html-to-image,
+ * removes the temp DOM. Mirrors exportCodeBlockAsPNG visually (#260, #261).
+ */
+async function exportTableAsPNG(card: HTMLElement): Promise<void> {
+  const filename = uniqueExportName('table', 'png');
+  const gradient = CODE_EXPORT_GRADIENTS[settings.codeExportGradient];
+
+  // Clone the card and inline styles needed for full-content render.
+  const cardClone = card.cloneNode(true) as HTMLElement;
+
+  const win = document.createElement('div');
+  win.className = 'mid-export-window';
+  win.innerHTML =
+    '<div class="mid-export-window-header">' +
+      '<div class="mid-export-window-dots">' +
+        '<span class="mid-export-window-dot mid-export-window-dot--red"></span>' +
+        '<span class="mid-export-window-dot mid-export-window-dot--amber"></span>' +
+        '<span class="mid-export-window-dot mid-export-window-dot--green"></span>' +
+      '</div>' +
+      '<div class="mid-export-window-title">table</div>' +
+      '<div class="mid-export-window-spacer"></div>' +
+    '</div>';
+  const body = document.createElement('div');
+  body.className = 'mid-export-window-body';
+  body.appendChild(cardClone);
+  win.appendChild(body);
+
+  const wrapper = document.createElement('div');
+  wrapper.style.position = 'fixed';
+  wrapper.style.left = '0';
+  wrapper.style.top = '0';
+  wrapper.style.transform = 'translate(-200vw, 0)';
+  wrapper.style.pointerEvents = 'none';
+  if (gradient) {
+    wrapper.className = 'mid-code-export-bg';
+    wrapper.style.background = gradient;
+  } else {
+    wrapper.style.padding = '32px';
+    wrapper.style.background = getComputedStyle(document.documentElement).getPropertyValue('--mid-bg').trim() || '#0d1117';
+  }
+  wrapper.appendChild(win);
+  document.body.appendChild(wrapper);
+  try {
+    await new Promise(resolve => requestAnimationFrame(() => resolve(null)));
+    const dataUrl = await toPng(wrapper, {
+      pixelRatio: 2,
+      style: { transform: 'none' },
+    });
+    const a = document.createElement('a');
+    a.href = dataUrl;
+    a.download = filename;
+    a.click();
+  } finally {
+    wrapper.remove();
+  }
 }
 
 async function shareTableToSheets(headers: HTMLTableCellElement[], rows: HTMLTableRowElement[]): Promise<void> {

--- a/docs/desktop-export-image.md
+++ b/docs/desktop-export-image.md
@@ -1,0 +1,63 @@
+# PNG export — code blocks & tables
+
+Mark It Down can snapshot rich content into a PNG using a Carbon-style chrome window over a gradient backdrop. Two surfaces use this today:
+
+- **Code blocks** — right-click a code block in the preview → *Export as PNG*.
+- **Data tables** — toolbar export menu (or right-click a table) → *Export as PNG*.
+
+## What you get
+
+```
+┌──────────────────────────────────────────────────────┐
+│  ←──────── ~96px gradient backdrop ────────►         │
+│                                                      │
+│        ┌──────────────────────────────┐              │
+│        │ ●●●         snippet.ts        │   ← chrome  │
+│        ├──────────────────────────────┤              │
+│        │                              │              │
+│        │     code / table content     │              │
+│        │                              │              │
+│        └──────────────────────────────┘              │
+│                                                      │
+└──────────────────────────────────────────────────────┘
+```
+
+- The gradient comes from the user's *Code export gradient* setting (Settings → Appearance). Toggle it off to capture without a backdrop — the chrome alone is exported on the app's surface color.
+- The chrome window keeps macOS-style traffic-light dots and a centered title pill.
+- Filenames are stamped with a unique 8-char id per #238: `code--<id>.png`, `table--<id>.png`.
+
+## Code-block padding (#260)
+
+The export's inner padding is intentionally looser than the live preview:
+
+| Surface         | Padding inside chrome | Backdrop padding |
+|-----------------|------------------------|-------------------|
+| Live preview    | 16px (compact, terminal feel) | n/a |
+| PNG export      | 28px / 24px            | 96px |
+
+The live preview keeps its tighter padding so reading isn't airy. The export deliberately breathes so the screenshot looks like Carbon — generous gradient on all four sides plus a comfortable margin between the chrome border and the first character.
+
+## Table PNG (#261)
+
+The DataTable export menu has a new *Export as PNG* item between *Copy as Markdown* and *Download CSV*. Behavior:
+
+- Snapshots the **filtered + sorted view** the user is looking at.
+- Hides the toolbar and pagination footer in the snapshot — the goal is a shareable image of the data, not the controls.
+- Removes the scroll cap (`overflow: visible`) so the *entire* visible page is captured even if it would normally be inside a scrollable area.
+- Wraps the same chrome window used by code-block exports for visual consistency.
+
+If the table is huge (hundreds of rows), the snapshot can become tall. Filter or paginate first — *Export as PNG* captures whatever's currently rendered.
+
+## Implementation
+
+Both flows live in `apps/electron/renderer/renderer.ts`:
+
+- `exportCodeBlockAsPNG(target)` — preserves the original code-window chrome.
+- `exportTableAsPNG(card)` — wraps the DataTable card in a generic `.mid-export-window` chrome before capture.
+
+CSS:
+- `.mid-code-export-bg` — backdrop wrapper (gradient + 96px padding).
+- `.mid-export-window` — generic chrome shared by tables (and reusable for any future "export X as PNG" surface).
+- `.mid-export-window .mid-data-table` — overrides scroll/border/shadow so the snapshot reads as one clean panel.
+
+Both helpers position the temporary capture node off-screen via `transform: translate(-200vw, 0)` rather than `opacity: 0` — html-to-image clones inline styles onto its captured root, so an opacity-hidden wrapper used to produce a fully-transparent PNG (#237).


### PR DESCRIPTION
## Summary
Two PNG-export improvements bundled because they share the same chrome+backdrop pipeline.

**#260 — code-block PNG felt cramped.**
- Backdrop padding 60→96px so the gradient is visible.
- Inner padding inside the chrome bumped to ~28/24px in export mode (live preview keeps its tight 16px so reading stays terminal-feel).

**#261 — DataTable can now export as PNG.**
- New \`Export as PNG\` item in the table export menu (and right-click).
- Snapshots the *filtered + sorted* view. Toolbar/footer hidden in the snapshot. Scroll wrapper expanded so the entire current page is rendered.
- Wraps the table card in a generic \`.mid-export-window\` chrome (traffic lights + title pill) over the same gradient backdrop code blocks use.
- Filename: \`table--<id>.png\` per #238.

Both helpers continue using the off-screen \`translate\` trick from #237 so the captured PNG never comes back transparent.

Docs: \`docs/desktop-export-image.md\`.

Closes #260
Closes #261

## Test plan
- [ ] Right-click a code block → Export as PNG → result has ~96px gradient on all sides and the code breathes inside the chrome.
- [ ] Toggle gradient OFF → no-backdrop branch still produces a clean PNG with the chrome alone.
- [ ] Open a markdown table → toolbar export menu shows *Export as PNG* between Copy and CSV.
- [ ] Filter the table → Export as PNG → filtered rows only.
- [ ] Sort a column → Export as PNG → reflects sort order.
- [ ] Right-click on the table card → same menu, including the new PNG item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)