### PR TITLE
chore(release): v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this extension will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-05-03
+
+### Fixed — packaged build broken on macOS (#270, #271)
+
+- **Tray icon + MCP server** were unreachable in the v0.2.0 .dmg because `apps/electron/main.ts` resolved every runtime asset via `process.cwd()`. In dev `cwd` is the repo root; in a packaged .app it's wherever the user launched from, so `media/brand/iconTemplate.png`, `out/mcp/server.js`, and `build/icons/16.png` all 404'd. New `bundleAsset(...segments)` helper resolves both dev and packaged paths via `__dirname` walk + transparent `app.asar.unpacked` fallback. Replaces every `process.cwd()` lookup.
+- **Bundle config** — added `out/mcp/**`, `media/brand/**`, `build/icons/**` to `package.json#build.files`. `out/mcp/**` and `node_modules/better-sqlite3/**` are `asarUnpack`'d so `fork()` can spawn the MCP server and the native sqlite binary loads.
+- **Universal macOS DMG** (#271) — switched `mac.target` from per-arch (arm64 + x64) to a single `universal` slice. No more Rosetta-deprecation warning when an arm Mac downloads the x64 DMG; one installer that runs natively on both architectures.
+- **Tray "Check for Updates…"** entry. Label flips to *Downloading v…* → *Restart and install v…* as the auto-updater progresses; local builds (no `app-update.yml`) get a friendly *only available in published releases* dialog.
+
+### Fixed — release pipeline (#269)
+
+- vsix job was racing the electron jobs to upload and failing with `release not found`. Made the upload idempotent (creates the release as a draft if it doesn't exist) and decoupled the release-notes job from the vsix job so a vsix retry doesn't re-block release-notes.
+
+### Added — Mac App Store target (#266)
+
+- New opt-in `mas` target for App Store distribution (sibling to the regular DMG). Sandboxed entitlements, 3rd-party Mac Developer signing, separate workflow file gated on `vars.MAS_ENABLED=1`. Regular DMG releases unchanged.
+
+### Added — Right-side outline rail (#252)
+
+- New table-of-contents rail on the right side of the preview, listing every heading in the active markdown file with indent matching heading level. Click → scroll to that section. IntersectionObserver highlights the current section as you scroll. Toggle from the status-bar *Outline* button or `⌘⇧L`. Hidden in edit-only mode and during PDF export. Persists across restart.
+
 ## [0.2.0] — 2026-05-03
 
 ### Added — Desktop app (Electron) — release engineering

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-it-down",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-it-down",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mark-it-down",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "l10n": "./l10n",
   "publisher": "fadymondy",
   "engines": {


### PR DESCRIPTION
## Summary
Hotfix release for the broken v0.2.0 macOS .dmg.

What's shipped since v0.2.0:
- **#270, #271** packaged-build paths + universal Mac DMG + tray *Check for Updates* (the headline fix — v0.2.0 tray icon was a hollow circle and *Install MCP* errored).
- **#269** vsix release-pipeline race fix.
- **#266** Mac App Store target (opt-in sibling to DMG).
- **#252** right-side outline rail (TOC).

`package.json` bumped 0.2.0 → 0.2.1.

## After this merges
\`\`\`bash
git checkout main && git pull && git tag v0.2.1 && git push origin v0.2.1
\`\`\`

CI builds + signs + notarizes the universal DMG, uploads installers + `latest-*.yml` to the GitHub Release. Existing v0.2.0 installs auto-update on next launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)