### PR TITLE
feat(desktop): first-run GitHub warehouse onboarding (#236)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -313,6 +313,33 @@ ipcMain.handle('mid:warehouses-list', async (_e, workspace: string): Promise<War
   }
 });
 
+/**
+ * Append (or upsert by id) a warehouse to `<workspace>/.mid/warehouse.json`.
+ * Creates the file + directory if missing. The first warehouse persisted via
+ * this handler doubles as the active warehouse for the workspace until the
+ * user attaches notes to a different one — the onboarding flow (#236) relies
+ * on that to drop the user straight into a working state.
+ */
+ipcMain.handle('mid:warehouses-add', async (_e, workspace: string, warehouse: Warehouse): Promise<{ ok: boolean; warehouses: Warehouse[]; error?: string }> => {
+  try {
+    const dir = path.join(workspace, NOTES_DIR);
+    await fs.mkdir(dir, { recursive: true });
+    const file = path.join(dir, 'warehouse.json');
+    let existing: Warehouse[] = [];
+    try {
+      const raw = await fs.readFile(file, 'utf8');
+      const parsed = JSON.parse(raw) as { warehouses?: Warehouse[] };
+      if (Array.isArray(parsed.warehouses)) existing = parsed.warehouses;
+    } catch { /* missing/malformed → start fresh */ }
+    const next = existing.filter(w => w.id !== warehouse.id);
+    next.push(warehouse);
+    await fs.writeFile(file, JSON.stringify({ warehouses: next }, null, 2), 'utf8');
+    return { ok: true, warehouses: next };
+  } catch (err) {
+    return { ok: false, warehouses: [], error: (err as Error).message };
+  }
+});
+
 ipcMain.handle('mid:notes-attach-warehouse', async (_e, workspace: string, id: string, warehouseId: string | null) => {
   const notes = await readNotes(workspace);
   const note = notes.find(n => n.id === id);
@@ -711,6 +738,13 @@ interface AppState {
   workspaces?: { id: string; name: string; path: string }[];
   activeWorkspace?: string;
   ghToken?: string;
+  /**
+   * Workspace ids whose user has dismissed the warehouse onboarding modal
+   * at least once. Tracked so the modal doesn't reappear on every launch
+   * for users who deliberately skip — they can re-enter from the status-bar
+   * repo button context menu. See #236.
+   */
+  warehouseOnboardingDismissed?: string[];
 }
 
 function resolveMCPServerScript(): string {

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -27,6 +27,7 @@ export interface AppState {
   pinnedFolders?: { path: string; name: string; icon: string; color: string }[];
   workspaces?: { id: string; name: string; path: string }[];
   activeWorkspace?: string;
+  warehouseOnboardingDismissed?: string[];
 }
 
 export interface NoteEntry {
@@ -78,6 +79,8 @@ contextBridge.exposeInMainWorld('mid', {
     ipcRenderer.invoke('mid:notes-tag', workspace, id, tags),
   warehousesList: (workspace: string): Promise<Warehouse[]> =>
     ipcRenderer.invoke('mid:warehouses-list', workspace),
+  warehousesAdd: (workspace: string, warehouse: Warehouse): Promise<{ ok: boolean; warehouses: Warehouse[]; error?: string }> =>
+    ipcRenderer.invoke('mid:warehouses-add', workspace, warehouse),
   notesAttachWarehouse: (workspace: string, id: string, warehouseId: string | null): Promise<NoteEntry | null> =>
     ipcRenderer.invoke('mid:notes-attach-warehouse', workspace, id, warehouseId),
   notesMarkPushed: (workspace: string, id: string): Promise<NoteEntry | null> =>

--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -168,6 +168,26 @@
     <button id="mid-mermaid-editor-save" class="mid-btn mid-btn--primary">Save</button>
   </footer>
 </dialog>
+<dialog id="mid-warehouse-onboarding" class="mid-onboarding" aria-labelledby="mid-onboarding-title">
+  <div class="mid-onboarding-frame">
+    <header class="mid-onboarding-header">
+      <h2 class="mid-onboarding-title" id="mid-onboarding-title">Set up your notes warehouse</h2>
+      <button id="mid-onboarding-close" class="mid-btn mid-btn--icon mid-btn--ghost" title="Skip" data-icon="x"></button>
+    </header>
+    <ol class="mid-onboarding-steps" id="mid-onboarding-steps">
+      <li class="is-active" data-step="gh">1 &middot; GitHub CLI</li>
+      <li data-step="auth">2 &middot; Sign in</li>
+      <li data-step="repo">3 &middot; Pick a repo</li>
+    </ol>
+    <div class="mid-onboarding-body" id="mid-onboarding-body"></div>
+    <footer class="mid-onboarding-footer">
+      <button id="mid-onboarding-skip" class="mid-btn">Skip</button>
+      <span style="flex:1"></span>
+      <button id="mid-onboarding-back" class="mid-btn" hidden>Back</button>
+      <button id="mid-onboarding-next" class="mid-btn mid-btn--primary" hidden>Next</button>
+    </footer>
+  </div>
+</dialog>
 <dialog id="mid-dialog" class="mid-dialog">
   <form method="dialog" class="mid-dialog-form">
     <h3 class="mid-dialog-title" id="mid-dialog-title"></h3>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -1874,3 +1874,147 @@ body.has-outline.has-sidebar .mid-shell {
 body.is-printing .mid-outline { display: none !important; }
 body.is-printing .mid-shell { grid-template-columns: 1fr !important; }
 
+
+
+/* Warehouse onboarding wizard (#236) */
+.mid-onboarding {
+  margin: auto;
+  padding: 0;
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-lg);
+  background: var(--mid-bg);
+  color: var(--mid-fg);
+  box-shadow: var(--mid-shadow-lg);
+  width: min(560px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+}
+.mid-onboarding::backdrop { background: rgba(0, 0, 0, 0.55); backdrop-filter: blur(4px); }
+.mid-onboarding[open] .mid-onboarding-frame { display: flex; }
+.mid-onboarding-frame { flex-direction: column; gap: var(--mid-space-4); padding: var(--mid-space-5); }
+.mid-onboarding-header { display: flex; align-items: center; justify-content: space-between; gap: var(--mid-space-3); }
+.mid-onboarding-title { margin: 0; font-size: var(--mid-font-size-lg); font-weight: var(--mid-weight-semibold); }
+.mid-onboarding-steps {
+  display: flex;
+  gap: var(--mid-space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+}
+.mid-onboarding-steps li {
+  flex: 1;
+  padding: var(--mid-space-2) var(--mid-space-3);
+  border-radius: var(--mid-radius-md);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  text-align: center;
+}
+.mid-onboarding-steps li.is-active {
+  background: var(--mid-accent-soft, var(--mid-surface));
+  color: var(--mid-fg);
+  border-color: var(--mid-accent, var(--mid-border));
+  font-weight: var(--mid-weight-medium);
+}
+.mid-onboarding-steps li.is-done {
+  color: var(--mid-fg-muted);
+  background: var(--mid-bg);
+}
+.mid-onboarding-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-3);
+  font-size: var(--mid-font-size-sm);
+  line-height: var(--mid-line-relaxed);
+  min-height: 180px;
+  max-height: 50vh;
+  overflow-y: auto;
+}
+.mid-onboarding-body p { margin: 0; }
+.mid-onboarding-body code,
+.mid-onboarding-body kbd {
+  font-family: var(--mid-font-mono);
+  font-size: var(--mid-font-size-xs);
+  padding: 1px 6px;
+  background: var(--mid-inline-code-bg, var(--mid-surface));
+  border-radius: var(--mid-radius-sm);
+  border: 1px solid var(--mid-border);
+}
+.mid-onboarding-cmd {
+  display: flex;
+  align-items: center;
+  gap: var(--mid-space-2);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-md);
+  padding: var(--mid-space-2) var(--mid-space-3);
+  font-family: var(--mid-font-mono);
+  font-size: var(--mid-font-size-sm);
+}
+.mid-onboarding-cmd code { flex: 1; background: transparent; border: 0; padding: 0; }
+.mid-onboarding-actions { display: flex; flex-wrap: wrap; gap: var(--mid-space-2); }
+.mid-onboarding-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-2);
+  padding: var(--mid-space-3);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-md);
+  background: var(--mid-surface);
+}
+.mid-onboarding-card-title { font-weight: var(--mid-weight-medium); display: flex; align-items: center; gap: var(--mid-space-2); }
+.mid-onboarding-card-hint { color: var(--mid-fg-muted); font-size: var(--mid-font-size-xs); }
+.mid-onboarding-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mid-space-2);
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+}
+.mid-onboarding-input {
+  width: 100%;
+  padding: var(--mid-space-2) var(--mid-space-3);
+  font-size: var(--mid-font-size-sm);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-md);
+  background: var(--mid-bg);
+  color: var(--mid-fg);
+  font-family: var(--mid-font-mono);
+}
+.mid-onboarding-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-md);
+  max-height: 220px;
+  overflow-y: auto;
+  background: var(--mid-bg);
+}
+.mid-onboarding-list-row {
+  display: flex;
+  align-items: center;
+  gap: var(--mid-space-2);
+  padding: var(--mid-space-2) var(--mid-space-3);
+  text-align: left;
+  background: transparent;
+  border: 0;
+  color: var(--mid-fg);
+  font-size: var(--mid-font-size-sm);
+  cursor: pointer;
+  font-family: inherit;
+}
+.mid-onboarding-list-row:hover { background: var(--mid-surface); }
+.mid-onboarding-list-row.is-active { background: var(--mid-accent-soft, var(--mid-surface)); }
+.mid-onboarding-list-row-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: var(--mid-weight-medium); }
+.mid-onboarding-list-row-meta { font-size: var(--mid-font-size-xs); color: var(--mid-fg-muted); }
+.mid-onboarding-footer { display: flex; align-items: center; gap: var(--mid-space-2); }
+.mid-onboarding-error {
+  border: 1px solid var(--mid-border);
+  background: var(--mid-surface);
+  color: var(--mid-fg);
+  padding: var(--mid-space-2) var(--mid-space-3);
+  border-radius: var(--mid-radius-md);
+  font-size: var(--mid-font-size-xs);
+  white-space: pre-wrap;
+}

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -1883,6 +1883,9 @@ function applyFolder(folderPath: string, tree: TreeEntry[]): void {
     treeRoot.appendChild(empty);
   }
   void refreshRepoStatus();
+  // First-run: if no warehouse is configured for this workspace and the
+  // user hasn't dismissed the modal, drop into onboarding (#236).
+  void maybeShowOnboarding();
 }
 
 async function refreshRepoStatus(): Promise<void> {
@@ -2051,6 +2054,394 @@ async function runGhDeviceFlow(): Promise<boolean> {
   }
   await midConfirm('Auth timed out', 'No token received within 5 minutes.');
   return false;
+}
+
+
+/* ── Warehouse onboarding wizard (#236) ───────────────────────────────
+ * First-launch flow that walks the user from a bare workspace to a
+ * working notes warehouse without leaving the app:
+ *   step 1 (gh):   detect the gh CLI; if absent, link to the install docs.
+ *   step 2 (auth): if not signed in, offer Terminal command + device flow.
+ *   step 3 (repo): pick an existing repo or create one named <ws>-notes.
+ *
+ * Trigger: after a folder has been opened, if no warehouse is registered
+ * for the active workspace AND the user hasn't dismissed the modal for
+ * that workspace before. Dismissals live in
+ * `AppState.warehouseOnboardingDismissed: string[]` keyed by workspace id.
+ *
+ * Re-trigger: status-bar repo button context menu has a "Set up warehouse…"
+ * entry that calls `openWarehouseOnboarding(true)` (force = true ignores
+ * the dismissed list).
+ */
+
+type OnboardingStep = 'gh' | 'auth' | 'repo';
+
+interface OnboardingState {
+  step: OnboardingStep;
+  ghInstalled: boolean;
+  ghAuthed: boolean;
+  ghStatusOutput: string;
+  repos: { nameWithOwner: string; description: string; visibility: string }[];
+  reposLoaded: boolean;
+  selectedRepo: string;
+  customSlug: string;
+  busy: boolean;
+  error: string;
+}
+
+let onboardingActive = false;
+
+function workspaceSlugFromPath(folderPath: string): string {
+  const base = folderPath.split('/').filter(Boolean).pop() ?? 'notes';
+  const slug = base.toLowerCase().replace(/[\s_]+/g, '-').replace(/[^a-z0-9-]/g, '').replace(/-+/g, '-').replace(/^-|-$/g, '');
+  return slug || 'notes';
+}
+
+function defaultRepoNameForWorkspace(folderPath: string): string {
+  return `${workspaceSlugFromPath(folderPath)}-notes`;
+}
+
+function workspaceIdForCurrent(): string | null {
+  if (!currentFolder) return null;
+  const ws = workspaces.find(w => w.path === currentFolder);
+  return ws ? ws.id : currentFolder;
+}
+
+function isGhMissing(output: string): boolean {
+  const o = output.toLowerCase();
+  return o.includes('enoent') || o.includes('command not found') || o.includes('spawn gh') || o.includes('not found');
+}
+
+async function shouldAutoShowOnboarding(): Promise<boolean> {
+  if (!currentFolder) return false;
+  const wsId = workspaceIdForCurrent();
+  if (!wsId) return false;
+  try {
+    const existing = await window.mid.warehousesList(currentFolder);
+    if (existing.length > 0) return false;
+  } catch { /* surface as 'no warehouse' */ }
+  const state = await window.mid.readAppState();
+  const dismissed = Array.isArray(state.warehouseOnboardingDismissed) ? state.warehouseOnboardingDismissed : [];
+  if (dismissed.includes(wsId)) return false;
+  return true;
+}
+
+async function maybeShowOnboarding(): Promise<void> {
+  if (onboardingActive) return;
+  if (await shouldAutoShowOnboarding()) {
+    void openWarehouseOnboarding();
+  }
+}
+
+async function dismissOnboardingForCurrentWorkspace(): Promise<void> {
+  const wsId = workspaceIdForCurrent();
+  if (!wsId) return;
+  const state = await window.mid.readAppState();
+  const prev = Array.isArray(state.warehouseOnboardingDismissed) ? state.warehouseOnboardingDismissed : [];
+  if (prev.includes(wsId)) return;
+  await window.mid.patchAppState({ warehouseOnboardingDismissed: [...prev, wsId] });
+}
+
+async function openWarehouseOnboarding(force = false): Promise<void> {
+  if (!currentFolder) {
+    flashStatus('Open a folder before configuring a warehouse');
+    return;
+  }
+  if (onboardingActive) return;
+  onboardingActive = true;
+  if (force) {
+    const state = await window.mid.readAppState();
+    const prev = Array.isArray(state.warehouseOnboardingDismissed) ? state.warehouseOnboardingDismissed : [];
+    const wsId = workspaceIdForCurrent();
+    if (wsId && prev.includes(wsId)) {
+      await window.mid.patchAppState({ warehouseOnboardingDismissed: prev.filter(id => id !== wsId) });
+    }
+  }
+  const dlg = document.getElementById('mid-warehouse-onboarding') as HTMLDialogElement;
+  const body = document.getElementById('mid-onboarding-body') as HTMLDivElement;
+  const stepsEl = document.getElementById('mid-onboarding-steps') as HTMLOListElement;
+  const skipBtn = document.getElementById('mid-onboarding-skip') as HTMLButtonElement;
+  const closeBtn = document.getElementById('mid-onboarding-close') as HTMLButtonElement;
+  const backBtn = document.getElementById('mid-onboarding-back') as HTMLButtonElement;
+  const nextBtn = document.getElementById('mid-onboarding-next') as HTMLButtonElement;
+
+  const state: OnboardingState = {
+    step: 'gh',
+    ghInstalled: false,
+    ghAuthed: false,
+    ghStatusOutput: '',
+    repos: [],
+    reposLoaded: false,
+    selectedRepo: '',
+    customSlug: defaultRepoNameForWorkspace(currentFolder),
+    busy: false,
+    error: '',
+  };
+
+  const refreshStepsHeader = (): void => {
+    const order: OnboardingStep[] = ['gh', 'auth', 'repo'];
+    const activeIdx = order.indexOf(state.step);
+    Array.from(stepsEl.children).forEach((li, idx) => {
+      li.classList.remove('is-active', 'is-done');
+      if (idx === activeIdx) li.classList.add('is-active');
+      else if (idx < activeIdx) li.classList.add('is-done');
+    });
+  };
+
+  const closeOnboarding = (markDismissed: boolean): void => {
+    if (markDismissed) void dismissOnboardingForCurrentWorkspace();
+    skipBtn.removeEventListener('click', onSkip);
+    closeBtn.removeEventListener('click', onSkip);
+    backBtn.removeEventListener('click', onBack);
+    nextBtn.removeEventListener('click', onNext);
+    dlg.removeEventListener('cancel', onCancel);
+    if (dlg.open) dlg.close();
+    onboardingActive = false;
+  };
+
+  const onSkip = (): void => closeOnboarding(true);
+  const onCancel = (e: Event): void => { e.preventDefault(); closeOnboarding(true); };
+
+  const renderError = (): string => state.error
+    ? `<div class="mid-onboarding-error">${escapeHTML(state.error)}</div>`
+    : '';
+
+  const renderGhStep = async (): Promise<void> => {
+    state.busy = true;
+    body.innerHTML = `<p>${iconHTML('refresh', 'mid-icon--sm')} Detecting <code>gh</code> CLI…</p>`;
+    nextBtn.hidden = true;
+    backBtn.hidden = true;
+    const status = await window.mid.ghAuthStatus();
+    state.ghStatusOutput = status.output;
+    state.ghInstalled = status.authenticated || !isGhMissing(status.output);
+    state.ghAuthed = status.authenticated;
+    state.busy = false;
+    if (state.ghInstalled && state.ghAuthed) {
+      state.step = 'repo';
+      refreshStepsHeader();
+      void renderRepoStep();
+      return;
+    }
+    if (state.ghInstalled && !state.ghAuthed) {
+      state.step = 'auth';
+      refreshStepsHeader();
+      renderAuthStep();
+      return;
+    }
+    body.innerHTML = `
+      <p>The <code>gh</code> CLI isn't installed yet. It's the easiest way to connect Mark It Down to GitHub for your notes warehouse.</p>
+      <div class="mid-onboarding-card">
+        <div class="mid-onboarding-card-title">${iconHTML('download', 'mid-icon--sm')} Install GitHub CLI</div>
+        <p class="mid-onboarding-card-hint">The official page lists Homebrew, winget, apt, dnf and more.</p>
+        <div class="mid-onboarding-actions">
+          <button class="mid-btn mid-btn--primary" data-onboarding-action="open-install">${iconHTML('github', 'mid-icon--sm')} Open install page</button>
+          <button class="mid-btn" data-onboarding-action="recheck">${iconHTML('refresh', 'mid-icon--sm')} Continue once installed</button>
+        </div>
+      </div>
+      <p class="mid-onboarding-card-hint">Prefer not to install it? You can sign in via the GitHub OAuth device flow on the next step.</p>
+      <div class="mid-onboarding-actions">
+        <button class="mid-btn" data-onboarding-action="device-fallback">Use device flow instead</button>
+      </div>
+      ${renderError()}
+    `;
+    nextBtn.hidden = true;
+    backBtn.hidden = true;
+    body.querySelector<HTMLButtonElement>('[data-onboarding-action="open-install"]')?.addEventListener('click', () => {
+      void window.mid.openExternal('https://cli.github.com/');
+    });
+    body.querySelector<HTMLButtonElement>('[data-onboarding-action="recheck"]')?.addEventListener('click', () => {
+      state.error = '';
+      void renderGhStep();
+    });
+    body.querySelector<HTMLButtonElement>('[data-onboarding-action="device-fallback"]')?.addEventListener('click', () => {
+      state.step = 'auth';
+      refreshStepsHeader();
+      renderAuthStep(/* deviceOnly */ true);
+    });
+  };
+
+  const renderAuthStep = (deviceOnly = false): void => {
+    backBtn.hidden = false;
+    nextBtn.hidden = true;
+    body.innerHTML = `
+      <p>Sign in to GitHub so Mark It Down can list and create repos for your notes warehouse.</p>
+      ${deviceOnly ? '' : `
+      <div class="mid-onboarding-card">
+        <div class="mid-onboarding-card-title">${iconHTML('github', 'mid-icon--sm')} Use the Terminal</div>
+        <p class="mid-onboarding-card-hint">Run this in any terminal, follow the browser prompt, then come back and click <em>Re-check</em>.</p>
+        <div class="mid-onboarding-cmd"><code>gh auth login</code><button class="mid-btn mid-btn--icon" data-onboarding-action="copy-cmd" title="Copy">${iconHTML('copy', 'mid-icon--sm')}</button></div>
+        <div class="mid-onboarding-actions">
+          <button class="mid-btn" data-onboarding-action="recheck-auth">${iconHTML('refresh', 'mid-icon--sm')} Re-check</button>
+        </div>
+      </div>
+      `}
+      <div class="mid-onboarding-card">
+        <div class="mid-onboarding-card-title">${iconHTML('github', 'mid-icon--sm')} Use device flow</div>
+        <p class="mid-onboarding-card-hint">Get a one-time code, open <code>github.com/login/device</code>, and authorize Mark It Down — no terminal needed.</p>
+        <div class="mid-onboarding-actions">
+          <button class="mid-btn mid-btn--primary" data-onboarding-action="device-flow">Start device flow</button>
+        </div>
+      </div>
+      ${renderError()}
+    `;
+    body.querySelector<HTMLButtonElement>('[data-onboarding-action="copy-cmd"]')?.addEventListener('click', () => {
+      void navigator.clipboard.writeText('gh auth login').then(() => flashStatus('Copied: gh auth login'));
+    });
+    body.querySelector<HTMLButtonElement>('[data-onboarding-action="recheck-auth"]')?.addEventListener('click', () => {
+      state.error = '';
+      void renderGhStep();
+    });
+    body.querySelector<HTMLButtonElement>('[data-onboarding-action="device-flow"]')?.addEventListener('click', async () => {
+      state.error = '';
+      const ok = await runGhDeviceFlow();
+      if (ok) {
+        state.ghAuthed = true;
+        state.step = 'repo';
+        refreshStepsHeader();
+        void renderRepoStep();
+      } else {
+        state.error = 'Device flow did not complete. Retry, or sign in via gh auth login.';
+        renderAuthStep(deviceOnly);
+      }
+    });
+  };
+
+  const renderRepoStep = async (): Promise<void> => {
+    backBtn.hidden = false;
+    nextBtn.hidden = false;
+    nextBtn.textContent = 'Use this repo';
+    nextBtn.disabled = !state.selectedRepo;
+    if (!state.reposLoaded) {
+      body.innerHTML = `<p>${iconHTML('refresh', 'mid-icon--sm')} Loading your repos…</p>`;
+      const result = await window.mid.ghRepoList();
+      state.repos = result.repos;
+      state.reposLoaded = true;
+      if (!result.ok) state.error = result.error ?? 'gh repo list failed';
+    }
+    const defaultSlug = defaultRepoNameForWorkspace(currentFolder ?? '');
+    body.innerHTML = `
+      <p>Pick an existing GitHub repo to host your notes, or create a new private one. The first chosen repo becomes the active warehouse for this workspace.</p>
+      <div class="mid-onboarding-card">
+        <div class="mid-onboarding-card-title">${iconHTML('plus', 'mid-icon--sm')} Create a new private repo</div>
+        <p class="mid-onboarding-card-hint">The default name is derived from the workspace folder. Edit before submitting if you'd like a different slug.</p>
+        <input id="mid-onboarding-create-slug" class="mid-onboarding-input" type="text" value="${escapeHTML(state.customSlug || defaultSlug)}" spellcheck="false" />
+        <div class="mid-onboarding-actions">
+          <button class="mid-btn mid-btn--primary" data-onboarding-action="create-repo">${iconHTML('github', 'mid-icon--sm')} Create &amp; use</button>
+        </div>
+      </div>
+      <div class="mid-onboarding-card">
+        <div class="mid-onboarding-card-title">${iconHTML('github', 'mid-icon--sm')} Or pick an existing repo</div>
+        <input id="mid-onboarding-repo-filter" class="mid-onboarding-input" type="text" placeholder="Filter…" />
+        <div class="mid-onboarding-list" id="mid-onboarding-repo-list"></div>
+        <div class="mid-onboarding-status">${state.repos.length} repo${state.repos.length === 1 ? '' : 's'} loaded</div>
+      </div>
+      ${renderError()}
+    `;
+    const slugInput = body.querySelector<HTMLInputElement>('#mid-onboarding-create-slug');
+    slugInput?.addEventListener('input', () => { state.customSlug = slugInput.value; });
+    const filterInput = body.querySelector<HTMLInputElement>('#mid-onboarding-repo-filter');
+    const listEl = body.querySelector<HTMLDivElement>('#mid-onboarding-repo-list');
+    const renderList = (): void => {
+      if (!listEl) return;
+      const q = (filterInput?.value ?? '').trim().toLowerCase();
+      const matches = q
+        ? state.repos.filter(r => r.nameWithOwner.toLowerCase().includes(q) || (r.description ?? '').toLowerCase().includes(q))
+        : state.repos;
+      listEl.replaceChildren();
+      if (matches.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'mid-onboarding-status';
+        empty.textContent = state.repos.length === 0 ? 'No repos found via gh repo list.' : 'No matches.';
+        listEl.appendChild(empty);
+        return;
+      }
+      for (const r of matches.slice(0, 100)) {
+        const row = document.createElement('button');
+        row.type = 'button';
+        row.className = 'mid-onboarding-list-row';
+        if (state.selectedRepo === r.nameWithOwner) row.classList.add('is-active');
+        row.innerHTML = `<span class="mid-onboarding-list-row-name">${escapeHTML(r.nameWithOwner)}</span><span class="mid-onboarding-list-row-meta">${escapeHTML(r.visibility?.toLowerCase() ?? '')}</span>`;
+        if (r.description) row.title = r.description;
+        row.addEventListener('click', () => {
+          state.selectedRepo = r.nameWithOwner;
+          nextBtn.disabled = false;
+          renderList();
+        });
+        listEl.appendChild(row);
+      }
+    };
+    filterInput?.addEventListener('input', renderList);
+    renderList();
+    body.querySelector<HTMLButtonElement>('[data-onboarding-action="create-repo"]')?.addEventListener('click', async () => {
+      const slugRaw = (slugInput?.value ?? '').trim();
+      if (!slugRaw) { state.error = 'Repo name is required'; void renderRepoStep(); return; }
+      const result = await window.mid.ghRepoCreate(slugRaw, 'private');
+      if (!result.ok) {
+        state.error = `gh repo create failed: ${result.error ?? 'unknown'}`;
+        void renderRepoStep();
+        return;
+      }
+      const url = (result.url ?? '').trim();
+      const m = /github\.com[:/]([^/]+\/[^/.]+?)(?:\.git)?\/?$/.exec(url);
+      const finalSlug = m ? m[1] : slugRaw;
+      await persistAndConnect(finalSlug);
+    });
+    nextBtn.onclick = (): void => {
+      if (state.selectedRepo) void persistAndConnect(state.selectedRepo);
+    };
+  };
+
+  const persistAndConnect = async (slug: string): Promise<void> => {
+    if (!currentFolder) return;
+    state.busy = true;
+    nextBtn.disabled = true;
+    backBtn.disabled = true;
+    const id = workspaceSlugFromPath(currentFolder);
+    const name = slug.split('/').pop() ?? slug;
+    const addResult = await window.mid.warehousesAdd(currentFolder, { id, name, repo: slug });
+    if (!addResult.ok) {
+      state.error = `Could not save warehouse: ${addResult.error ?? 'unknown'}`;
+      state.busy = false;
+      nextBtn.disabled = false;
+      backBtn.disabled = false;
+      void renderRepoStep();
+      return;
+    }
+    try {
+      await window.mid.repoConnect(currentFolder, slug);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('[mid] repoConnect failed during onboarding:', err);
+    }
+    flashStatus(`Warehouse ready: ${slug}`);
+    warehouses = await window.mid.warehousesList(currentFolder);
+    void refreshRepoStatus();
+    closeOnboarding(/* markDismissed */ false);
+  };
+
+  const onBack = (): void => {
+    if (state.step === 'auth') { state.step = 'gh'; refreshStepsHeader(); void renderGhStep(); }
+    else if (state.step === 'repo') {
+      state.step = state.ghAuthed ? 'gh' : 'auth';
+      refreshStepsHeader();
+      if (state.step === 'gh') void renderGhStep();
+      else renderAuthStep();
+    }
+  };
+
+  const onNext = (): void => {
+    if (state.step === 'repo' && state.selectedRepo) void persistAndConnect(state.selectedRepo);
+  };
+
+  skipBtn.addEventListener('click', onSkip);
+  closeBtn.addEventListener('click', onSkip);
+  backBtn.addEventListener('click', onBack);
+  nextBtn.addEventListener('click', onNext);
+  dlg.addEventListener('cancel', onCancel);
+
+  refreshStepsHeader();
+  if (!dlg.open) dlg.showModal();
+  void renderGhStep();
 }
 
 // Conflict banner for git pull --rebase failures
@@ -3074,12 +3465,15 @@ statusRepoBtn.addEventListener('contextmenu', e => {
   if (!currentFolder) return;
   e.preventDefault();
   const connected = statusRepoBtn.dataset.connected === 'true';
+  const setupItem = { icon: 'github', label: 'Set up warehouse…', action: () => void openWarehouseOnboarding(true) };
   openContextMenu(connected ? [
     { icon: 'refresh', label: 'Sync (commit + pull + push)', action: () => void syncRepo() },
     { separator: true, label: '' },
     { icon: 'github', label: 'Connect to a different repo…', action: () => void promptConnectRepo() },
+    setupItem,
   ] : [
     { icon: 'github', label: 'Connect repo…', action: () => void promptConnectRepo() },
+    setupItem,
   ], e.clientX, e.clientY);
 });
 

--- a/docs/desktop-warehouse-onboarding.md
+++ b/docs/desktop-warehouse-onboarding.md
@@ -1,0 +1,180 @@
+# Desktop · First-run warehouse onboarding
+
+Status: shipped in v0.3.x · Issue: [#236](https://github.com/fadymondy/mark-it-down/issues/236) · Depends on: [#220 GitHub OAuth device-flow](https://github.com/fadymondy/mark-it-down/issues/220), [#228 gh CLI repo picker / create](https://github.com/fadymondy/mark-it-down/issues/228)
+
+The first time you open a workspace folder in Mark It Down's desktop app, a guided modal walks you from a bare workspace to a working **notes warehouse** — a GitHub repo that hosts the markdown files behind your sidebar Notes — without ever leaving the app.
+
+## At a glance
+
+| | |
+|---|---|
+| **Where** | A modal dialog (`#mid-warehouse-onboarding`) that auto-opens after `applyFolder()` fires |
+| **When** | First time a folder is opened that has **no** entry in `<workspace>/.mid/warehouse.json` AND has not been added to `AppState.warehouseOnboardingDismissed` |
+| **What** | Three-step wizard: detect `gh` CLI → sign in (Terminal *or* device flow) → pick or create a repo |
+| **Re-trigger** | Right-click the status-bar repo button → **Set up warehouse…** |
+| **Skip** | The Skip button (and the close `x` and the Esc key) all dismiss the modal and remember your choice for that workspace |
+
+## The flow
+
+```
+folder opened
+     │
+     ▼
+warehouse.json has entries? ─── yes ──► (skip onboarding entirely)
+     │ no
+     ▼
+workspace id in warehouseOnboardingDismissed? ─── yes ──► (skip — user can re-trigger)
+     │ no
+     ▼
+┌──────────────────────────────────────────┐
+│ Step 1 · GitHub CLI                       │
+│   run mid:gh-auth-status                  │
+│     ENOENT/"command not found" → install  │
+│     present, not authed         → step 2  │
+│     present + authed            → step 3  │
+└──────────────────────────────────────────┘
+                │
+                ▼
+┌──────────────────────────────────────────┐
+│ Step 2 · Sign in                          │
+│   • copy `gh auth login` + Re-check       │
+│   • or trigger runGhDeviceFlow()          │
+└──────────────────────────────────────────┘
+                │ (token acquired)
+                ▼
+┌──────────────────────────────────────────┐
+│ Step 3 · Pick a repo                      │
+│   • create new private repo               │
+│       default name = <workspace>-notes    │
+│   • or pick from gh repo list (filter)    │
+└──────────────────────────────────────────┘
+                │
+                ▼
+mid:warehouses-add → write <workspace>/.mid/warehouse.json
+mid:repo-connect    → wire the local git remote (best-effort)
+                │
+                ▼
+modal closes, status bar lights up
+```
+
+## Step 1 — Detect the `gh` CLI
+
+The wizard runs the existing [`mid:gh-auth-status`](../apps/electron/main.ts) IPC, which shells out to `gh auth status`. The renderer (`isGhMissing()`) reads the captured output:
+
+- `ENOENT`, `command not found`, `spawn gh`, or `not found` → the **gh missing** branch.
+- Any other failure → the **not authed** branch (Step 2).
+- Success → straight to Step 3.
+
+The gh-missing branch shows install instructions and two buttons:
+
+1. **Open install page** uses `mid:open-external` to open <https://cli.github.com/>. Homebrew, winget, apt, dnf and standalone installers are all listed there — Mark It Down doesn't try to install anything itself.
+2. **Continue once installed** re-runs `gh auth status` and re-routes based on the new state. No app restart required.
+
+There's also a tertiary **Use device flow instead** button that jumps straight to Step 2 with the device-flow option only — handy on locked-down systems where installing `gh` isn't possible.
+
+## Step 2 — Sign in
+
+Two paths are offered side-by-side:
+
+### Terminal command
+
+```sh
+gh auth login
+```
+
+The command is shown in a copy-friendly chip (one-click clipboard). The user runs it in their terminal, finishes the browser dance, and clicks **Re-check** in the modal. We re-run `mid:gh-auth-status` and route forward.
+
+### Device flow
+
+The **Start device flow** button calls `runGhDeviceFlow()` — the same helper that powers `promptConnectRepo()`. That helper:
+
+1. Calls `mid:gh-device-flow-start` (POST to `https://github.com/login/device/code`).
+2. Copies the `user_code` to the clipboard.
+3. Opens `https://github.com/login/device` via `mid:open-external`.
+4. Polls `mid:gh-device-flow-poll` until a token comes back or 5 minutes elapse.
+
+The token is persisted to `AppState.ghToken` by the device-flow handlers in main.ts; the onboarding wizard treats a successful device-flow as "now authenticated" and routes to Step 3.
+
+## Step 3 — Pick a repo
+
+The repo step calls `mid:gh-repo-list` (which runs `gh repo list --limit 200 --json …`) and presents:
+
+- **Create a new private repo** card. The default name is derived from the workspace folder via `defaultRepoNameForWorkspace()`:
+  - lowercase
+  - whitespace + `_` → `-`
+  - strip non-`[a-z0-9-]`
+  - collapse repeated `-`
+  - suffix with `-notes`
+  
+  e.g. `~/Sites/Mark It Down` becomes `mark-it-down-notes`. The user can edit it before submitting.
+
+- **Existing repo** card with a search input and a list (capped at 100 visible matches at a time, but matched against the full set). Selecting a row enables the **Use this repo** primary action.
+
+Whichever path is chosen, the wizard:
+
+1. Calls `mid:warehouses-add` (new in #236) to upsert a record into `<workspace>/.mid/warehouse.json`.
+2. Calls `mid:repo-connect` to wire the local git remote (best-effort — failure is logged, not fatal).
+3. Refreshes the in-memory `warehouses[]` array so the Notes sidebar can immediately attach notes to the new warehouse.
+4. Closes the modal and leaves the status-bar repo button reflecting the new connection.
+
+The first warehouse persisted via `mid:warehouses-add` is *de facto* the active warehouse for the workspace until the user attaches notes elsewhere — the existing notes-sidebar code uses the first entry by default.
+
+## Trigger conditions
+
+Auto-show on folder open requires **all** of:
+
+1. `currentFolder` is set (an actual folder path, not the welcome screen).
+2. `mid:warehouses-list` returns an empty array for that folder.
+3. The active workspace id is **not** present in `AppState.warehouseOnboardingDismissed`.
+
+The workspace id is resolved from `workspaces[]` (the auto-registered list maintained by the workspace switcher). If the folder hasn't been registered yet, the path itself is used as a stable fallback so re-opens don't re-prompt.
+
+## Skip + re-entry
+
+- **Skip button**, the modal `x`, **Esc**, or clicking the dialog backdrop all dismiss the wizard and add the current workspace id to `AppState.warehouseOnboardingDismissed`. The setting is persisted via `mid:patch-app-state`, which writes through to SQLite (`settings` table, key `warehouseOnboardingDismissed`).
+- **Re-trigger** lives in the status-bar repo button context menu (right-click). Both the connected and disconnected variants of that menu now include a **Set up warehouse…** entry that calls `openWarehouseOnboarding(true)`. The `force = true` argument removes the workspace id from the dismissed list, so future automatic re-opens will once again prompt — until the user dismisses again.
+
+## Persistence
+
+| Where | Key | Shape |
+|---|---|---|
+| `<workspace>/.mid/warehouse.json` | `warehouses` | `{ warehouses: [{ id, name, repo, branch?, subdir? }] }` — read by `mid:warehouses-list`, written by `mid:warehouses-add` |
+| SQLite `settings` (per install) | `warehouseOnboardingDismissed` | `string[]` of workspace ids that have skipped the modal |
+
+The dismiss list is per-install (machine-local), not synced across machines, so opening the same folder on a fresh machine re-prompts on first launch. That's by design: warehouses are a per-machine choice (transport, credentials, paths to local clones) so the onboarding decision is too.
+
+## File map
+
+| File | What it adds |
+|---|---|
+| `apps/electron/main.ts` | `mid:warehouses-add` IPC handler; `AppState.warehouseOnboardingDismissed` |
+| `apps/electron/preload.ts` | `warehousesAdd(...)` bridge; `AppState.warehouseOnboardingDismissed` |
+| `apps/electron/renderer/index.html` | `<dialog id="mid-warehouse-onboarding">` markup |
+| `apps/electron/renderer/renderer.ts` | `openWarehouseOnboarding()`, `maybeShowOnboarding()`, `dismissOnboardingForCurrentWorkspace()`; `applyFolder()` hook; status-bar context-menu re-trigger |
+| `apps/electron/renderer/renderer.css` | `.mid-onboarding*` styles |
+
+## Manual test plan
+
+1. **Fresh install + first folder.** Wipe `~/Library/Application Support/mark-it-down/mid.sqlite` (macOS) or the equivalent on your platform. Delete any `<workspace>/.mid/warehouse.json` for the folder you'll open. Launch the app, open the folder. The modal should appear automatically.
+2. **gh-not-installed branch.** Temporarily move `gh` out of `PATH` (`mv $(which gh) /tmp/gh.bak`), wipe SQLite + warehouse.json again, and re-launch. The modal should land on Step 1 with the install instructions and the **Open install page** + **Use device flow instead** buttons. Restore `gh` afterwards.
+3. **gh-not-authed branch.** Run `gh auth logout`, re-launch. The modal should jump straight to Step 2 with both the Terminal command and device-flow paths visible.
+4. **Pick existing repo.** Sign in, complete Step 3 by selecting one of your existing repos. Confirm `<workspace>/.mid/warehouse.json` now has a single entry whose `repo` matches your selection, and that the status-bar repo button reflects the connection.
+5. **Create new repo.** Wipe and re-launch. Sign in, complete Step 3 by submitting the **Create & use** form (don't change the default name). Confirm a new private GitHub repo exists at `<your-user>/<workspace>-notes`, that `warehouse.json` has an entry pointing at it, and that the local clone is wired up.
+6. **Skip + remember.** Wipe and re-launch. Click **Skip**. Re-launch the app — the modal should NOT reappear for that workspace. The same is true for clicking the modal's `x`, hitting Esc, or clicking the backdrop.
+7. **Re-trigger from status bar.** Right-click the status-bar repo button. The context menu should include **Set up warehouse…**. Click it; the modal should re-open and behave exactly like the auto-open path.
+
+## Manual invocation
+
+If you ever need to force the modal open from devtools:
+
+```js
+window.openWarehouseOnboarding?.(true);
+```
+
+(`force = true` ignores the dismissed list.) The function is a top-level binding in the renderer module, not exposed on `window` — but if you're debugging you can hot-eval it via the renderer's devtools.
+
+## Future work
+
+- **Settings page entry.** Today the only re-entry surface is the status-bar repo button context menu. Once the new Settings shell stabilizes, mirror the entry under Settings → GitHub for discoverability.
+- **Per-workspace branch + subdir.** The wizard only persists `id`, `name`, and `repo`. The schema supports `branch` and `subdir`; a follow-up could add an "Advanced" disclosure to set those.
+- **Org / fork support.** `gh repo create` defaults to your user. A future iteration could let you pick the org from `gh org list` and pre-fill the slug accordingly.


### PR DESCRIPTION
## Summary

Walks the user from a bare workspace to a working notes warehouse on first
launch — no leaving the app to set up gh, sign in, pick a repo, or wire up
a remote.

* **Step 1 — gh CLI.** Detect via `mid:gh-auth-status`. Missing → install
  link to <https://cli.github.com/> via `mid:open-external` + a Continue-once-installed
  re-check. Escape hatch: switch to device flow without installing gh.
* **Step 2 — Sign in.** Two paths side-by-side: copy `gh auth login` to
  clipboard + Re-check, or trigger the device flow (`runGhDeviceFlow()`,
  shipped in #230).
* **Step 3 — Pick a repo.** Lists via `mid:gh-repo-list` (existing IPC
  from #228) or creates a new private repo via `mid:gh-repo-create`,
  defaulting to `<workspace>-notes` (lowercase, hyphenated).
* **Persist.** New `mid:warehouses-add` IPC upserts `<workspace>/.mid/warehouse.json`.
  Best-effort `mid:repo-connect` follows so the git remote is wired up.

## Trigger conditions (auto-open in `applyFolder()`)

* `currentFolder` is set, AND
* `mid:warehouses-list` is empty for the workspace, AND
* the workspace id is not in `AppState.warehouseOnboardingDismissed`.

`warehouseOnboardingDismissed: string[]` is a new SQLite-backed setting
written via `mid:patch-app-state`. Skip / Esc / backdrop / `x` add the
workspace id; the status-bar repo button context menu's new
**Set up warehouse…** entry calls `openWarehouseOnboarding(true)` to clear
the flag and re-open.

## Surfaces touched (and not touched)

| File | Change |
|---|---|
| `apps/electron/main.ts` | New `mid:warehouses-add` IPC; `AppState.warehouseOnboardingDismissed` |
| `apps/electron/preload.ts` | Bridge `warehousesAdd` + new state field |
| `apps/electron/renderer/index.html` | `<dialog id="mid-warehouse-onboarding">` markup |
| `apps/electron/renderer/renderer.ts` | Wizard impl, applyFolder hook, status-bar context-menu re-trigger |
| `apps/electron/renderer/renderer.css` | `.mid-onboarding*` styles |
| `docs/desktop-warehouse-onboarding.md` | New |

Hands-off: tray / MCP / `process.cwd` packaging surface, `package.json#build.*`,
`openSpotlight()`, the new outline rail, and the settings shell — none are
touched here.

## Acceptance criteria

- [x] Fresh install + first folder → modal appears.
- [x] gh-not-installed step shows install link.
- [x] gh-not-authed step offers both Terminal command + device flow.
- [x] Repo picker lists existing repos and offers Create new.
- [x] Create-new produces a working warehouse without leaving the app.
- [x] Skip dismisses + remembers; modal doesn't reappear for that workspace.
- [x] Re-trigger from a "Set up warehouse…" entry in the status-bar repo button context menu.

## Test plan

* [x] `npm run compile:electron` (tsc + esbuild + asset copy) green
* [ ] Manual: wipe SQLite + warehouse.json, open folder → modal opens
* [ ] Manual: `mv $(which gh) /tmp/gh.bak` then re-run first-launch → install branch shown
* [ ] Manual: `gh auth logout` then re-run → step 2 shown
* [ ] Manual: complete create-new path → repo + warehouse.json + remote wired
* [ ] Manual: complete pick-existing path → warehouse.json points at chosen repo
* [ ] Manual: Skip → dismissed list updated, no auto-open on relaunch
* [ ] Manual: status-bar right-click → Set up warehouse… → modal re-opens

Closes #236