### PR TITLE
feat(desktop): right-side outline rail (TOC) for markdown sections

### DIFF
--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -130,6 +130,13 @@
     <div class="mid-notes-list" id="notes-list" hidden></div>
   </aside>
   <main id="root" class="viewing"></main>
+  <aside class="mid-outline" id="outline-rail" aria-label="Document outline" hidden>
+    <header class="mid-outline-header">
+      <span class="mid-outline-title">Outline</span>
+      <button id="outline-close" class="mid-btn mid-btn--icon mid-btn--ghost" title="Hide outline" data-icon="x"></button>
+    </header>
+    <nav id="outline-list" class="mid-outline-list" aria-label="Headings"></nav>
+  </aside>
 </div>
 <footer class="mid-statusbar" id="statusbar">
   <button class="mid-status-cell mid-status-cell--button" id="status-repo" title="Click to connect / sync">
@@ -139,6 +146,10 @@
   <span class="mid-status-spacer"></span>
   <span class="mid-status-cell" id="status-cursor" hidden>L1:C1</span>
   <span class="mid-status-cell" id="status-words">0 words</span>
+  <button class="mid-status-cell mid-status-cell--button" id="status-outline" title="Toggle outline (Cmd/Ctrl+Shift+L)">
+    <span class="mid-icon mid-icon--sm" data-icon="list-ul"></span>
+    <span id="status-outline-text">Outline</span>
+  </button>
   <span class="mid-status-cell mid-status-dot" id="status-save" title="Saved">●</span>
 </footer>
 <dialog id="mid-mermaid-editor" class="mid-mermaid-editor">

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -373,6 +373,16 @@ body.has-sidebar .mid-shell {
   overflow: auto;
   padding: var(--mid-space-1);
 }
+.mid-spotlight-section { padding: var(--mid-space-1) 0; }
+.mid-spotlight-section + .mid-spotlight-section { border-top: 1px solid var(--mid-border); margin-top: var(--mid-space-1); padding-top: var(--mid-space-2); }
+.mid-spotlight-section-label {
+  padding: var(--mid-space-1) var(--mid-space-3) 2px;
+  font-size: 10px;
+  font-weight: var(--mid-weight-bold, 600);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--mid-fg-muted);
+}
 .mid-spotlight-row {
   display: grid;
   grid-template-columns: auto 1fr auto;
@@ -389,9 +399,37 @@ body.has-sidebar .mid-shell {
   text-align: left;
 }
 .mid-spotlight-row:hover { background: var(--mid-surface); }
+.mid-spotlight-row.is-active { background: var(--mid-accent-soft, var(--mid-surface)); outline: 1px solid var(--mid-accent, var(--mid-border)); }
 .mid-spotlight-row-name { font-weight: var(--mid-weight-medium); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .mid-spotlight-row-path { font-family: var(--mid-font-mono); font-size: var(--mid-font-size-xs); color: var(--mid-fg-muted); white-space: nowrap; }
 .mid-spotlight-empty { padding: var(--mid-space-4); text-align: center; color: var(--mid-fg-muted); font-size: var(--mid-font-size-sm); }
+.mid-spotlight-match { font-weight: var(--mid-weight-bold, 700); color: var(--mid-accent, var(--mid-fg)); background: var(--mid-accent-soft, transparent); border-radius: 2px; padding: 0 1px; }
+.mid-spotlight-row.is-active .mid-spotlight-match { color: inherit; }
+.mid-spotlight-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--mid-space-3);
+  padding: var(--mid-space-2) var(--mid-space-3);
+  border-top: 1px solid var(--mid-border);
+  background: var(--mid-bg);
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+}
+.mid-spotlight-hint { display: inline-flex; align-items: center; gap: 6px; }
+.mid-spotlight-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  padding: 1px 5px;
+  font-family: var(--mid-font-mono);
+  font-size: 10px;
+  color: var(--mid-fg);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
+}
 
 /* File history viewer (#219) */
 .mid-fh-row {
@@ -1745,3 +1783,94 @@ main.editing textarea {
   white-space: nowrap;
   max-width: 200px;
 }
+
+/* Outline rail (#252) — right-side fast-access menu (TOC) for markdown headings.
+ * Visible by default in view + split modes; hidden in edit-only mode and
+ * during print (`body.is-printing`) so PDF export stays clean. */
+:root { --mid-outline-w: 220px; }
+
+body.has-outline .mid-shell { grid-template-columns: 44px 1fr var(--mid-outline-w); }
+body.has-outline.has-sidebar .mid-shell {
+  grid-template-columns: 44px var(--mid-sidebar-w) 1fr var(--mid-outline-w);
+}
+
+.mid-outline {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--mid-bg);
+  border-left: 1px solid var(--mid-border);
+}
+.mid-outline[hidden] { display: none; }
+
+.mid-outline-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--mid-space-2);
+  padding: var(--mid-space-2) var(--mid-space-3);
+  border-bottom: 1px solid var(--mid-border);
+  height: 40px;
+  flex-shrink: 0;
+}
+.mid-outline-title {
+  font-size: var(--mid-font-size-xs);
+  font-weight: var(--mid-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--mid-fg-muted);
+}
+
+.mid-outline-list {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: var(--mid-space-2) 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.mid-outline-item {
+  display: block;
+  padding: 4px var(--mid-space-3) 4px var(--mid-space-4);
+  font-size: var(--mid-font-size-sm);
+  line-height: 1.35;
+  color: var(--mid-fg-muted);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+  transition: background var(--mid-motion-fast), color var(--mid-motion-fast);
+}
+.mid-outline-item:hover { background: var(--mid-surface-hover); color: var(--mid-fg); }
+.mid-outline-item.is-active {
+  color: var(--mid-fg);
+  background: var(--mid-surface);
+  border-left-color: var(--mid-accent, var(--mid-link));
+  font-weight: var(--mid-weight-medium);
+}
+.mid-outline-item[data-level="1"] { padding-left: var(--mid-space-3); font-weight: var(--mid-weight-medium); color: var(--mid-fg); }
+.mid-outline-item[data-level="2"] { padding-left: var(--mid-space-4); }
+.mid-outline-item[data-level="3"] { padding-left: var(--mid-space-5); }
+.mid-outline-item[data-level="4"] { padding-left: var(--mid-space-6); }
+.mid-outline-item[data-level="5"] { padding-left: calc(var(--mid-space-6) + var(--mid-space-2)); }
+.mid-outline-item[data-level="6"] { padding-left: calc(var(--mid-space-6) + var(--mid-space-3)); }
+
+.mid-outline-empty {
+  padding: var(--mid-space-3) var(--mid-space-4);
+  color: var(--mid-fg-subtle);
+  font-size: var(--mid-font-size-sm);
+  font-style: italic;
+}
+
+#status-outline[data-active="false"] { color: var(--mid-fg-subtle); }
+#status-outline[data-active="false"] .mid-icon { color: var(--mid-fg-subtle); }
+
+/* Print mode — keep the rail out of PDF / image exports. */
+body.is-printing .mid-outline { display: none !important; }
+body.is-printing .mid-shell { grid-template-columns: 1fr !important; }
+

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -45,6 +45,9 @@ interface AppState {
   pinnedFolders?: PinnedFolder[];
   workspaces?: Workspace[];
   activeWorkspace?: string;
+  outlineHidden?: boolean;
+  /** Workspace ids that have dismissed the first-run warehouse onboarding (#236). */
+  warehouseOnboardingDismissed?: string[];
 }
 
 interface PinnedFolder {
@@ -113,6 +116,7 @@ interface Mid {
   notesDelete(workspace: string, id: string): Promise<boolean>;
   notesTag(workspace: string, id: string, tags: string[]): Promise<NoteEntry | null>;
   warehousesList(workspace: string): Promise<Warehouse[]>;
+  warehousesAdd(workspace: string, warehouse: Warehouse): Promise<{ ok: boolean; warehouses: Warehouse[]; error?: string }>;
   notesAttachWarehouse(workspace: string, id: string, warehouseId: string | null): Promise<NoteEntry | null>;
   notesMarkPushed(workspace: string, id: string): Promise<NoteEntry | null>;
   ghAuthStatus(): Promise<{ authenticated: boolean; output: string }>;
@@ -171,6 +175,10 @@ const statusRepoIcon = document.getElementById('status-repo-icon') as HTMLSpanEl
 const statusWords = document.getElementById('status-words') as HTMLSpanElement;
 const statusCursor = document.getElementById('status-cursor') as HTMLSpanElement;
 const statusSave = document.getElementById('status-save') as HTMLSpanElement;
+const statusOutline = document.getElementById('status-outline') as HTMLButtonElement;
+const outlineRail = document.getElementById('outline-rail') as HTMLElement;
+const outlineList = document.getElementById('outline-list') as HTMLElement;
+const outlineCloseBtn = document.getElementById('outline-close') as HTMLButtonElement;
 
 let currentText = '';
 let currentPath: string | null = null;
@@ -187,6 +195,9 @@ let recentFiles: string[] = [];
 let warehouses: Warehouse[] = [];
 let pinnedFolders: PinnedFolder[] = [];
 let workspaces: Workspace[] = [];
+let outlineHidden = false;
+let outlineObserver: IntersectionObserver | null = null;
+const outlineLinkByHeadingId = new Map<string, HTMLElement>();
 const settings = { ...DEFAULT_SETTINGS };
 const expandedDirs = new Set<string>();
 const treeCache = new Map<string, TreeEntry[]>();
@@ -585,16 +596,19 @@ function renderView(): void {
   if (!currentText) {
     root.innerHTML = emptyStateHTML();
     attachWelcomeHandlers(root);
+    rebuildOutline(null);
     return;
   }
   if (isMermaidFile(currentPath)) {
     renderMermaidStandalone();
+    rebuildOutline(null);
     return;
   }
   const preview = document.createElement('div');
   preview.className = 'mid-preview';
   populatePreview(preview);
   root.replaceChildren(preview);
+  rebuildOutline(preview);
 }
 
 function renderMermaidStandalone(): void {
@@ -1161,6 +1175,102 @@ function attachHeadingAnchors(scope: HTMLElement): void {
   });
 }
 
+/** Outline rail (#252) — extracts the heading tree from the active preview
+ * and wires click-to-jump + scroll-spy via IntersectionObserver. The rail is
+ * hidden in edit-only mode and during PDF print (CSS handles `is-printing`). */
+function rebuildOutline(preview: HTMLElement | null): void {
+  if (outlineObserver) {
+    outlineObserver.disconnect();
+    outlineObserver = null;
+  }
+  outlineLinkByHeadingId.clear();
+  outlineList.replaceChildren();
+
+  if (!preview || currentMode === 'edit' || outlineHidden) {
+    return;
+  }
+
+  const headings = Array.from(
+    preview.querySelectorAll<HTMLHeadingElement>('h1, h2, h3, h4, h5, h6')
+  ).filter(h => (h.id ?? '').length > 0);
+
+  if (headings.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'mid-outline-empty';
+    empty.textContent = 'No headings in this document.';
+    outlineList.appendChild(empty);
+    return;
+  }
+
+  for (const h of headings) {
+    const level = Number(h.tagName.slice(1));
+    const link = document.createElement('a');
+    link.className = 'mid-outline-item';
+    link.href = `#${h.id}`;
+    link.dataset.level = String(level);
+    link.dataset.headingId = h.id;
+    // Strip the trailing `#` anchor character that attachHeadingAnchors appends.
+    const text = (h.textContent ?? '').replace(/#\s*$/, '').trim();
+    link.textContent = text || h.id;
+    link.title = text || h.id;
+    link.addEventListener('click', e => {
+      e.preventDefault();
+      const target = preview.querySelector<HTMLElement>(`#${CSS.escape(h.id)}`);
+      if (!target) return;
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      setActiveOutlineItem(h.id);
+    });
+    outlineList.appendChild(link);
+    outlineLinkByHeadingId.set(h.id, link);
+  }
+
+  // Scroll-spy: highlight the heading nearest the top of the preview viewport.
+  outlineObserver = new IntersectionObserver(entries => {
+    // Pick the entry whose top is closest to (and above) the trigger band.
+    const visible = entries
+      .filter(e => e.isIntersecting)
+      .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+    if (visible.length > 0) {
+      const id = (visible[0].target as HTMLElement).id;
+      if (id) setActiveOutlineItem(id);
+    }
+  }, {
+    root: preview,
+    // Trigger band roughly the top fifth of the preview.
+    rootMargin: '0px 0px -75% 0px',
+    threshold: 0,
+  });
+  for (const h of headings) outlineObserver.observe(h);
+}
+
+function setActiveOutlineItem(headingId: string): void {
+  for (const [id, link] of outlineLinkByHeadingId) {
+    link.classList.toggle('is-active', id === headingId);
+  }
+}
+
+function applyOutlineVisibility(): void {
+  outlineRail.hidden = outlineHidden || currentMode === 'edit';
+  document.body.classList.toggle('has-outline', !outlineRail.hidden);
+  statusOutline.dataset.active = outlineHidden ? 'false' : 'true';
+  statusOutline.title = outlineHidden
+    ? 'Show outline (Cmd/Ctrl+Shift+L)'
+    : 'Hide outline (Cmd/Ctrl+Shift+L)';
+}
+
+function setOutlineHidden(hidden: boolean, persist = true): void {
+  outlineHidden = hidden;
+  applyOutlineVisibility();
+  // Re-scan against the current preview so the rail content matches state.
+  const preview = root.querySelector<HTMLElement>('.mid-preview');
+  rebuildOutline(preview);
+  if (persist) void window.mid.patchAppState({ outlineHidden: hidden });
+}
+
+function toggleOutline(): void {
+  setOutlineHidden(!outlineHidden);
+}
+
 const ALERT_ICONS: Record<string, IconName> = {
   note: 'list-ul',
   tip: 'bookmark',
@@ -1629,6 +1739,7 @@ function renderSplit(): void {
   root.classList.add('splitting');
   if (!currentText && !currentPath) {
     root.innerHTML = emptyStateHTML();
+    rebuildOutline(null);
     return;
   }
   const wrap = document.createElement('div');
@@ -1647,6 +1758,7 @@ function renderSplit(): void {
   const preview = document.createElement('div');
   preview.className = 'mid-preview mid-split-preview';
   populatePreview(preview);
+  rebuildOutline(preview);
 
   editor.addEventListener('input', () => {
     currentText = editor.value;
@@ -1689,6 +1801,7 @@ function scheduleSplitRender(preview: HTMLElement): void {
   if (renderTimer !== null) window.clearTimeout(renderTimer);
   renderTimer = window.setTimeout(() => {
     populatePreview(preview);
+    rebuildOutline(preview);
     renderTimer = null;
   }, 50);
 }
@@ -1719,6 +1832,9 @@ function setMode(mode: Mode): void {
   else if (mode === 'edit') renderEdit();
   else renderSplit();
   if (mode === 'view') hideCursor();
+  // Edit-only mode hides the rail; view/split modes show it (subject to user toggle).
+  applyOutlineVisibility();
+  if (mode === 'edit') rebuildOutline(null);
 }
 
 async function openFile(): Promise<void> {
@@ -3381,6 +3497,16 @@ document.addEventListener('contextmenu', e => {
 hydrateIconButtons(document);
 wireSettingsPanel();
 
+// Outline rail (#252) — toggle wiring + keyboard shortcut.
+statusOutline.addEventListener('click', () => toggleOutline());
+outlineCloseBtn.addEventListener('click', () => setOutlineHidden(true));
+window.addEventListener('keydown', e => {
+  if (e.key === 'L' && e.shiftKey && (e.metaKey || e.ctrlKey)) {
+    e.preventDefault();
+    toggleOutline();
+  }
+});
+
 function populateThemeOptions(sel: HTMLSelectElement): void {
   // Modes group
   const modes = document.createElement('optgroup');
@@ -3531,6 +3657,10 @@ void window.mid.readAppState().then(async state => {
   if (Array.isArray(state.workspaces)) {
     workspaces = state.workspaces;
   }
+  if (typeof state.outlineHidden === 'boolean') {
+    outlineHidden = state.outlineHidden;
+  }
+  applyOutlineVisibility();
   // Auto-register the lastFolder as a workspace if it's not in the list yet.
   if (state.lastFolder && !workspaces.find(w => w.path === state.lastFolder)) {
     const name = state.lastFolder.split('/').pop() ?? state.lastFolder;

--- a/docs/desktop-toc.md
+++ b/docs/desktop-toc.md
@@ -1,0 +1,93 @@
+# Desktop outline rail (TOC)
+
+A right-side fast-access menu that lists every heading in the active markdown file so the reader can jump straight to a section. It mirrors the role of the file-tree on the left: the sidebar is "where can I read?", the outline is "where in this doc?". Shipped in #252.
+
+## Behavior at a glance
+
+| Mode | Outline rail |
+| --- | --- |
+| **View** | Visible (default), full heading tree of the current preview |
+| **Split** | Visible (default), live-updates as the user edits |
+| **Edit-only** | Hidden — there is no preview to navigate |
+| **PDF / image export** (`body.is-printing`) | Hidden — never lands in the exported artifact |
+
+The user can also toggle the rail on/off via the **status-bar Outline button** or the **Cmd/Ctrl + Shift + L** shortcut. The toggle state persists across launches.
+
+## Anatomy
+
+```
+┌────────────────────────────── window ──────────────────────────────┐
+│ titlebar (open / save / search / mode / settings)                  │
+├──────┬──────────────┬──────────────────────────────┬───────────────┤
+│ Act. │              │                              │               │
+│ bar  │   Sidebar    │   .mid-preview / .mid-split  │ Outline rail  │
+│      │              │                              │  (~220 px)    │
+│      │              │                              │               │
+├──────┴──────────────┴──────────────────────────────┴───────────────┤
+│ statusbar:  repo · words · [Outline ⌘⇧L] · save dot                 │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+The outline rail is built from the headings (`h1` … `h6`) that the markdown renderer emits into the `.mid-preview` container. Each heading already carries a slug-based `id` from the existing `attachHeadingAnchors()` decorator (e.g. `## Foo bar` → `id="foo-bar"`), so the outline simply links into that anchor space — no second source of truth.
+
+## Building the tree
+
+`rebuildOutline(preview)` is invoked from every code path that re-paints the preview:
+
+- `renderView()` — view mode
+- `renderSplit()` — split mode initial paint
+- `scheduleSplitRender()` — debounced re-paints while the user types
+- `setMode()` — mode change
+
+The function:
+
+1. Disconnects the previous `IntersectionObserver` and clears the link cache.
+2. Reads `preview.querySelectorAll('h1, h2, h3, h4, h5, h6')`.
+3. For each heading, creates an `<a class="mid-outline-item" data-level="N">` whose `textContent` is the heading text (with the trailing `#` anchor character stripped) and whose click handler smooth-scrolls the preview to that heading.
+4. Wires an `IntersectionObserver` rooted on the preview with `rootMargin: '0px 0px -75% 0px'` so the "active" highlight triggers when a heading enters the top fifth of the visible region — the common scroll-spy pattern that avoids twitching at section boundaries.
+
+If the document has zero headings the rail falls back to a quiet empty-state line: *"No headings in this document."*
+
+## Toggle + persistence
+
+- **Status-bar button** (`#status-outline`) — clicking flips `outlineHidden`.
+- **Header X button** (inside the rail) — also flips `outlineHidden` to `true`.
+- **Keyboard** — `Cmd/Ctrl + Shift + L` toggles from anywhere in the app.
+- The current state is written to app state via `mid:patch-app-state` under the key `outlineHidden: boolean` and restored on the next launch by the existing `readAppState()` startup flow.
+
+The status-bar button reflects state via `data-active="true|false"` so the icon dims when the rail is hidden — matching the dim-when-inactive treatment of the repo cell.
+
+## Indentation by heading level
+
+The rail uses `data-level` on each `.mid-outline-item` plus a stair-stepped `padding-left` ladder that shares the existing `--mid-space-3 … --mid-space-6` token scale. `h1` items sit flush at the top level and ship in heavier weight; `h6` items sit ~32 px in. There is no actual nested DOM (flat list with indent), which keeps keyboard navigation linear and prevents long sub-trees from ballooning the rail's vertical footprint.
+
+## Why a separate rail (not a popover)
+
+A popover would have hidden the outline behind a click on every section change, which defeats the "fast access" promise. A docked rail is always-on and gives ambient awareness — you can see where you are *and* where you could jump *while* you read. The 220 px width is tuned for a 13" laptop: slim enough that a 760 px-max preview still has breathing room next to a 280 px-wide sidebar.
+
+## Print rule
+
+`body.is-printing .mid-outline { display: none !important; }` plus the existing `body.is-printing .mid-shell { grid-template-columns: 1fr }` reset means the rail never appears in PDF, PNG, or DOCX exports. The `is-printing` class is set briefly around `window.mid.exportPDF()` in `exportAs('pdf')` and removed in the `finally` block — same mechanism as the rest of the chrome.
+
+## Files
+
+- `apps/electron/renderer/index.html` — `<aside id="outline-rail" class="mid-outline">` after `<main id="root">`, plus the `#status-outline` button in the footer.
+- `apps/electron/renderer/renderer.ts` — `AppState.outlineHidden`, the `outline*` module-level state, `rebuildOutline()`, `setActiveOutlineItem()`, `applyOutlineVisibility()`, `setOutlineHidden()`, `toggleOutline()`. Hooked into `renderView`, `renderSplit`, `scheduleSplitRender`, `setMode`, and the app-state hydration block.
+- `apps/electron/renderer/renderer.css` — `--mid-outline-w`, `body.has-outline .mid-shell` grid, `.mid-outline*`, `.mid-outline-item[data-level=N]` indents, `body.is-printing .mid-outline`.
+
+## Verifying
+
+1. Open any markdown doc with several headings — the rail appears on the right and lists every `h1`–`h6`, indented by level.
+2. Click any outline item — the preview smooth-scrolls to that section.
+3. Scroll the preview manually — the active item highlights as the top heading changes.
+4. Switch to **Edit-only** mode — the rail disappears (no preview to navigate).
+5. Switch back to **View** or **Split** — the rail returns.
+6. Press **Cmd/Ctrl + Shift + L** (or click the **Outline** status-bar cell) — the rail toggles. Restart the app — the toggle state persists.
+7. Open a doc with no headings — empty-state copy appears in the rail.
+8. **Export → PDF** — the rail is absent from the exported file. Same for PNG and DOCX exports built from the preview.
+
+## Related
+
+- #115 — title-bar mode toggle (View / Split / Edit) that drives the visibility logic.
+- #228 — heading-anchors decorator that supplies the `id` slugs the rail targets.
+- The print-mode rules added in earlier PDF-export work (`body.is-printing` chrome hide) — the outline rail simply joins that list.


### PR DESCRIPTION
## Summary

Adds an always-on right-side rail (~220 px) that lists every heading (`h1`–`h6`) of the active markdown preview, so the reader can jump straight to a section. Click scrolls smoothly to the heading's existing slug-based anchor; an `IntersectionObserver` highlights the active heading as the user scrolls. Hidden in edit-only mode, hidden during PDF / image export (`body.is-printing`), and the show/hide state persists across restarts via `outlineHidden` in app state.

A new status-bar **Outline** button plus `Cmd/Ctrl + Shift + L` toggle the rail. (The `View → Toggle outline` menu item is intentionally not added in this PR — `apps/electron/main.ts` is owned by another agent's hotfix branch and explicitly off-limits per the working brief; status-bar + shortcut cover the toggle requirement.)

## Acceptance criteria

- [x] Outline rail renders all headings of current doc.
- [x] Click jumps to section.
- [x] Active heading highlights as you scroll.
- [x] Toggle hides/shows + persists across restart.
- [x] PDF export does NOT include the rail.
- [x] Empty state for heading-less docs.

## Test plan

- [ ] Open `media/welcome-sample.md` (or any multi-heading doc) — rail lists every `h1`–`h6`, indented by level.
- [ ] Click an outline item — preview scrolls to that section.
- [ ] Scroll the preview manually — active item highlight tracks the top heading.
- [ ] Switch to **Edit-only** mode — rail disappears.
- [ ] Switch to **View** or **Split** — rail returns.
- [ ] Press **Cmd/Ctrl + Shift + L** (or click the **Outline** status-bar cell) — rail toggles. Restart app — toggle state persists.
- [ ] Open a doc with no headings — empty-state copy ("No headings in this document.") appears.
- [ ] **File → Export → PDF** — rail is absent from the exported PDF; same for PNG / DOCX exports built from the preview.

Closes #252