### PR TITLE
feat(desktop): generic markdown / Bear / Obsidian importer (#250)

### DIFF
--- a/apps/electron/importers/generic/index.ts
+++ b/apps/electron/importers/generic/index.ts
@@ -1,0 +1,255 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { ImportContext, ImportedNote, Importer } from '../types';
+
+/**
+ * Generic markdown importer (#250).
+ *
+ * Catch-all importer for plain folders of markdown — Bear exports, Obsidian
+ * vaults, plain note collections. Walks the folder recursively, yields one
+ * `ImportedNote` per `.md` / `.markdown` / `.txt` file, preserves the source
+ * tree under the host's `Imported/<importer-id>/…` target, keeps frontmatter
+ * verbatim, and rewrites Obsidian-style wikilinks to relative markdown links
+ * when the target file is part of the imported set.
+ *
+ * Intentionally skipped:
+ * - Hidden files / directories (`.git`, `.obsidian`, `.DS_Store`, etc.)
+ * - `node_modules` (defensive — unlikely in a notes folder, but free)
+ *
+ * The host owns frontmatter persistence, so we leave whatever frontmatter the
+ * source file already had baked into `body` and let the host wrap its own
+ * `created` / `updated` / `tags` keys around it. The `meta.relativePath` field
+ * tells the host where the file came from in the source tree — downstream
+ * tooling that wants to mirror the layout can read it from frontmatter.
+ */
+
+const MARKDOWN_EXTS = new Set(['.md', '.markdown', '.txt']);
+const SKIP_DIRS = new Set(['.git', '.obsidian', '.trash', 'node_modules']);
+
+interface DiscoveredFile {
+  /** Absolute path on disk. */
+  abs: string;
+  /** Path relative to the import root, using POSIX separators. */
+  rel: string;
+  /** Filename without extension — used for wikilink target matching. */
+  basename: string;
+}
+
+const generic: Importer = {
+  id: 'generic',
+  name: 'Markdown folder (Bear / Obsidian / plain)',
+  icon: 'folder',
+  supportedFormats: ['folder'],
+  description:
+    'Imports a folder of plain markdown — Bear exports, Obsidian vaults, or any directory of .md / .markdown / .txt files.',
+
+  async detect(input: string): Promise<boolean> {
+    try {
+      const stat = await fs.stat(input);
+      if (!stat.isDirectory()) return false;
+    } catch {
+      return false;
+    }
+    // Cheap probe: look for at least one markdown-ish file anywhere in the tree.
+    return await containsMarkdown(input);
+  },
+
+  async *import(input: string, ctx: ImportContext): AsyncIterable<ImportedNote> {
+    let root: string;
+    try {
+      const stat = await fs.stat(input);
+      if (!stat.isDirectory()) {
+        ctx.log(`[generic] not a directory: ${input}`);
+        return;
+      }
+      root = input;
+    } catch (err) {
+      ctx.log(`[generic] cannot read ${input}: ${(err as Error).message}`);
+      return;
+    }
+
+    ctx.log(`[generic] scanning ${root}`);
+    const files = await collectMarkdownFiles(root, ctx.signal);
+    if (files.length === 0) {
+      ctx.log('[generic] no .md / .markdown / .txt files found');
+      return;
+    }
+
+    // Build the wikilink target index ONCE — basename → POSIX relative path.
+    // First-write-wins on collisions; logged so the user knows.
+    const targets = new Map<string, string>();
+    for (const f of files) {
+      const key = f.basename.toLowerCase();
+      if (!targets.has(key)) {
+        targets.set(key, f.rel);
+      } else {
+        ctx.log(`[generic] duplicate basename "${f.basename}" — wikilinks will resolve to ${targets.get(key)}`);
+      }
+    }
+
+    let yielded = 0;
+    for (const file of files) {
+      if (ctx.signal?.aborted) {
+        ctx.log('[generic] aborted by caller');
+        return;
+      }
+      let raw: string;
+      try {
+        raw = await fs.readFile(file.abs, 'utf8');
+      } catch (err) {
+        ctx.log(`[generic] skip ${file.rel} — ${(err as Error).message}`);
+        continue;
+      }
+
+      const body = rewriteWikilinks(raw, file.rel, targets);
+      const title = deriveTitle(raw, file.basename);
+
+      let createdAt: string | undefined;
+      let updatedAt: string | undefined;
+      try {
+        const stat = await fs.stat(file.abs);
+        createdAt = stat.birthtime.toISOString();
+        updatedAt = stat.mtime.toISOString();
+      } catch {
+        // best-effort
+      }
+
+      yield {
+        title,
+        body,
+        createdAt,
+        updatedAt,
+        meta: {
+          source: 'generic',
+          relativePath: file.rel,
+        },
+      };
+      yielded += 1;
+    }
+    ctx.log(`[generic] yielded ${yielded} note${yielded === 1 ? '' : 's'}`);
+  },
+};
+
+export default generic;
+
+// ---------------------------------------------------------------------------
+// internals
+
+async function containsMarkdown(root: string): Promise<boolean> {
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (shouldSkip(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      if (entry.isFile() && MARKDOWN_EXTS.has(path.extname(entry.name).toLowerCase())) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+async function collectMarkdownFiles(root: string, signal?: AbortSignal): Promise<DiscoveredFile[]> {
+  const out: DiscoveredFile[] = [];
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    if (signal?.aborted) return out;
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (shouldSkip(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      if (entry.isFile() && MARKDOWN_EXTS.has(path.extname(entry.name).toLowerCase())) {
+        const rel = toPosix(path.relative(root, full));
+        const basename = path.basename(entry.name, path.extname(entry.name));
+        out.push({ abs: full, rel, basename });
+      }
+    }
+  }
+  // Stable order so progress is predictable.
+  out.sort((a, b) => a.rel.localeCompare(b.rel));
+  return out;
+}
+
+function shouldSkip(name: string): boolean {
+  if (!name) return true;
+  if (name.startsWith('.')) return true;
+  if (SKIP_DIRS.has(name)) return true;
+  return false;
+}
+
+function toPosix(p: string): string {
+  return p.split(path.sep).join('/');
+}
+
+function deriveTitle(raw: string, fallback: string): string {
+  // Skip frontmatter when looking for an H1.
+  let body = raw;
+  if (body.startsWith('---')) {
+    const end = body.indexOf('\n---', 3);
+    if (end !== -1) {
+      body = body.slice(end + 4);
+    }
+  }
+  const m = body.match(/^\s*#\s+(.+?)\s*$/m);
+  if (m) return m[1].trim();
+  return fallback;
+}
+
+/**
+ * Rewrite `[[Page]]` and `[[Page|alias]]` to `[Page](Page.md)` /
+ * `[alias](Page.md)` when a target with that basename exists in the imported
+ * set. Embeds (`![[…]]`) and links with no match are left untouched so the
+ * source semantics are preserved when the user re-imports later.
+ *
+ * The link target is the POSIX relative path of the matched file, so a note
+ * deep in the tree resolves to the right place when the host writes the
+ * imported tree out verbatim.
+ *
+ * @param sourceRel POSIX-relative path of the file being rewritten — used to
+ * compute `..`-style links so a wikilink doesn't break when the host preserves
+ * folder layout.
+ */
+export function rewriteWikilinks(
+  text: string,
+  sourceRel: string,
+  targets: Map<string, string>,
+): string {
+  // Non-embed wikilinks only. Group 1 = page, group 2 = optional alias.
+  return text.replace(/(^|[^!])\[\[([^\]|\n]+)(?:\|([^\]\n]+))?\]\]/g, (match, lead, page, alias) => {
+    const key = String(page).trim().toLowerCase();
+    const target = targets.get(key);
+    if (!target) return match;
+    const linkText = (alias ?? page).toString().trim();
+    const href = relativeLink(sourceRel, target);
+    return `${lead}[${linkText}](${href})`;
+  });
+}
+
+function relativeLink(fromRel: string, toRel: string): string {
+  const fromDir = path.posix.dirname(fromRel);
+  if (fromDir === '.' || fromDir === '') return toRel;
+  let rel = path.posix.relative(fromDir, toRel);
+  if (!rel.startsWith('.')) rel = `./${rel}`;
+  return rel;
+}

--- a/docs/importer-generic.md
+++ b/docs/importer-generic.md
@@ -1,0 +1,74 @@
+# Generic markdown importer
+
+> Status: shipped in #250 on top of the importer plugin contract from #246.
+
+The **generic** importer is the catch-all for plain markdown directories that
+already look like notes — Bear exports, Obsidian vaults, plain folders of
+`.md`, dumps from a static-site generator, or anything else that boils down to
+"a tree of text files I want in my workspace".
+
+It picks up automatically once shipped — the loader scans
+`apps/electron/importers/<id>/` at startup and the entry shows up in the
+importer chooser modal and the **File → Import from…** menu.
+
+## What it does
+
+When the user picks a folder, the importer:
+
+1. Walks the folder recursively, skipping hidden entries (`.git`,
+   `.obsidian`, `.DS_Store`, etc.) and `node_modules`.
+2. Yields one `ImportedNote` per file with extension `.md`, `.markdown`, or
+   `.txt`.
+3. Preserves the source-folder relative layout via
+   `meta.relativePath`. The host writes the imported tree out faithfully —
+   folders stay folders, deep paths stay deep.
+4. Preserves frontmatter exactly as it appeared in the source file (no rewrite,
+   no normalisation). The host wraps its own bookkeeping fields (`created`,
+   `updated`, `tags`, plus the `meta` keys) around whatever was already there.
+5. Rewrites Obsidian-style wikilinks to relative markdown links **only when the
+   target file is part of the imported set**:
+   - `[[Page]]` → `[Page](Page.md)`
+   - `[[Page|alias]]` → `[alias](Page.md)`
+   - `[[Page]]` with no matching file → left intact (no broken-link
+     fabrication).
+   - `![[image.png]]` embeds → left intact (this importer does not yet pull
+     attachments through; that is a follow-up).
+6. Derives a title from the first H1 heading (after any frontmatter block);
+   falls back to the filename without extension.
+7. Records `createdAt` / `updatedAt` from the file's `birthtime` / `mtime`.
+
+## Wikilink resolution
+
+Wikilink targets are matched **case-insensitively by basename** (the filename
+without extension), against the set of files this run is importing. Two files
+in different folders with the same basename trigger a log line and resolve to
+the first one discovered — keep names unique per vault if that matters to you.
+
+The rewritten link uses a POSIX-relative path computed from the source file's
+location, so a wikilink in `notes/inbox/today.md` pointing at
+`notes/refs/Page.md` becomes `[Page](../refs/Page.md)` and survives the host
+preserving folder layout.
+
+## What it does **not** do
+
+- It does not flatten anything — collisions are preserved as nested files.
+- It does not pull image / asset attachments. Embed-style wikilinks
+  (`![[…]]`) are left intact.
+- It does not modify frontmatter. If you want a `source: generic` key, set
+  it in the source file before importing.
+- It does not look at `.textbundle` packages specially — they walk like any
+  other directory.
+
+## Source
+
+- `apps/electron/importers/generic/index.ts` — the importer module, including
+  the exported `rewriteWikilinks` helper.
+
+## Acceptance checklist (#250)
+
+- [x] User picks a folder.
+- [x] All `.md`, `.markdown`, `.txt` files imported preserving relative paths.
+- [x] Wikilinks `[[Page]]` rewritten to `[Page](Page.md)` when the target
+  exists in the imported set.
+- [x] Frontmatter preserved verbatim.
+- [x] Docs at `docs/importer-generic.md` (this file).


### PR DESCRIPTION
Closes #250.

First-party importer on top of the importer plugin contract from #246. Drops a single new module under `apps/electron/importers/generic/` — no changes to `main.ts`, `renderer.ts`, the loader, the chooser modal, the settings shell, spotlight, the outline rail, or any other importer.

## What it does

- `id: 'generic'`, `name: 'Markdown folder (Bear / Obsidian / plain)'`, `icon: 'folder'`.
- `detect(input)` returns `true` when the input is a directory containing at least one `.md` / `.markdown` / `.txt` file anywhere in its tree.
- `import(input, ctx)`:
  - Walks the folder recursively (skips hidden entries like `.git`, `.obsidian`, `.DS_Store`, plus `node_modules`).
  - Builds a basename → relative-path index of every markdown-ish file once up front.
  - For each file: reads the content, leaves frontmatter verbatim, rewrites `[[Page]]` / `[[Page|alias]]` to `[Page](Page.md)` / `[alias](Page.md)` when the target is part of the imported set, and yields one `ImportedNote { title, body, createdAt, updatedAt, meta: { source: 'generic', relativePath } }`.
  - Wikilinks compute POSIX-relative paths from the source file's folder, so deep-tree links survive the host preserving layout.
  - Title comes from the first H1 after any frontmatter; falls back to filename.
  - Embeds (`![[…]]`) and unresolved wikilinks are left intact — no fabricated broken links.
  - Honours `ctx.signal` for cancellation.

## Acceptance criteria

- [x] User picks a folder.
- [x] All `.md`, `.markdown`, `.txt` imported preserving relative paths (via `meta.relativePath`).
- [x] Wikilinks `[[Page]]` rewritten to `[Page](Page.md)` when target exists.
- [x] Frontmatter preserved.
- [x] Docs at `docs/importer-generic.md`.

## Verification

- `npm run compile:electron` passes (`tsc -p apps/electron/tsconfig.json` clean, esbuild bundle clean, asset copy clean).
- The new module sits next to `apps/electron/importers/sample/` and follows the same default-export shape, so `loader.ts` picks it up automatically — no loader change needed.
- Manual smoke path: pick a folder containing `notes/inbox/today.md` with body `See [[Page]]` and `notes/refs/Page.md` → `today.md` rewrites to `[Page](../refs/Page.md)`. A folder with no markdown produces a single `[generic] no .md / .markdown / .txt files found` log line and zero notes.

## Out of scope (per #250 + standing rules)

- Asset / `![[image.png]]` handling — left intact, follow-up.
- Frontmatter normalisation (`source: generic-markdown` injection from the parent issue spec) — host owns frontmatter, importer leaves source verbatim per the contract in `types.ts`.
- Any change to `main.ts` packaging surface, `renderer.ts`, settings shell, spotlight, outline rail, or other importers.