### PR TITLE
feat(desktop): importer plugin system — architecture & contract (#246)

### DIFF
--- a/apps/electron/importers/loader.ts
+++ b/apps/electron/importers/loader.ts
@@ -1,0 +1,117 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { Importer, ImporterMetadata, isImporter } from './types';
+
+/**
+ * Importer registry — populated once at app startup by {@link loadImporters}.
+ * Subsequent calls return the cached map; callers that want a fresh scan can
+ * pass `force: true`.
+ */
+const registry = new Map<string, Importer>();
+let loaded = false;
+
+export interface LoadOptions {
+  /**
+   * Absolute path to the directory containing per-importer subfolders. In dev
+   * this is `apps/electron/importers/`; in packaged builds main.ts resolves it
+   * via the asset helper to `<resources>/out/electron/importers/`.
+   */
+  importerRootDir: string;
+  /** Re-scan even if already loaded. */
+  force?: boolean;
+  /** Optional logger — falls back to console. */
+  log?: (msg: string) => void;
+}
+
+/**
+ * Scan `importerRootDir` for subfolders containing `index.js` (packaged/dev
+ * compiled) or `index.ts` (dev fallback when ts-node is in use). Each module's
+ * default export — or its named `importer` export — is validated and registered.
+ * The current `types.ts` and `loader.ts` files in the parent directory are
+ * skipped because they're not importer plugins.
+ */
+export async function loadImporters(opts: LoadOptions): Promise<Importer[]> {
+  const log = opts.log ?? ((msg: string) => console.log(msg));
+  if (loaded && !opts.force) return Array.from(registry.values());
+  registry.clear();
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(opts.importerRootDir);
+  } catch (err) {
+    log(`[importers] no importer dir at ${opts.importerRootDir}: ${(err as Error).message}`);
+    loaded = true;
+    return [];
+  }
+
+  for (const entry of entries) {
+    const full = path.join(opts.importerRootDir, entry);
+    let stat;
+    try {
+      stat = await fs.stat(full);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+
+    // Try .js first (packaged + dev compiled output), then .ts (dev source).
+    const candidates = [path.join(full, 'index.js'), path.join(full, 'index.ts')];
+    let modulePath: string | null = null;
+    for (const c of candidates) {
+      try {
+        await fs.access(c);
+        modulePath = c;
+        break;
+      } catch {
+        // try next
+      }
+    }
+    if (!modulePath) {
+      log(`[importers] skip ${entry} — no index.js or index.ts`);
+      continue;
+    }
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require(modulePath);
+      const candidate = mod?.default ?? mod?.importer ?? mod;
+      if (!isImporter(candidate)) {
+        log(`[importers] skip ${entry} — default export does not satisfy Importer`);
+        continue;
+      }
+      if (registry.has(candidate.id)) {
+        log(`[importers] skip ${entry} — duplicate id "${candidate.id}"`);
+        continue;
+      }
+      registry.set(candidate.id, candidate);
+    } catch (err) {
+      log(`[importers] failed to load ${entry}: ${(err as Error).message}`);
+    }
+  }
+
+  loaded = true;
+  const ids = Array.from(registry.keys()).sort();
+  log(`[importers] registered: ${ids.length === 0 ? '(none)' : ids.join(', ')}`);
+  return Array.from(registry.values());
+}
+
+/** Return all loaded importers. Empty until {@link loadImporters} resolves. */
+export function listImporters(): Importer[] {
+  return Array.from(registry.values());
+}
+
+/** Strip runtime functions so the metadata is safe to send across IPC. */
+export function listImporterMetadata(): ImporterMetadata[] {
+  return listImporters().map(({ id, name, icon, supportedFormats, description }) => ({
+    id,
+    name,
+    icon,
+    supportedFormats,
+    description,
+  }));
+}
+
+/** Look up a registered importer by id. */
+export function getImporter(id: string): Importer | undefined {
+  return registry.get(id);
+}

--- a/apps/electron/importers/sample/index.ts
+++ b/apps/electron/importers/sample/index.ts
@@ -1,0 +1,43 @@
+import { ImportContext, ImportedNote, Importer } from '../types';
+
+/**
+ * Sample importer — exists purely to prove the loader, IPC, and renderer
+ * chooser are wired correctly. It ignores `input` entirely and yields a single
+ * hardcoded markdown note. Real importers (#247–#250) replace this pattern.
+ */
+const sample: Importer = {
+  id: 'sample',
+  name: 'Sample (smoke test)',
+  icon: 'bx-test-tube',
+  supportedFormats: ['folder'],
+  description: 'Imports a single hardcoded note. Used to verify the importer pipeline.',
+
+  async detect(_input: string): Promise<boolean> {
+    return true;
+  },
+
+  async *import(_input: string, ctx: ImportContext): AsyncIterable<ImportedNote> {
+    ctx.log('[sample] yielding one hardcoded note');
+    const now = new Date().toISOString();
+    yield {
+      title: 'Hello from the sample importer',
+      body: [
+        '# Hello from the sample importer',
+        '',
+        'If you can see this note in your workspace under',
+        '`Imported/sample/`, the importer plugin pipeline is working end-to-end.',
+        '',
+        '- Loader registered the plugin',
+        '- IPC streamed the note to the renderer',
+        '- Host wrote markdown + frontmatter to disk',
+        '',
+        `_Generated at ${now}._`,
+      ].join('\n'),
+      tags: ['imported', 'sample'],
+      createdAt: now,
+      updatedAt: now,
+    };
+  },
+};
+
+export default sample;

--- a/apps/electron/importers/types.ts
+++ b/apps/electron/importers/types.ts
@@ -1,0 +1,102 @@
+/**
+ * Importer plugin contract — see docs/importers.md.
+ *
+ * The runtime under apps/electron/importers/loader.ts discovers every folder in
+ * apps/electron/importers/<id>/index.ts (dev) or <resources>/importers/<id>/index.js
+ * (packaged) whose default export satisfies {@link Importer}. No core code touches
+ * an importer directly — the loader, the IPC layer in main.ts, and the chooser
+ * modal in renderer.ts are fully data-driven.
+ *
+ * Concrete importers (Apple Notes, Google Keep, Notion, generic markdown) live in
+ * separate issues (#247–#250). This file is the spine.
+ */
+
+/**
+ * Static, serialisable description of an importer. The renderer only ever sees
+ * this shape — runtime functions stay in the main process.
+ */
+export interface ImporterMetadata {
+  /** Stable kebab-case identifier, unique across all importers. */
+  id: string;
+  /** Display name shown in the chooser modal. */
+  name: string;
+  /** boxicons name (e.g. "bx-import") — already shipped via icons.css. */
+  icon: string;
+  /** Optional human-readable list of accepted source kinds, e.g. ["folder", "zip"]. */
+  supportedFormats?: string[];
+  /** Short blurb shown under the name in the chooser. */
+  description?: string;
+}
+
+/**
+ * One imported note as produced by an importer's async iterator. The host adds
+ * frontmatter (id, created, updated, tags) when persisting — importers should
+ * leave `body` as plain markdown.
+ */
+export interface ImportedNote {
+  title: string;
+  /** Markdown body. No frontmatter — host adds it. */
+  body: string;
+  tags?: string[];
+  /** ISO 8601. */
+  createdAt?: string;
+  /** ISO 8601. */
+  updatedAt?: string;
+  attachments?: ImportedAttachment[];
+  /** Extra frontmatter fields the importer wants persisted verbatim. */
+  meta?: Record<string, unknown>;
+}
+
+export interface ImportedAttachment {
+  /** Filename relative to the note's attachments folder, e.g. "image.png". */
+  name: string;
+  data: Buffer;
+  /** Optional MIME type — host can sniff if absent. */
+  mime?: string;
+}
+
+/** Runtime context handed to {@link Importer.import}. */
+export interface ImportContext {
+  /** Absolute path to the workspace root the user is importing into. */
+  workspaceFolder: string;
+  /**
+   * Per-importer log sink — the loader pipes this into the main-process logger
+   * so importer output shows up alongside other diagnostics.
+   */
+  log: (msg: string) => void;
+  /** Optional cancellation handle wired to the renderer. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Fully-fleshed importer plugin. The default export of every
+ * apps/electron/importers/<id>/index.ts must satisfy this interface.
+ */
+export interface Importer extends ImporterMetadata {
+  /**
+   * Cheap probe: given a folder/file path, return true if this importer thinks
+   * it can handle it. Optional — used by the chooser to highlight likely
+   * matches when the user picks a path before picking an importer.
+   */
+  detect?(input: string): Promise<boolean>;
+  /**
+   * The actual import. Yields notes one at a time so the renderer can show
+   * incremental progress without buffering everything in memory.
+   */
+  import(input: string, ctx: ImportContext): AsyncIterable<ImportedNote>;
+}
+
+/**
+ * Type guard: validate that an unknown module default export is a usable
+ * {@link Importer}. The loader uses this before registering anything.
+ */
+export function isImporter(value: unknown): value is Importer {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === 'string' &&
+    typeof v.name === 'string' &&
+    typeof v.icon === 'string' &&
+    typeof v.import === 'function'
+  );
+}

--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -129,6 +129,7 @@ app.whenReady().then(async () => {
   Menu.setApplicationMenu(buildMenu());
   buildTray();
   startMCP();
+  void initImporters();
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) void createWindow();
   });
@@ -1060,6 +1061,10 @@ function buildMenu(): Menu {
         },
         { type: 'separator' },
         {
+          label: 'Import from…',
+          click: () => mainWindow?.webContents.send('mid:menu-import'),
+        },
+        {
           label: 'Export',
           submenu: [
             { label: 'Markdown source…', click: () => mainWindow?.webContents.send('mid:menu-export', 'md') },
@@ -1134,4 +1139,104 @@ function buildMenu(): Menu {
     },
   ];
   return Menu.buildFromTemplate(template);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Importer plugin system (#246)
+//
+// The contract, loader, and per-importer modules live under
+// apps/electron/importers/. This block hosts only the IPC surface and one-shot
+// init — adding a new importer requires zero changes here.
+// ─────────────────────────────────────────────────────────────────────────────
+import { loadImporters, listImporterMetadata, getImporter } from './importers/loader';
+import type { ImportContext, ImportedNote } from './importers/types';
+
+/**
+ * Resolve the importer root for both dev (TS source) and packaged builds
+ * (compiled JS under out/electron/importers, copied into the asar via the
+ * build files glob). Dev uses the live source dir so iterating on an importer
+ * doesn't require recompilation of the loader itself.
+ */
+function importerRootDir(): string {
+  if (isDev) return path.join(process.cwd(), 'apps/electron/importers');
+  // In packaged builds main.js is at <asar>/out/electron/main.js;
+  // sibling importers/ ships compiled.
+  return path.join(__dirname, 'importers');
+}
+
+async function initImporters(): Promise<void> {
+  try {
+    await loadImporters({
+      importerRootDir: importerRootDir(),
+      log: (msg) => console.log(msg),
+    });
+  } catch (err) {
+    console.error('[importers] init failed:', err);
+  }
+}
+
+ipcMain.handle('mid:importers-list', async () => listImporterMetadata());
+
+ipcMain.handle(
+  'mid:importers-run',
+  async (e, importerId: string, input: string, workspaceFolder: string): Promise<{ ok: boolean; runId?: string; error?: string }> => {
+    const importer = getImporter(importerId);
+    if (!importer) return { ok: false, error: `Unknown importer "${importerId}"` };
+    if (!workspaceFolder) return { ok: false, error: 'No workspace folder selected' };
+
+    const runId = `${importerId}-${Date.now()}`;
+    const targetDir = path.join(workspaceFolder, 'Imported', importer.id);
+    const sender = e.sender;
+
+    const ctx: ImportContext = {
+      workspaceFolder,
+      log: (msg: string) => sender.send('mid:importers-log', { runId, msg }),
+    };
+
+    // Fire-and-forget: stream notes back to the renderer as they arrive. The
+    // renderer surfaces progress via mid:importers-progress and a final done
+    // event. Any thrown error is reported on the same channel.
+    void (async () => {
+      try {
+        await fs.mkdir(targetDir, { recursive: true });
+        let count = 0;
+        for await (const note of importer.import(input, ctx)) {
+          count += 1;
+          const filename = sanitiseFilename(note.title) + '.md';
+          const filePath = path.join(targetDir, filename);
+          await fs.mkdir(targetDir, { recursive: true });
+          await fs.writeFile(filePath, formatNoteAsMarkdown(note), 'utf8');
+          if (note.attachments && note.attachments.length) {
+            const attachDir = path.join(targetDir, 'attachments', sanitiseFilename(note.title));
+            await fs.mkdir(attachDir, { recursive: true });
+            for (const att of note.attachments) {
+              await fs.writeFile(path.join(attachDir, att.name), att.data);
+            }
+          }
+          sender.send('mid:importers-progress', { runId, current: count, note: { title: note.title, path: filePath } });
+        }
+        sender.send('mid:importers-done', { runId, count });
+      } catch (err) {
+        sender.send('mid:importers-error', { runId, error: (err as Error).message });
+      }
+    })();
+
+    return { ok: true, runId };
+  },
+);
+
+function sanitiseFilename(input: string): string {
+  return (input || 'untitled').replace(/[/\\:*?"<>|]/g, '-').replace(/\s+/g, ' ').trim().slice(0, 120) || 'untitled';
+}
+
+function formatNoteAsMarkdown(note: ImportedNote): string {
+  const fm: string[] = ['---'];
+  if (note.createdAt) fm.push(`created: ${note.createdAt}`);
+  if (note.updatedAt) fm.push(`updated: ${note.updatedAt}`);
+  if (note.tags && note.tags.length) fm.push(`tags: [${note.tags.map(t => JSON.stringify(t)).join(', ')}]`);
+  if (note.meta) {
+    for (const [k, v] of Object.entries(note.meta)) fm.push(`${k}: ${JSON.stringify(v)}`);
+  }
+  fm.push('---', '');
+  return fm.join('\n') + note.body + (note.body.endsWith('\n') ? '' : '\n');
 }

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -136,4 +136,34 @@ contextBridge.exposeInMainWorld('mid', {
     ipcRenderer.on('mid:menu-export', handler);
     return () => ipcRenderer.removeListener('mid:menu-export', handler);
   },
+  // ── Importer plugin system (#246) ──────────────────────────────────────────
+  importersList: (): Promise<{ id: string; name: string; icon: string; supportedFormats?: string[]; description?: string }[]> =>
+    ipcRenderer.invoke('mid:importers-list'),
+  importersRun: (importerId: string, input: string, workspaceFolder: string): Promise<{ ok: boolean; runId?: string; error?: string }> =>
+    ipcRenderer.invoke('mid:importers-run', importerId, input, workspaceFolder),
+  onImportersProgress: (cb: (e: { runId: string; current: number; note: { title: string; path: string } }) => void): (() => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, payload: { runId: string; current: number; note: { title: string; path: string } }) => cb(payload);
+    ipcRenderer.on('mid:importers-progress', handler);
+    return () => ipcRenderer.removeListener('mid:importers-progress', handler);
+  },
+  onImportersDone: (cb: (e: { runId: string; count: number }) => void): (() => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, payload: { runId: string; count: number }) => cb(payload);
+    ipcRenderer.on('mid:importers-done', handler);
+    return () => ipcRenderer.removeListener('mid:importers-done', handler);
+  },
+  onImportersError: (cb: (e: { runId: string; error: string }) => void): (() => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, payload: { runId: string; error: string }) => cb(payload);
+    ipcRenderer.on('mid:importers-error', handler);
+    return () => ipcRenderer.removeListener('mid:importers-error', handler);
+  },
+  onImportersLog: (cb: (e: { runId: string; msg: string }) => void): (() => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, payload: { runId: string; msg: string }) => cb(payload);
+    ipcRenderer.on('mid:importers-log', handler);
+    return () => ipcRenderer.removeListener('mid:importers-log', handler);
+  },
+  onMenuImport: (cb: () => void): (() => void) => {
+    const handler = (): void => cb();
+    ipcRenderer.on('mid:menu-import', handler);
+    return () => ipcRenderer.removeListener('mid:menu-import', handler);
+  },
 });

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -2018,3 +2018,66 @@ body.is-printing .mid-shell { grid-template-columns: 1fr !important; }
   font-size: var(--mid-font-size-xs);
   white-space: pre-wrap;
 }
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Importer plugin chooser (#246)
+   Lives at the bottom of the file so concurrent edits to other surfaces don't
+   collide with this surface.
+   ───────────────────────────────────────────────────────────────────────────── */
+.mid-importers-dialog {
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-lg, 12px);
+  background: var(--mid-bg);
+  color: var(--mid-fg);
+  padding: 0;
+  width: min(520px, 90vw);
+  max-height: 80vh;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+}
+.mid-importers-dialog::backdrop { background: rgba(0, 0, 0, 0.4); }
+.mid-importers-form { display: flex; flex-direction: column; gap: 0; }
+.mid-importers-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--mid-border);
+}
+.mid-importers-header h2 { margin: 0; font-size: var(--mid-font-size-lg, 16px); font-weight: 600; }
+.mid-importers-list { display: flex; flex-direction: column; padding: 8px; max-height: 56vh; overflow-y: auto; }
+.mid-importers-empty {
+  padding: 24px 16px;
+  color: var(--mid-fg-muted);
+  font-size: var(--mid-font-size-sm);
+  text-align: center;
+}
+.mid-importers-row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: var(--mid-radius, 8px);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+}
+.mid-importers-row:hover,
+.mid-importers-row:focus-visible {
+  background: var(--mid-surface-hover, var(--mid-surface, rgba(127,127,127,0.08)));
+  border-color: var(--mid-border);
+  outline: none;
+}
+.mid-importers-row-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.mid-importers-row-name { font-weight: 600; }
+.mid-importers-row-desc { color: var(--mid-fg-muted); font-size: var(--mid-font-size-sm); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mid-importers-progress { padding: 18px; display: flex; flex-direction: column; gap: 10px; }
+.mid-importers-progress-text { font-weight: 600; }
+.mid-importers-progress-log {
+  list-style: none; margin: 0; padding: 8px;
+  background: var(--mid-code-bg, rgba(127,127,127,0.06));
+  border-radius: var(--mid-radius, 8px);
+  font-family: var(--mid-font-mono, ui-monospace, Menlo, monospace);
+  font-size: var(--mid-font-size-sm, 12px);
+  max-height: 220px; overflow-y: auto;
+}
+.mid-importers-progress-log li { padding: 2px 4px; }
+.mid-importers-progress-log-line { color: var(--mid-fg-muted); }

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -4075,3 +4075,187 @@ void window.mid.readAppState().then(async state => {
   }
   setMode(currentMode);
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Importer plugin chooser (#246)
+//
+// Self-contained block — kept at the bottom of renderer.ts to minimise merge
+// conflicts with the settings stack and spotlight agents. The chooser modal is
+// built lazily on first use; the only static surface is the activity-bar
+// "Import from…" button injected next to Settings.
+// ─────────────────────────────────────────────────────────────────────────────
+interface ImporterMetaRow {
+  id: string;
+  name: string;
+  icon: string;
+  supportedFormats?: string[];
+  description?: string;
+}
+
+interface ImportersBridge {
+  importersList(): Promise<ImporterMetaRow[]>;
+  importersRun(importerId: string, input: string, workspaceFolder: string): Promise<{ ok: boolean; runId?: string; error?: string }>;
+  onImportersProgress(cb: (e: { runId: string; current: number; note: { title: string; path: string } }) => void): () => void;
+  onImportersDone(cb: (e: { runId: string; count: number }) => void): () => void;
+  onImportersError(cb: (e: { runId: string; error: string }) => void): () => void;
+  onImportersLog(cb: (e: { runId: string; msg: string }) => void): () => void;
+}
+
+const importersBridge = (window.mid as unknown as ImportersBridge);
+
+function buildImportersButton(): void {
+  // Inject an "Import from…" button into the activity bar overflow position.
+  // We add it just before the spacer so it lives next to the pinned-folder
+  // group and doesn't disturb existing layout.
+  const bar = document.getElementById('activity-bar');
+  if (!bar || document.getElementById('activity-import')) return;
+  const btn = document.createElement('button');
+  btn.id = 'activity-import';
+  btn.className = 'mid-activity-btn';
+  btn.title = 'Import from…';
+  btn.setAttribute('data-icon', 'import');
+  btn.addEventListener('click', () => void openImportersChooser());
+  const spacer = bar.querySelector('.mid-activity-spacer');
+  if (spacer) bar.insertBefore(btn, spacer);
+  else bar.appendChild(btn);
+}
+
+async function openImportersChooser(): Promise<void> {
+  const importers = await importersBridge.importersList();
+  const dlg = ensureImportersDialog();
+  const list = dlg.querySelector('.mid-importers-list') as HTMLDivElement;
+  list.replaceChildren();
+  if (importers.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'mid-importers-empty';
+    empty.textContent = 'No importers registered. Drop a folder under apps/electron/importers/<id>/ and restart.';
+    list.appendChild(empty);
+  } else {
+    for (const meta of importers) {
+      const row = document.createElement('button');
+      row.type = 'button';
+      row.className = 'mid-importers-row';
+      row.innerHTML = `
+        <span class="mid-icon mid-icon--md" data-icon="${meta.icon || 'import'}"></span>
+        <span class="mid-importers-row-text">
+          <span class="mid-importers-row-name"></span>
+          <span class="mid-importers-row-desc"></span>
+        </span>
+      `;
+      (row.querySelector('.mid-importers-row-name') as HTMLSpanElement).textContent = meta.name;
+      (row.querySelector('.mid-importers-row-desc') as HTMLSpanElement).textContent = meta.description || (meta.supportedFormats || []).join(', ');
+      row.addEventListener('click', () => {
+        if (dlg.open) dlg.close();
+        void runImporter(meta);
+      });
+      list.appendChild(row);
+    }
+  }
+  if (!dlg.open) dlg.showModal();
+}
+
+function ensureImportersDialog(): HTMLDialogElement {
+  let dlg = document.getElementById('mid-importers-dialog') as HTMLDialogElement | null;
+  if (dlg) return dlg;
+  dlg = document.createElement('dialog');
+  dlg.id = 'mid-importers-dialog';
+  dlg.className = 'mid-importers-dialog';
+  dlg.innerHTML = `
+    <form method="dialog" class="mid-importers-form">
+      <header class="mid-importers-header">
+        <h2>Import from…</h2>
+        <button type="submit" value="cancel" class="mid-btn mid-btn--icon mid-btn--ghost" aria-label="Close" data-icon="x"></button>
+      </header>
+      <div class="mid-importers-list"></div>
+      <div class="mid-importers-progress" hidden>
+        <div class="mid-importers-progress-text">Starting…</div>
+        <ul class="mid-importers-progress-log"></ul>
+      </div>
+    </form>
+  `;
+  document.body.appendChild(dlg);
+  dlg.addEventListener('click', (e) => {
+    if (e.target === dlg) dlg.close();
+  });
+  return dlg;
+}
+
+async function runImporter(meta: ImporterMetaRow): Promise<void> {
+  if (!currentFolder) {
+    const folder = await window.mid.openFolderDialog();
+    if (!folder) return;
+    applyFolder(folder.folderPath, folder.tree);
+  }
+  if (!currentFolder) return;
+
+  // Importer source: re-use the open-folder dialog as the universal picker for
+  // now. Real importers will pick zip/file/live in their own flows; for the
+  // sample (which ignores input) we just default to the workspace folder.
+  let input = currentFolder;
+  if ((meta.supportedFormats || []).some(fmt => fmt === 'folder' || fmt === 'zip' || fmt === 'file') && meta.id !== 'sample') {
+    const picked = await window.mid.openFolderDialog();
+    if (!picked) return;
+    input = picked.folderPath;
+  }
+
+  const dlg = ensureImportersDialog();
+  const list = dlg.querySelector('.mid-importers-list') as HTMLDivElement;
+  const progress = dlg.querySelector('.mid-importers-progress') as HTMLDivElement;
+  const progressText = dlg.querySelector('.mid-importers-progress-text') as HTMLDivElement;
+  const log = dlg.querySelector('.mid-importers-progress-log') as HTMLUListElement;
+  list.hidden = true;
+  progress.hidden = false;
+  log.replaceChildren();
+  progressText.textContent = `Running "${meta.name}"…`;
+  if (!dlg.open) dlg.showModal();
+
+  const offProgress = importersBridge.onImportersProgress(({ runId, current, note }) => {
+    if (runId !== expectedRunId) return;
+    progressText.textContent = `Imported ${current} note${current === 1 ? '' : 's'}…`;
+    const li = document.createElement('li');
+    li.textContent = `• ${note.title}`;
+    li.title = note.path;
+    log.appendChild(li);
+  });
+  const offDone = importersBridge.onImportersDone(({ runId, count }) => {
+    if (runId !== expectedRunId) return;
+    progressText.textContent = `Done — imported ${count} note${count === 1 ? '' : 's'} into Imported/${meta.id}/`;
+    cleanup();
+    if (currentFolder) void window.mid.listFolderMd(currentFolder).then(tree => applyFolder(currentFolder!, tree));
+  });
+  const offError = importersBridge.onImportersError(({ runId, error }) => {
+    if (runId !== expectedRunId) return;
+    progressText.textContent = `Failed: ${error}`;
+    cleanup();
+  });
+  const offLog = importersBridge.onImportersLog(({ runId, msg }) => {
+    if (runId !== expectedRunId) return;
+    const li = document.createElement('li');
+    li.className = 'mid-importers-progress-log-line';
+    li.textContent = msg;
+    log.appendChild(li);
+  });
+
+  let expectedRunId = '';
+  const cleanup = (): void => {
+    offProgress();
+    offDone();
+    offError();
+    offLog();
+  };
+
+  const result = await importersBridge.importersRun(meta.id, input, currentFolder);
+  if (!result.ok || !result.runId) {
+    progressText.textContent = `Failed to start: ${result.error ?? 'unknown error'}`;
+    cleanup();
+    return;
+  }
+  expectedRunId = result.runId;
+}
+
+buildImportersButton();
+
+interface ImportersMenuBridge {
+  onMenuImport(cb: () => void): () => void;
+}
+((window.mid as unknown as ImportersMenuBridge)).onMenuImport(() => void openImportersChooser());

--- a/apps/electron/tsconfig.json
+++ b/apps/electron/tsconfig.json
@@ -14,6 +14,6 @@
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["main.ts", "preload.ts"],
+  "include": ["main.ts", "preload.ts", "importers/**/*.ts"],
   "exclude": ["renderer/**/*"]
 }

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -1,0 +1,190 @@
+# Importer plugin system
+
+> Status: shipped in #246. First-party importers (Apple Notes, Google Keep,
+> Notion, generic markdown) land in #247–#250 on top of this contract.
+
+Mark It Down imports notes from external apps via a tiny plugin contract. Adding
+a new importer is a matter of dropping one folder under
+`apps/electron/importers/<id>/` — no changes to the core renderer, main process,
+loader, or chooser modal are required.
+
+## What ships in this issue
+
+- `apps/electron/importers/types.ts` — the `Importer` contract, plus
+  `ImporterMetadata`, `ImportedNote`, `ImportContext`, `ImportedAttachment`, and
+  the `isImporter` type guard.
+- `apps/electron/importers/loader.ts` — discovers `index.js` (compiled) or
+  `index.ts` (dev) under each `apps/electron/importers/<id>/` folder, validates
+  the default export, and registers it in an in-memory map.
+- `apps/electron/importers/sample/index.ts` — the smoke-test importer that
+  yields one hardcoded markdown note. Deleting this folder leaves the system
+  with zero importers and the chooser shows an empty-state message.
+- IPC surface in `apps/electron/main.ts`:
+  - `mid:importers-list` returns metadata only (no functions).
+  - `mid:importers-run` starts a streaming import.
+  - `mid:importers-progress`, `mid:importers-done`, `mid:importers-error`,
+    `mid:importers-log` push events back to the renderer.
+- Renderer surface in `apps/electron/renderer/renderer.ts` (and matching CSS in
+  `renderer.css`):
+  - "Import from…" button injected at the bottom of the activity bar.
+  - "Import from…" entry in the **File** menu (sends `mid:menu-import`).
+  - Modal dialog that lists registered importers, runs the chosen one, and
+    streams progress lines as notes hit disk.
+
+## The contract
+
+Every importer module under `apps/electron/importers/<id>/index.ts` default-
+exports an object satisfying:
+
+```ts
+export interface Importer extends ImporterMetadata {
+  detect?(input: string): Promise<boolean>;
+  import(input: string, ctx: ImportContext): AsyncIterable<ImportedNote>;
+}
+
+export interface ImporterMetadata {
+  id: string;                       // kebab-case, unique
+  name: string;                     // display name
+  icon: string;                     // boxicons name (e.g. "bx-import")
+  supportedFormats?: string[];      // e.g. ["folder", "zip"]
+  description?: string;             // short blurb shown in the chooser
+}
+
+export interface ImportedNote {
+  title: string;
+  body: string;                     // markdown body (no frontmatter — host adds it)
+  tags?: string[];
+  createdAt?: string;               // ISO 8601
+  updatedAt?: string;               // ISO 8601
+  attachments?: ImportedAttachment[];
+  meta?: Record<string, unknown>;   // extra frontmatter fields
+}
+
+export interface ImportedAttachment {
+  name: string;                     // filename relative to the attachments folder
+  data: Buffer;
+  mime?: string;
+}
+
+export interface ImportContext {
+  workspaceFolder: string;          // absolute path to the workspace root
+  log: (msg: string) => void;       // pipes into the main-process logger
+  signal?: AbortSignal;
+}
+```
+
+The contract intentionally returns an `AsyncIterable<ImportedNote>` instead of
+buffering everything: the host writes each note to disk as it arrives, so a
+giant Notion export doesn't sit in memory.
+
+## How the host uses an importer
+
+1. **Discovery** (one-shot at app startup): `loadImporters()` reads every
+   subdirectory of `apps/electron/importers/`, requires the first available
+   `index.js` or `index.ts`, validates the default export with `isImporter`,
+   and registers it. Failures and duplicate ids are logged and skipped — they
+   never crash the app. The startup log prints
+   `[importers] registered: id-a, id-b, …`.
+2. **Listing** (per renderer request): `mid:importers-list` strips the
+   `detect`/`import` functions and returns the metadata array.
+3. **Running** (per chooser click):
+   - Renderer calls `mid:importers-run(importerId, input, workspaceFolder)`.
+   - Main process resolves the importer, creates
+     `<workspace>/Imported/<importer-id>/`, and invokes `import(input, ctx)`.
+   - For each yielded note, the host:
+     - Sanitises the title into a filename.
+     - Writes a markdown file with frontmatter (`created`, `updated`, `tags`,
+       any keys from `note.meta`).
+     - If `note.attachments` is non-empty, writes each attachment under
+       `Imported/<id>/attachments/<sanitised-title>/`.
+     - Sends `mid:importers-progress` to the renderer with the running count.
+   - On completion, `mid:importers-done` fires with the final count; on failure
+     `mid:importers-error` carries the message.
+
+## Adding a new importer
+
+1. Create a folder: `apps/electron/importers/my-importer/`.
+2. Add `index.ts` whose default export satisfies `Importer`:
+
+   ```ts
+   import { Importer, ImportedNote, ImportContext } from '../types';
+
+   const myImporter: Importer = {
+     id: 'my-importer',
+     name: 'My App',
+     icon: 'bx-import',
+     supportedFormats: ['folder'],
+     description: 'Imports notes from My App.',
+
+     async detect(input) {
+       // Cheap probe — return true if this folder/file looks like My App.
+       return false;
+     },
+
+     async *import(input, ctx) {
+       ctx.log(`[my-importer] scanning ${input}`);
+       // Walk the source, yield ImportedNote objects.
+       yield {
+         title: 'Example',
+         body: '# Example\n\nbody…',
+         tags: ['my-importer'],
+         createdAt: new Date().toISOString(),
+       };
+     },
+   };
+
+   export default myImporter;
+   ```
+
+3. `npm run compile:electron` — TypeScript picks the new file up automatically
+   because `apps/electron/tsconfig.json` includes `importers/**/*.ts`.
+4. Restart the app. The startup log lists your importer; it appears in both
+   the activity-bar chooser and the **File → Import from…** menu.
+
+That's it. **No changes** to:
+
+- `apps/electron/importers/loader.ts`
+- `apps/electron/main.ts`
+- `apps/electron/preload.ts`
+- `apps/electron/renderer/renderer.ts`
+- `apps/electron/renderer/index.html`
+
+If a change to one of those files becomes necessary for a future importer (e.g.
+to surface a new `ImporterInput.kind`), that's a contract change — bump the
+contract in `types.ts` and update this doc in the same PR.
+
+## Testing locally
+
+```bash
+npm run compile:electron
+npm run dev:electron
+```
+
+Click **Import from…** in the activity bar (or **File → Import from…**), pick
+the **Sample (smoke test)** entry, and confirm:
+
+- Progress text reads `Imported 1 note…`.
+- A note titled `Hello from the sample importer.md` lands under
+  `<workspace>/Imported/sample/`.
+- The file tree refreshes once the importer is done.
+
+If the loader can't find a registered importer, the chooser shows the empty-
+state message instead — that's a sign the loader scan didn't pick anything up
+(check the main-process console for `[importers] skip <name> — …` lines).
+
+## File layout
+
+```
+apps/electron/
+├── importers/
+│   ├── types.ts          ← contract (this PR)
+│   ├── loader.ts         ← scanner + registry (this PR)
+│   └── sample/
+│       └── index.ts      ← smoke test (this PR)
+├── main.ts               ← IPC + init (this PR adds a block at the bottom)
+├── preload.ts            ← exposes window.mid.importers* (this PR)
+└── renderer/
+    ├── renderer.ts       ← chooser modal (this PR adds a block at the bottom)
+    ├── renderer.css      ← chooser styles (this PR adds a block at the bottom)
+    └── index.html        ← unchanged
+```


### PR DESCRIPTION
## Summary

Foundation for the v0.10 importer milestone. Defines the plugin contract,
loader, IPC surface, and chooser modal so subsequent first-party importers
(#247–#250) drop in as a single folder under `apps/electron/importers/<id>/`
with zero changes to core code.

- `apps/electron/importers/types.ts` — `Importer`, `ImporterMetadata`,
  `ImportedNote`, `ImportContext`, `ImportedAttachment`, `isImporter` guard.
- `apps/electron/importers/loader.ts` — discovers + validates +
  registers; logs `[importers] registered: …` at startup; cached in-process.
- `apps/electron/importers/sample/index.ts` — single hardcoded-note
  smoke-test importer that proves the pipeline end-to-end.
- `apps/electron/main.ts` — `mid:importers-list` + `mid:importers-run`
  IPCs (and `mid:importers-{progress,done,error,log}` push channels) added
  in a self-contained block at the bottom of the file. Notes are written
  to `<workspace>/Imported/<importer-id>/` with frontmatter.
- `apps/electron/preload.ts` — `window.mid.importersList/Run` plus event
  subscriptions and `onMenuImport`.
- Renderer — "Import from…" entry in the activity bar and File menu;
  modal that streams progress as notes hit disk. All new code at the
  bottom of `renderer.ts` / `renderer.css` to minimise conflicts with
  concurrent settings (#232/#233/#234) and spotlight (#235) work.
- `docs/importers.md` — contract + step-by-step "how to add an importer".

Smoke test (locally):
```
$ node -e "require('./out/electron/importers/loader').loadImporters({importerRootDir:'./out/electron/importers',log:console.log})"
[importers] registered: sample
```

## Acceptance criteria
- [x] Contract types declared (`apps/electron/importers/types.ts`).
- [x] Loader scans the directory and registers each importer.
- [x] `mid:importers-list` IPC returns the metadata array.
- [x] "Import from…" chooser modal in renderer (activity bar + File menu).
- [x] Sample importer runs end-to-end and writes a note to disk.
- [x] Adding a new importer requires zero changes to loader/renderer/main —
      drop in `apps/electron/importers/<id>/index.ts` and recompile.
- [x] `docs/importers.md` walks through the contract and adding an importer.

## Test plan
- [ ] `npm run compile:electron` passes (verified in this PR).
- [ ] `npm run lint` introduces no new errors (verified — only pre-existing
      warnings remain).
- [ ] Run `npm run dev:electron`, click **Import from…** in the activity
      bar, pick **Sample (smoke test)**, and confirm a note named
      `Hello from the sample importer.md` appears under
      `<workspace>/Imported/sample/`.
- [ ] Confirm **File → Import from…** opens the same chooser.
- [ ] Drop a stub `apps/electron/importers/foo/index.ts` exporting a valid
      `Importer` — confirm it shows up after restart with no other code
      changes.

Closes #246