### PR TITLE
feat(desktop): Mac App Store target — opt-in sibling to DMG (#266)

### DIFF
--- a/.github/workflows/release-mas.yml
+++ b/.github/workflows/release-mas.yml
@@ -1,0 +1,114 @@
+name: Release (Mac App Store)
+
+# Optional sibling release pipeline that builds + signs + (optionally)
+# uploads the Mac App Store .pkg. Kept entirely separate from
+# .github/workflows/release.yml so:
+#   - regular DMG releases stay lean (no wasted MAS minutes / cert lookups)
+#   - opting into MAS is a one-flag thing (MAS_ENABLED=1), reversible
+#   - reviewer-required submission failures don't taint the main release
+#     workflow's status
+#
+# Triggers:
+#   - push of a `v*.*.*` / `v*.*.*-*` tag, ONLY when repo variable
+#     `MAS_ENABLED=1` is set (Settings → Variables → Actions).
+#   - workflow_dispatch with input `mas_enabled=true` (manual one-off).
+#
+# Required secrets (only when this workflow runs):
+#   - MAS_CERTS               — base64-encoded .p12 with the
+#                               "3rd Party Mac Developer Application" +
+#                               "3rd Party Mac Developer Installer" certs.
+#   - MAS_CERTS_PASSWORD      — password for the .p12.
+#   - MAS_PROVISIONING_PROFILE — base64-encoded .provisionprofile from
+#                                Apple Developer (Mac App Store distribution).
+#   - APPLE_ID                — Apple ID for App Store Connect upload.
+#   - APPLE_APP_SPECIFIC_PASSWORD — app-specific password for the Apple ID.
+#   - APPLE_TEAM_ID           — 10-char team identifier.
+#
+# See docs/desktop-mac-app-store.md for the full setup runbook.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-*'
+  workflow_dispatch:
+    inputs:
+      mas_enabled:
+        description: 'Build the MAS .pkg for this run'
+        required: true
+        default: 'false'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-mas-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mas:
+    name: Mac App Store (.pkg)
+    runs-on: macos-latest
+    # Gate: opt-in only. The repo variable MAS_ENABLED=1 enables it for
+    # tag pushes; workflow_dispatch can also force it on for a one-off run.
+    if: ${{ vars.MAS_ENABLED == '1' || github.event.inputs.mas_enabled == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build extension + electron
+        run: npm run compile && npm run compile:electron
+      - name: Decode provisioning profile
+        env:
+          MAS_PROVISIONING_PROFILE: ${{ secrets.MAS_PROVISIONING_PROFILE }}
+        run: |
+          if [ -z "$MAS_PROVISIONING_PROFILE" ]; then
+            echo "MAS_PROVISIONING_PROFILE secret is not set; cannot build MAS target." >&2
+            exit 1
+          fi
+          echo "$MAS_PROVISIONING_PROFILE" | base64 --decode > build/embedded.provisionprofile
+      - name: Build MAS .pkg
+        # `--mac mas` selects the `build.mas` block from package.json.
+        # CSC_LINK / CSC_KEY_PASSWORD point electron-builder at the .p12
+        # containing both the App Distribution and Installer certs.
+        run: npx electron-builder --mac mas --publish never
+        env:
+          CSC_LINK: ${{ secrets.MAS_CERTS }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAS_CERTS_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      - name: List built artifacts
+        run: ls -la dist/electron/ || true
+      - name: Upload .pkg as workflow artifact
+        # We deliberately do NOT attach the .pkg to the GitHub Release —
+        # MAS .pkg files only validate against the App Store and are not
+        # useful to download directly. Keep them as a workflow artifact for
+        # manual `xcrun altool --upload-app` / Transporter submission.
+        uses: actions/upload-artifact@v4
+        with:
+          name: mark-it-down-mas-pkg
+          path: dist/electron/*.pkg
+          if-no-files-found: error
+          retention-days: 30
+      - name: Submit to App Store Connect
+        # Optional final step. Skipped unless the runner has a Transporter
+        # JWT or the legacy altool flow is wired in; left as a guarded
+        # placeholder so first-time MAS submitters can do it manually
+        # from their workstation following docs/desktop-mac-app-store.md.
+        if: ${{ vars.MAS_AUTO_SUBMIT == '1' }}
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          PKG=$(ls dist/electron/*.pkg | head -n 1)
+          echo "Submitting $PKG via notarytool..."
+          xcrun altool --upload-app --type osx --file "$PKG" \
+            --username "$APPLE_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --apiIssuer "$APPLE_TEAM_ID"

--- a/build/entitlements.mas.inherit.plist
+++ b/build/entitlements.mas.inherit.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Mac App Store entitlements for Electron child / helper processes
+  (Renderer, GPU, Network, Plugin, Crashpad).
+
+  These inherit the parent's sandbox state via:
+    com.apple.security.app-sandbox = true
+    com.apple.security.inherit     = true
+
+  No additional capabilities are granted here — the helpers don't need them
+  because they communicate with the parent via Electron's IPC, and IPC is
+  not gated by an entitlement.
+-->
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.inherit</key>
+  <true/>
+</dict>
+</plist>

--- a/build/entitlements.mas.plist
+++ b/build/entitlements.mas.plist
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Mac App Store entitlements for the main (parent) Electron process.
+
+  Notes vs build/entitlements.mac.plist (the Developer ID / DMG variant):
+    - sandbox is REQUIRED on the App Store; the DMG variant doesn't run sandboxed.
+    - allow-jit, allow-unsigned-executable-memory, and disable-library-validation
+      are NOT permitted on MAS submissions and are intentionally absent here.
+    - allow-unsafe-dyld-environment-variables is also stripped — App Store
+      Review will reject the binary if any of those are present.
+    - Network client is allowed for: GitHub release polling, gh CLI device-flow,
+      MCP traffic.
+    - File picker access is granted via user-selected.read-write — the sandbox
+      will let the user widen scope at their discretion via the standard open
+      panel.
+
+  Helper / child processes consume build/entitlements.mas.inherit.plist instead
+  so their sandbox state is inherited from this process.
+-->
+<plist version="1.0">
+<dict>
+  <!-- App Sandbox is mandatory for Mac App Store distribution. -->
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+
+  <!-- Outbound network for GitHub release polling, gh CLI device-flow,
+       optional MCP server traffic. -->
+  <key>com.apple.security.network.client</key>
+  <true/>
+
+  <!-- Read/write the files and folders the user explicitly chose via the
+       standard open / save panels. Sandbox-aware variant of how the DMG
+       build accesses arbitrary files. -->
+  <key>com.apple.security.files.user-selected.read-write</key>
+  <true/>
+
+  <!-- Bookmarks for files / folders persisted across launches (e.g. the
+       last-opened workspace). Required for the notes warehouse to remember
+       its directory after a relaunch. -->
+  <key>com.apple.security.files.bookmarks.app-scope</key>
+  <true/>
+</dict>
+</plist>

--- a/docs/desktop-mac-app-store.md
+++ b/docs/desktop-mac-app-store.md
@@ -1,0 +1,178 @@
+# Mark It Down — Mac App Store distribution
+
+This guide explains how to ship Mark It Down's Electron desktop app to the **Mac App Store (MAS)** in addition to the existing Developer ID-signed `.dmg` channel. MAS is **opt-in**: regular tagged releases continue to ship only `.dmg` / `.zip` / Windows / Linux artifacts unless the MAS workflow is explicitly enabled.
+
+> Before you start: this requires a paid **Apple Developer Program** membership ($99/year) **and** a separate enrollment for the **Mac App Store** distribution path. If you only have Developer ID signing set up (per [docs/desktop-mac-signing.md](desktop-mac-signing.md)), you'll need to add the App Store distribution profile + cert below.
+
+## Why a separate target?
+
+The existing notarized `.dmg` is for direct download via GitHub Releases and uses the `Developer ID Application` certificate with the entitlements at [`build/entitlements.mac.plist`](../build/entitlements.mac.plist). That bundle relies on JIT, unsigned executable memory, and library validation overrides — all of which are **rejected by App Store Review**.
+
+The MAS target is therefore a **sibling** with its own cert + entitlements + bundle:
+
+| Aspect | DMG / Developer ID | Mac App Store |
+|---|---|---|
+| Signing identity | `Developer ID Application` | `3rd Party Mac Developer Application` (binary) + `3rd Party Mac Developer Installer` (.pkg) |
+| Sandbox | Off | **On** (mandatory) |
+| Entitlements | [`build/entitlements.mac.plist`](../build/entitlements.mac.plist) | [`build/entitlements.mas.plist`](../build/entitlements.mas.plist) + [`build/entitlements.mas.inherit.plist`](../build/entitlements.mas.inherit.plist) |
+| Provisioning profile | None | `build/embedded.provisionprofile` (Mac App Store distribution) |
+| Output artifact | `.dmg` + `.zip` | `.pkg` |
+| Distribution surface | GitHub Releases | App Store Connect → Mac App Store |
+| Auto-update | `electron-updater` polls GitHub | Mac App Store handles it |
+| Workflow file | [`.github/workflows/release.yml`](../.github/workflows/release.yml) | [`.github/workflows/release-mas.yml`](../.github/workflows/release-mas.yml) |
+
+Both targets share the same source tree, the same `package.json#version`, and the same icon. They diverge only at electron-builder config time.
+
+## One-time setup
+
+### 1. Enroll in the App Store distribution path
+
+In the [Apple Developer portal](https://developer.apple.com/account):
+
+1. Confirm your team is enrolled in the Apple Developer Program (paid).
+2. Under **Certificates, Identifiers & Profiles**:
+   - Create a **Mac App ID** with bundle identifier `io.markitdown.app` (must match `package.json#build.appId`). Enable any capabilities you actually use; for Mark It Down nothing extra beyond default sandbox-friendly capabilities is needed.
+   - Generate the two MAS certificates:
+     - **Mac App Distribution** (signs the `.app` binary)
+     - **Mac Installer Distribution** (signs the wrapping `.pkg`)
+   - Generate a **Mac App Store** distribution provisioning profile bound to the `io.markitdown.app` App ID. Download it as `markitdown_mas.provisionprofile`.
+
+### 2. Export both certs into a single `.p12`
+
+In **Keychain Access** on a Mac with the certs imported:
+
+1. Select both `3rd Party Mac Developer Application: ...` and `3rd Party Mac Developer Installer: ...` items in **My Certificates** (cmd-click).
+2. Right-click → **Export 2 items…** → save as `markitdown-mas-signing.p12`.
+3. Set a strong password — that becomes the `MAS_CERTS_PASSWORD` secret.
+4. Base64-encode for CI:
+
+   ```bash
+   base64 -i markitdown-mas-signing.p12 | pbcopy
+   ```
+
+   The clipboard contents are `MAS_CERTS`.
+
+### 3. Base64 the provisioning profile
+
+```bash
+base64 -i markitdown_mas.provisionprofile | pbcopy
+```
+
+The clipboard contents are `MAS_PROVISIONING_PROFILE`.
+
+### 4. Create the App Store Connect record
+
+1. Go to [App Store Connect](https://appstoreconnect.apple.com) → **My Apps → +**.
+2. **Platform**: macOS. **Bundle ID**: pick the App ID you registered. **SKU**: anything unique (e.g. `mark-it-down-macos`).
+3. Fill in the metadata (description, screenshots, support URL, privacy policy URL). The privacy policy URL is required because Mark It Down talks to the network (auto-update poller, gh CLI device-flow, MCP).
+
+Even before binaries are uploaded, the App Store Connect record needs to exist for the upload step to land somewhere.
+
+### 5. Add CI secrets + variables
+
+Repo → **Settings → Secrets and variables → Actions**.
+
+| Secret | Source |
+|---|---|
+| `MAS_CERTS` | base64 of step 2 |
+| `MAS_CERTS_PASSWORD` | the .p12 password from step 2 |
+| `MAS_PROVISIONING_PROFILE` | base64 of step 3 |
+| `APPLE_ID` | the Apple ID email |
+| `APPLE_APP_SPECIFIC_PASSWORD` | app-specific password from [appleid.apple.com](https://appleid.apple.com) |
+| `APPLE_TEAM_ID` | 10-char team ID |
+
+> The last three secrets are **the same values** the regular Developer ID release workflow uses — share them; don't duplicate.
+
+Then under **Variables → Actions**:
+
+| Variable | Value | Effect |
+|---|---|---|
+| `MAS_ENABLED` | `1` | Enables the MAS workflow on every `v*.*.*` tag push |
+| `MAS_AUTO_SUBMIT` | `1` (optional) | Also runs `xcrun altool --upload-app` after the build |
+
+If `MAS_ENABLED` is unset, the MAS workflow's `mas` job is skipped — tagged releases continue to ship only the existing `.dmg` channel. That's the default and recommended state until your App Store Connect listing is fully reviewed and ready.
+
+## Local pkg build (smoke test before the first submission)
+
+```bash
+npm ci
+npm run compile && npm run compile:electron
+
+# Drop the provisioning profile in the build dir so electron-builder embeds it.
+cp ~/Downloads/markitdown_mas.provisionprofile build/embedded.provisionprofile
+
+# CSC_LINK can be either a path to the .p12 or a base64 blob; here we use the file.
+CSC_LINK=~/Downloads/markitdown-mas-signing.p12 \
+CSC_KEY_PASSWORD='<the p12 password>' \
+APPLE_TEAM_ID='ABCD123456' \
+npx electron-builder --mac mas --publish never
+```
+
+The output lands in `dist/electron/` as `Mark It Down-<version>.pkg`. Smoke-test:
+
+```bash
+# Validate signing
+codesign -dv --verbose=4 "dist/electron/mas/Mark It Down.app"
+
+# Inspect entitlements actually applied
+codesign -d --entitlements - "dist/electron/mas/Mark It Down.app"
+```
+
+Then upload the `.pkg` manually for the first submission so you can verify everything end-to-end before automating:
+
+```bash
+xcrun altool --upload-app --type osx \
+  --file "dist/electron/Mark It Down-0.X.Y-mas.pkg" \
+  --username "$APPLE_ID" \
+  --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+  --asc-provider "$APPLE_TEAM_ID"
+```
+
+`altool` is deprecated in favour of `notarytool` for notarization, but for App Store Connect uploads it's still the simplest one-shot. The Apple-recommended modern path is **Transporter.app** (GUI) or `iTMSTransporter` (CLI shim). Pick whichever fits your workflow — they all hit the same endpoint.
+
+After the upload finishes, the binary appears in App Store Connect → your app → TestFlight or Mac App Store tab. From there you submit it for review through the App Store Connect UI.
+
+## CI flow
+
+Once `MAS_ENABLED=1` is set and all secrets are in place, every `v*.*.*` tag push runs **two independent workflows**:
+
+1. **`Release`** ([`.github/workflows/release.yml`](../.github/workflows/release.yml)) — the existing matrix that produces the `.dmg`, `.zip`, `.exe`, AppImage, `.deb`, `.vsix`, and the GitHub Release record.
+2. **`Release (Mac App Store)`** ([`.github/workflows/release-mas.yml`](../.github/workflows/release-mas.yml)) — runs **only on macOS**, builds the sandboxed `.pkg`, uploads it as a workflow artifact, and (when `MAS_AUTO_SUBMIT=1`) pushes it to App Store Connect.
+
+The two workflows do not share state. A failure in the MAS workflow does not affect the public DMG release.
+
+The `.pkg` is intentionally **not attached to the GitHub Release**: MAS-signed pkgs only validate against the App Store and are unhelpful to GitHub-Release downloaders, who would just see a non-functional installer.
+
+You can also run the MAS workflow manually via **Actions → Release (Mac App Store) → Run workflow → mas_enabled=true** for a tag that's already shipped, e.g. when you've fixed an MAS-only review-rejection issue without needing a new tag.
+
+## Submitting for review
+
+After CI uploads the binary (or you do it manually):
+
+1. App Store Connect → **My Apps → Mark It Down → macOS → Prepare for Submission**.
+2. Pick the build that just arrived from your upload step.
+3. Fill in **What to Test** / **Notes for Review** if any reviewer-facing info is needed (e.g. demo account credentials — Mark It Down doesn't need any).
+4. Click **Submit for Review**. Apple typically responds within 24–48h. First-time submissions tend to get extra scrutiny on:
+   - Privacy disclosures (the fact that you ping `api.github.com` for release polling, and `gh` for device-flow auth).
+   - Sandbox compliance — make sure you've actually run a sandboxed build locally and confirmed the file open / save flows still work.
+
+## Updates
+
+Mac App Store distribution opts you out of `electron-updater`. The auto-update plumbing in `electron-updater` is incompatible with sandboxed apps — Apple disallows the differential-update mechanism it relies on.
+
+Users on the App Store version receive updates through the standard **App Store → Updates** flow, exactly like any other Mac App Store app. The `electron-updater` polling code does still run inside the bundle (because the same source tree builds both targets), but it harmlessly fails to apply updates and the App Store updater takes over. If you want to fully suppress the in-app update banner for MAS builds, gate it on `process.mas` (set by Electron when running from the App Store) and skip the update check.
+
+## Maintenance
+
+- **Cert rotation.** Both MAS certs are valid for ~5 years. When either approaches expiry, regenerate them in Apple Developer, repeat steps 2 + 5 (`MAS_CERTS` + `MAS_CERTS_PASSWORD`).
+- **Profile rotation.** The provisioning profile is valid for 1 year; refresh in Apple Developer and update `MAS_PROVISIONING_PROFILE` annually.
+- **Reverting to DMG-only.** Set the repo variable `MAS_ENABLED` to anything other than `1` (or delete it). The MAS workflow will skip its job on the next tag and the regular Developer ID release continues uninterrupted.
+
+## Files of interest
+
+- [`build/entitlements.mas.plist`](../build/entitlements.mas.plist) — sandboxed parent-process entitlements (no JIT, no library-validation override).
+- [`build/entitlements.mas.inherit.plist`](../build/entitlements.mas.inherit.plist) — child-process inherit-only entitlements.
+- [`package.json#build.mas`](../package.json) — MAS-only electron-builder block (sibling to `build.mac`, which keeps targeting DMG / ZIP for Developer ID releases).
+- [`.github/workflows/release-mas.yml`](../.github/workflows/release-mas.yml) — the opt-in MAS workflow.
+- [`docs/desktop-mac-signing.md`](desktop-mac-signing.md) — sister guide for the Developer ID / DMG signing path.
+- [`docs/releasing.md`](releasing.md) — overall release runbook.

--- a/package.json
+++ b/package.json
@@ -121,7 +121,26 @@
         "repo": "mark-it-down",
         "releaseType": "release"
       }
-    ]
+    ],
+    "mas": {
+      "category": "public.app-category.productivity",
+      "icon": "media/brand/icon.icns",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mas.plist",
+      "entitlementsInherit": "build/entitlements.mas.inherit.plist",
+      "provisioningProfile": "build/embedded.provisionprofile",
+      "type": "distribution",
+      "target": [
+        {
+          "target": "mas",
+          "arch": [
+            "arm64",
+            "x64"
+          ]
+        }
+      ]
+    }
   },
   "activationEvents": [],
   "contributes": {


### PR DESCRIPTION
Closes #266.

## Summary
Adds an opt-in Mac App Store distribution path alongside the existing notarized DMG channel. Regular DMG releases are unaffected — the MAS workflow runs only when repo variable `MAS_ENABLED=1` is set or when manually dispatched.

## Why a sibling target?
Developer ID DMG and Mac App Store have incompatible entitlement requirements. The DMG bundle relies on JIT, unsigned executable memory, and library validation overrides — all rejected by App Store Review. So the MAS bundle gets:
- its own cert (`3rd Party Mac Developer Application` + `Installer` instead of `Developer ID Application`),
- mandatory sandbox + locked-down entitlements (no JIT, no library-validation override),
- its own provisioning profile,
- its own electron-builder block (`build.mas`, sibling to `build.mac`),
- its own workflow file (`release-mas.yml`, separate from `release.yml`).

## What's in this PR
- `package.json#build.mas` — sandboxed, signed-for-MAS, single `.pkg` target (universal arm64 + x64). The existing `build.mac` block is **untouched** (still DMG + ZIP for Developer ID).
- `build/entitlements.mas.plist` — sandbox-on, `network.client`, `files.user-selected.read-write`, `files.bookmarks.app-scope`. Strips JIT / unsigned-memory / library-validation that App Store Review rejects.
- `build/entitlements.mas.inherit.plist` — inherit-only entitlements for Electron child / helper processes.
- `.github/workflows/release-mas.yml` — separate workflow file, gated on `vars.MAS_ENABLED == '1'` (or `workflow_dispatch` input). Runs only on `macos-latest`. Decodes the provisioning profile, runs `electron-builder --mac mas --publish never`, uploads the `.pkg` as a workflow artifact (intentionally NOT attached to the GitHub Release — MAS-signed pkgs only validate against the App Store), and optionally auto-submits via `xcrun altool` when `vars.MAS_AUTO_SUBMIT=1`.
- `docs/desktop-mac-app-store.md` — full setup runbook: enrollment, certs (the two MAS certs in one `.p12`), provisioning profile, App Store Connect record, all required secrets + variables, local pkg smoke build, manual `altool` / Transporter upload, review-submission flow, cert / profile rotation.

## Acceptance per issue
- [x] `mas` block in electron-builder config (target: pkg).
- [x] `build/entitlements.mas.plist` + `build/entitlements.mas.inherit.plist`.
- [x] CI workflow gates the MAS target on `MAS_ENABLED=1` so regular DMG releases are unaffected.
- [x] Documented setup at `docs/desktop-mac-app-store.md`.

## Out of scope (intentional)
- `apps/electron/main.ts` packaging fixes (`process.cwd`, tray, MCP) — separate human hotfix.
- `package.json#build.mac.*` universal target — separate human hotfix.
- First .pkg local build + altool submission — runbook items the maintainer runs once Apple Developer + App Store Connect enrollment is live.

## Test plan
- [ ] On a Mac with the MAS certs + provisioning profile in keychain, run `npx electron-builder --mac mas --publish never` locally and confirm a `.pkg` lands in `dist/electron/`.
- [ ] `codesign -d --entitlements - "dist/electron/mas/Mark It Down.app"` shows sandbox-on with no JIT / library-validation override.
- [ ] On GitHub: leave `MAS_ENABLED` unset; cut a tag and confirm only `release.yml` runs (DMG path), `release-mas.yml`'s `mas` job is skipped via the `if:` gate.
- [ ] Set `MAS_ENABLED=1` + secrets; cut a tag and confirm both workflows run independently and a `.pkg` artifact is produced + uploaded.
- [ ] Submit one .pkg manually via Transporter / `altool`; confirm it appears in App Store Connect.