### PR TITLE
fix(ci): vsix release race + release-notes decoupling (#269)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,15 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           VSIX=$(ls *.vsix | head -n 1)
+          # The electron matrix jobs run in parallel — one of them creates
+          # the GitHub Release on first `electron-builder --publish always`.
+          # vsix often gets there first, so make this idempotent: if the
+          # release doesn't exist yet, create it as a draft placeholder.
+          # The release-notes job rewrites the body afterwards, and
+          # electron-builder / release-notes flip off the draft state.
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" --draft --title "$TAG" --notes "Build in progress..."
+          fi
           gh release upload "$TAG" "$VSIX" --clobber
       - name: Publish to VSCode Marketplace
         if: ${{ env.VSCE_PAT != '' }}
@@ -76,8 +85,31 @@ jobs:
   release-notes:
     name: Generate release notes from CHANGELOG
     runs-on: ubuntu-latest
-    needs: [electron, vscode]
+    # Only gate on `electron` — that's the job whose first runner creates
+    # the GitHub Release. The `vscode` job is decoupled so a vsix-side
+    # failure (or a re-run) doesn't block notes from landing, and so
+    # release-notes can be re-run independently to fix a wrong body.
+    needs: [electron]
     steps:
+      - name: Wait for the GitHub Release to exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          # `electron` `needs` guarantees at least one matrix runner finished,
+          # but electron-builder publishes assets before flipping the draft
+          # off. Poll for up to ~60s in case the release record is still
+          # propagating.
+          for i in $(seq 1 30); do
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              echo "Release $TAG is visible."
+              exit 0
+            fi
+            echo "Waiting for release $TAG... ($i/30)"
+            sleep 2
+          done
+          echo "Release $TAG never showed up." >&2
+          exit 1
       - uses: actions/checkout@v4
       - name: Extract section for this version
         id: extract

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -83,8 +83,8 @@ Three parallel jobs:
 | Job | Where | What |
 |---|---|---|
 | `electron` | matrix: macos-latest / windows-latest / ubuntu-latest | `npm ci` → `npm run compile && npm run compile:electron` → `npx electron-builder --publish always`. Each runner builds + uploads its installers + the `latest-*.yml` metadata file to the new GitHub release. |
-| `vscode` | ubuntu-latest | `npm ci` → `npm run compile` → `npx vsce package --no-dependencies` → `gh release upload` the `.vsix`. If `VSCE_PAT` secret is set: also `npx vsce publish --packagePath *.vsix` to the Marketplace. |
-| `release-notes` | ubuntu-latest, depends on the two above | Extracts the matching `## [X.Y.Z]` section from CHANGELOG.md → `gh release edit --notes "$NOTES"`. |
+| `vscode` | ubuntu-latest | `npm ci` → `npm run compile` → `npx vsce package --no-dependencies`. If the GitHub Release doesn't exist yet (the electron matrix may not have created it), the job ensures a draft placeholder via `gh release create`, then `gh release upload --clobber` the `.vsix`. If `VSCE_PAT` secret is set: also `npx vsce publish --packagePath *.vsix` to the Marketplace. |
+| `release-notes` | ubuntu-latest, depends on `electron` only | Polls for the GitHub Release record (with a short backoff in case it's still propagating), then extracts the matching `## [X.Y.Z]` section from CHANGELOG.md → `gh release edit --notes "$NOTES"`. Decoupled from `vscode` so a `.vsix` retry never blocks the release body update — and so release-notes can be re-run independently to fix a wrong body. |
 
 Watch in the Actions tab of the repo. All three should go green.
 


### PR DESCRIPTION
Closes #269.

## Problem
On the v0.2.0 tag push the `vscode` job failed at `gh release upload` with `release not found`. The matrix `electron` jobs and the `vscode` job kick off in parallel — whichever electron runner finishes its first `electron-builder --publish always` is the one that creates the GitHub Release. The vsix job is fast and frequently gets there first, before any release exists to upload to.

## Fix (`.github/workflows/release.yml` only)

1. **Idempotent vsix upload.** Before `gh release upload`, the job runs `gh release view "$TAG"` and, if missing, creates a draft placeholder (`gh release create "$TAG" --draft --title "$TAG" --notes "Build in progress..."`), then uploads with `--clobber`. electron-builder + the release-notes job both end up rewriting the body and flipping off the draft state, so the placeholder is invisible by the time CI completes.
2. **`release-notes` decoupled from `vscode`.** `needs: [electron]` (was `[electron, vscode]`). A vsix retry never blocks notes from landing, and release-notes can be re-run independently to fix a wrong body.
3. **Polling step in `release-notes`.** Up to ~60s of `gh release view` polling before editing the body, covering the gap between electron-builder publishing and GitHub's release index becoming queryable. Belt-and-braces for the new ordering.

## Acceptance
- vsix job no longer fails on a first run when the electron jobs haven't created the release yet.
- release-notes runs regardless of vsix outcome and is re-runnable independently.

## Out of scope
- `apps/electron/main.ts` packaging fixes (separate hotfix).
- `package.json#build.mac.*` universal target (separate hotfix).

## Test plan
- [ ] Cut a pre-release tag (e.g. `v0.3.0-rc.1`) and watch all three jobs finish on the first run, including a fast-vsix scenario.
- [ ] Re-run the `release-notes` job in isolation on an existing release to confirm decoupling.
- [ ] Confirm electron-builder's publish on macOS runner still flips the release out of draft + uploads its DMG/ZIP/yml metadata.