### PR TITLE
feat(desktop): hardened-runtime + entitlements + macOS zip target for signed auto-update (#264, #265)

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Electron's V8 needs JIT under hardened runtime. -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <!-- Electron + libffmpeg need to allocate executable memory. -->
+  <key>com.apple.security.cs.allow-unsafe-dyld-environment-variables</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <!-- better-sqlite3 ships an unsigned native .node — let it load. -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <!-- Outbound network for: GitHub release polling (auto-updater),
+       gh CLI device-flow + repo list, optional MCP server traffic. -->
+  <key>com.apple.security.network.client</key>
+  <true/>
+  <!-- File picker access for opening folders + saving exports. -->
+  <key>com.apple.security.files.user-selected.read-write</key>
+  <true/>
+</dict>
+</plist>

--- a/docs/desktop-auto-update.md
+++ b/docs/desktop-auto-update.md
@@ -1,0 +1,67 @@
+# Desktop auto-update (Electron, GitHub Releases)
+
+The Electron app keeps itself current by polling GitHub Releases on launch and applying updates automatically when the user opts in.
+
+## How it works
+
+1. **You tag a new version** (e.g. `git tag v0.4.0 && git push origin v0.4.0`).
+2. **`.github/workflows/release.yml`** runs on tag push. The `electron` matrix job runs on macos-latest / windows-latest / ubuntu-latest, each calling `npx electron-builder --publish always`.
+3. **electron-builder uploads** the per-OS installer + a manifest file to the GitHub Release for that tag:
+   - macOS: `Mark It Down-X.Y.Z-arm64.dmg`, `…-x64.dmg`, `…-arm64-mac.zip`, `…-x64-mac.zip`, `latest-mac.yml`, `…blockmap`
+   - Windows: `Mark It Down Setup X.Y.Z.exe`, `latest.yml`
+   - Linux: `Mark It Down-X.Y.Z.AppImage`, `mark-it-down_X.Y.Z_amd64.deb`, `latest-linux.yml`
+4. **Running clients** (`apps/electron/main.ts → setupAutoUpdate()`) fire `autoUpdater.checkForUpdatesAndNotify()` on launch. electron-updater fetches `latest-mac.yml` / `latest.yml` / `latest-linux.yml`, compares the version, downloads the matching artifact in the background.
+5. **The user is prompted twice**:
+   - When the new version is detected → an info dialog ("Downloading in the background…").
+   - When the download finishes → a choice dialog: *Install on next launch* or *Restart and install now*.
+
+## What ships in the bundle
+
+The `publish` block in `package.json#build` is wired to GitHub:
+
+```json
+"publish": [{
+  "provider": "github",
+  "owner": "fadymondy",
+  "repo": "mark-it-down",
+  "releaseType": "release"
+}]
+```
+
+`electron-updater` reads the same block at runtime to know where to look. No separate URL or feed config.
+
+## Channels
+
+`process.env.MID_CHANNEL` (or the matching VSCode setting) drives the channel:
+
+| `MID_CHANNEL` | Behavior |
+|---|---|
+| unset / `latest` | Stable channel — only non-prerelease tags are offered |
+| `beta` | Pre-release tags (e.g. `v0.4.0-rc.1`) are also offered |
+
+The release workflow's `release-notes` step automatically marks any tag with a hyphen (`v0.4.0-rc.1`) as a GitHub pre-release, so the stable channel skips it.
+
+## What doesn't auto-update
+
+- **Dev builds** (`MID_DEV=1` or non-packaged) skip the entire flow — `setupAutoUpdate()` returns early with a console log.
+- **Unsigned macOS builds** can install fresh but can't apply updates — Apple Gatekeeper rejects the differential update on unsigned apps. See [docs/desktop-mac-signing.md](desktop-mac-signing.md) to wire signing.
+
+## Failure modes
+
+| Symptom in console | Cause | Fix |
+|---|---|---|
+| `checkForUpdatesAndNotify failed: Cannot find latest-mac.yml` | The release was published before the manifest was uploaded, OR the OS didn't run `electron-builder` for this tag | Re-run the failed CI job |
+| `code signature verification failed` on macOS update | Update was signed with a different identity than the running app | Don't rotate Developer ID mid-version. If you must, ship a fresh DMG and have users reinstall |
+| Auto-update dialog never appears | `setupAutoUpdate()` early-returns in dev (intentional). In packaged builds, check the GitHub Release exists and isn't marked prerelease | Confirm the release page shows the assets |
+
+## Manual check
+
+In the running app: **Help → Check for Updates** triggers `autoUpdater.checkForUpdates()` directly without waiting for the launch poll.
+
+## Where to look in the code
+
+- `apps/electron/main.ts` — `setupAutoUpdate()` (event wiring), `broadcastUpdateState()` (sync to renderer for the status bar), the `Help → Check for Updates` menu item.
+- `package.json#build.publish` — the GitHub provider config.
+- `.github/workflows/release.yml` — the CI pipeline that builds + uploads.
+- `docs/auto-update.md` — covers the full picture across both surfaces (extension + desktop) including channel detection.
+- `docs/releasing.md` — runbook for cutting a release.

--- a/docs/desktop-mac-signing.md
+++ b/docs/desktop-mac-signing.md
@@ -1,0 +1,81 @@
+# macOS code signing & notarization
+
+The macOS Electron build is signed with an Apple Developer ID and notarized via Apple's notary service so it installs without "unidentified developer" warnings and so `electron-updater` can apply over-the-air updates. All credentials live in GitHub Actions repository secrets — never committed.
+
+## TL;DR
+
+1. Apple Developer membership ($99/year).
+2. Export a `Developer ID Application` cert as a `.p12`.
+3. Generate an app-specific password at appleid.apple.com.
+4. Drop 5 secrets into the repo's Actions secrets.
+5. Push a `v*` tag → release workflow signs + notarizes automatically.
+
+## Required GitHub Actions secrets
+
+Repo → **Settings → Secrets and variables → Actions** → *New repository secret*:
+
+| Secret name | What it is |
+|---|---|
+| `MAC_CERTS` | Base64 of the `.p12` exported from Keychain Access (Developer ID Application cert + private key). The release workflow exposes it as `CSC_LINK` to electron-builder. |
+| `MAC_CERTS_PASSWORD` | Password you set when exporting the `.p12`. Exposed as `CSC_KEY_PASSWORD`. |
+| `APPLE_ID` | Apple ID email used for the developer account. |
+| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password from [appleid.apple.com → Sign-In and Security](https://appleid.apple.com). |
+| `APPLE_TEAM_ID` | 10-char team id (visible in Xcode → Settings → Accounts, or [developer.apple.com/account](https://developer.apple.com/account)). |
+
+When all five are set, the release workflow's `electron` matrix job exports them to env on the macOS runner before `npx electron-builder --publish always` runs. electron-builder picks them up automatically — no further config in `package.json`.
+
+## What the build config does
+
+`package.json#build.mac`:
+
+```json
+"hardenedRuntime": true,
+"gatekeeperAssess": false,
+"entitlements": "build/entitlements.mac.plist",
+"entitlementsInherit": "build/entitlements.mac.plist"
+```
+
+- **`hardenedRuntime`** is required for notarization. Without it, the notary service rejects the upload.
+- **`gatekeeperAssess: false`** skips an `spctl assess` step that sometimes reports false positives during the post-sign verify pass on the runner.
+- **Entitlements** point at [`build/entitlements.mac.plist`](../build/entitlements.mac.plist), which lists the minimum capabilities the hardened-runtime app needs:
+  - `com.apple.security.cs.allow-jit` — Electron's V8.
+  - `com.apple.security.cs.allow-unsigned-executable-memory` + `…allow-unsafe-dyld-environment-variables` — Electron's libffmpeg + native loaders.
+  - `com.apple.security.cs.disable-library-validation` — `better-sqlite3`'s unsigned native `.node` binary.
+  - `com.apple.security.network.client` — outbound network for auto-update / GitHub / MCP.
+  - `com.apple.security.files.user-selected.read-write` — the file picker.
+
+Don't add entitlements you don't need — every extra capability widens the attack surface and makes future App Store review harder.
+
+## First-time setup
+
+The full step-by-step (export the cert, generate the app password, find your team id, drop the secrets in) lives in [docs/releasing.md → "Setting up macOS code signing"](releasing.md#setting-up-macos-code-signing). That section was written when the auto-update plumbing was first added and is the canonical runbook.
+
+## Verifying
+
+After the next tagged release:
+
+1. Download the new `.dmg` from the GitHub Release page.
+2. Open it on a Mac that's never had Mark It Down installed.
+3. First-launch dialog should say *"Mark It Down is from an identified developer"* (NOT *"unidentified developer"*).
+4. Run `codesign --display --verbose=4 /Applications/Mark\ It\ Down.app` — output should show your team id and `Authority=Developer ID Application: …`.
+5. Run `spctl --assess --verbose --type install /Applications/Mark\ It\ Down.app` — should print `accepted source=Notarized Developer ID`.
+
+## Skipping signing (when secrets are absent)
+
+The workflow's env block names every secret unconditionally. If a secret is missing, GitHub Actions sets the env var to an empty string. electron-builder's behavior in that case:
+
+- No `CSC_LINK` → skip signing entirely. Build succeeds, produces an unsigned DMG that installs on first download but cannot be auto-updated by `electron-updater`.
+- `CSC_LINK` set but no `APPLE_ID` → sign but skip notarization. Installs without the Gatekeeper warning only on the same Mac that built it.
+- All five set → sign + notarize. Distributable, auto-updatable.
+
+## Cert rotation
+
+Developer ID Application certs are valid for ~5 years. Before expiry: re-export the cert, base64 it, replace `MAC_CERTS` and `MAC_CERTS_PASSWORD` in repo secrets. Apple ID + team id don't change.
+
+## Files of interest
+
+- [`build/entitlements.mac.plist`](../build/entitlements.mac.plist) — the hardened-runtime allow-list.
+- [`package.json#build.mac`](../package.json) — signing config.
+- [`.github/workflows/release.yml`](../.github/workflows/release.yml) — env block that maps secrets into electron-builder.
+- [`docs/releasing.md`](releasing.md) — full runbook including macOS signing setup.
+- [`docs/desktop-auto-update.md`](desktop-auto-update.md) — how the running app receives updates.

--- a/package.json
+++ b/package.json
@@ -64,9 +64,20 @@
     "mac": {
       "category": "public.app-category.productivity",
       "icon": "media/brand/icon.icns",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
       "target": [
         {
           "target": "dmg",
+          "arch": [
+            "arm64",
+            "x64"
+          ]
+        },
+        {
+          "target": "zip",
           "arch": [
             "arm64",
             "x64"


### PR DESCRIPTION
## Summary
Closes #264 and #265 — the missing pieces between \"electron-updater is imported\" and \"a tagged release produces a notarized, auto-updatable macOS DMG.\"

The release workflow + GH Releases publish target + in-app auto-update event flow were already in place from prior work. This PR adds:

**Signing**
- \`mac.hardenedRuntime: true\` (required for notarization).
- \`mac.gatekeeperAssess: false\` (skips a flaky post-sign verify step).
- \`mac.entitlements\` + \`mac.entitlementsInherit\` pointing at a new \`build/entitlements.mac.plist\` with the minimum capabilities the hardened-runtime app needs:
  - \`com.apple.security.cs.allow-jit\` (V8)
  - \`com.apple.security.cs.allow-unsigned-executable-memory\` (libffmpeg / native loaders)
  - \`com.apple.security.cs.disable-library-validation\` (better-sqlite3 native module)
  - \`com.apple.security.network.client\` (auto-update / GH / MCP)
  - \`com.apple.security.files.user-selected.read-write\` (file picker)

**Auto-update transport**
- Adds a macOS \`zip\` target alongside the DMG. \`electron-updater\` pulls the \`.zip\` for blockmap-based delta updates; without it auto-update can't apply on macOS.

**Docs**
- \`docs/desktop-auto-update.md\` — receiver-side flow, channels, failure modes.
- \`docs/desktop-mac-signing.md\` — signing config + verification steps + links to the canonical runbook in \`docs/releasing.md\`.

Workflow secrets (already documented in \`docs/releasing.md\`): \`MAC_CERTS\`, \`MAC_CERTS_PASSWORD\`, \`APPLE_ID\`, \`APPLE_APP_SPECIFIC_PASSWORD\`, \`APPLE_TEAM_ID\`. When present → signed + notarized. Absent → unsigned (still installs, can't auto-update).

## Test plan
- [ ] Local sanity: \`npm run compile:electron\` passes.
- [ ] Local unsigned build: \`npm run dist:electron\` produces a DMG + ZIP without trying to sign (fails fast if secrets aren't present — that's the intended dev-loop behavior).
- [ ] Push a \`v0.X.Y\` tag with the secrets configured → workflow's mac runner emits \`latest-mac.yml\` + \`*-mac.zip\` + signed \`.dmg\`.
- [ ] On a fresh Mac, install the prior unsigned build, then bump and reinstall the new signed build → first-launch dialog says \"identified developer\".
- [ ] From the new signed build, force a check (Help → Check for Updates) when an even-newer release exists → download + restart prompt fires.

#266 (Mac App Store target) stays separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)