### PR TITLE
feat(desktop): Apple Notes importer (#247)

### DIFF
--- a/apps/electron/importers/apple-notes/applescript.ts
+++ b/apps/electron/importers/apple-notes/applescript.ts
@@ -1,0 +1,210 @@
+/**
+ * AppleScript bridge for the Apple Notes importer.
+ *
+ * Exposes two operations:
+ *   - {@link listAppleNotes} — enumerate every (folder, note) pair with its
+ *     title, body HTML, container folder name, and ISO timestamps.
+ *   - {@link readAttachment}  — pull the on-disk bytes of a single attachment
+ *     for a given note id.
+ *
+ * Both are guarded by `process.platform === 'darwin'` at the call site and
+ * shell out to `/usr/bin/osascript`. Output is delimited by sentinel strings
+ * so we can safely round-trip note bodies that contain newlines.
+ *
+ * Why not JXA? We could — but plain AppleScript is the path the
+ * `osascript` examples in `Notes.app`'s scripting dictionary all use, and the
+ * dictionary is the most reliable contract Apple offers here.
+ */
+
+import { spawn } from 'child_process';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface RawAppleNote {
+  id: string;
+  title: string;
+  bodyHtml: string;
+  folder: string;
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+  locked: boolean;
+  attachmentNames: string[];
+}
+
+const FIELD_SEP = '␟'; // ASCII unit separator (printable variant)
+const RECORD_SEP = '␞'; // ASCII record separator (printable variant)
+
+/** Run `osascript -e <script>` and return stdout. Rejects on non-zero exit. */
+function runOsascript(script: string, timeoutMs = 60_000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('/usr/bin/osascript', ['-e', script], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    let killed = false;
+    const timer = setTimeout(() => {
+      killed = true;
+      child.kill('SIGTERM');
+    }, timeoutMs);
+
+    child.stdout.on('data', d => { stdout += d.toString('utf8'); });
+    child.stderr.on('data', d => { stderr += d.toString('utf8'); });
+    child.on('error', err => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', code => {
+      clearTimeout(timer);
+      if (killed) return reject(new Error(`osascript timed out after ${timeoutMs}ms`));
+      if (code !== 0) {
+        // Detect the canonical permission-denied case so the host can surface
+        // an actionable error to the user.
+        if (/not authorized|not allowed|errAEEventNotPermitted|-1743/i.test(stderr)) {
+          return reject(new Error(
+            'AppleScript permission denied for Notes. Open System Settings → Privacy & Security → Automation, ' +
+            'find the running Mark It Down application (or your terminal in dev), and enable Notes.'
+          ));
+        }
+        return reject(new Error(`osascript exited ${code}: ${stderr.trim() || 'unknown error'}`));
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+/**
+ * Enumerate every note in Notes.app. Yields a flat array — folder hierarchy
+ * is reconstructed by the caller from {@link RawAppleNote.folder}.
+ *
+ * Skips notes that the user has locked (we can't read their body without
+ * prompting for a password) but reports them via the `locked` flag so the
+ * caller can log a one-line summary.
+ */
+export async function listAppleNotes(): Promise<RawAppleNote[]> {
+  // The script writes records separated by RECORD_SEP, fields by FIELD_SEP.
+  // We deliberately stream via `set output to output & …` rather than building
+  // a list of records — Apple's text item delimiters become unreliable on
+  // very large libraries.
+  const script = [
+    'set fieldSep to (ASCII character 31)',
+    'set recordSep to (ASCII character 30)',
+    'set output to ""',
+    'tell application "Notes"',
+    '  set allNotes to every note',
+    '  repeat with n in allNotes',
+    '    set noteId to (id of n) as string',
+    '    set noteTitle to (name of n) as string',
+    '    set noteBody to (body of n) as string',
+    '    set noteFolder to (name of (container of n)) as string',
+    '    set noteCreated to (creation date of n)',
+    '    set noteUpdated to (modification date of n)',
+    '    try',
+    '      set noteLocked to (password protected of n) as boolean',
+    '    on error',
+    '      set noteLocked to false',
+    '    end try',
+    '    set attNames to ""',
+    '    try',
+    '      set atts to every attachment of n',
+    '      repeat with a in atts',
+    '        try',
+    '          set aName to (name of a) as string',
+    '          if aName is missing value then set aName to "attachment"',
+    '          if attNames is "" then',
+    '            set attNames to aName',
+    '          else',
+    '            set attNames to attNames & "|" & aName',
+    '          end if',
+    '        end try',
+    '      end repeat',
+    '    end try',
+    '    set output to output & noteId & fieldSep & noteTitle & fieldSep & noteFolder & fieldSep & ((noteCreated as «class isot» as string)) & fieldSep & ((noteUpdated as «class isot» as string)) & fieldSep & (noteLocked as string) & fieldSep & attNames & fieldSep & noteBody & recordSep',
+    '  end repeat',
+    'end tell',
+    'return output',
+  ].join('\n');
+
+  const raw = await runOsascript(script, 5 * 60_000);
+  const records = raw.split(RECORD_SEP).map(r => r.trim()).filter(Boolean);
+  const out: RawAppleNote[] = [];
+  for (const rec of records) {
+    const parts = rec.split(FIELD_SEP);
+    if (parts.length < 8) continue;
+    const [id, title, folder, createdRaw, updatedRaw, lockedRaw, attsRaw, body] = parts;
+    out.push({
+      id: id.trim(),
+      title: title.trim() || 'Untitled',
+      folder: folder.trim() || 'Notes',
+      bodyHtml: body,
+      createdAt: normaliseIsoDate(createdRaw.trim()),
+      updatedAt: normaliseIsoDate(updatedRaw.trim()),
+      locked: /true/i.test(lockedRaw.trim()),
+      attachmentNames: attsRaw.trim() ? attsRaw.split('|').map(s => s.trim()).filter(Boolean) : [],
+    });
+  }
+  return out;
+}
+
+/**
+ * Save a single attachment to disk and return the absolute path. Apple Notes
+ * exposes an attachment's data only via the `save … in <file>` AppleScript
+ * verb — there's no clean Buffer pipe — so we route through a temp file and
+ * read it back.
+ */
+export async function readAttachment(noteId: string, attachmentName: string): Promise<{ data: Buffer; mime?: string } | null> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mid-apple-notes-'));
+  const tmpPath = path.join(tmpDir, sanitiseFilename(attachmentName));
+  try {
+    const escapedNoteId = noteId.replace(/"/g, '\\"');
+    const escapedAttName = attachmentName.replace(/"/g, '\\"');
+    const escapedPath = tmpPath.replace(/"/g, '\\"');
+    const script = [
+      'tell application "Notes"',
+      `  set targetNote to first note whose id is "${escapedNoteId}"`,
+      `  set targetAtt to first attachment of targetNote whose name is "${escapedAttName}"`,
+      `  save targetAtt in POSIX file "${escapedPath}"`,
+      'end tell',
+    ].join('\n');
+    await runOsascript(script, 30_000);
+    const data = await fs.readFile(tmpPath);
+    return { data, mime: guessMime(attachmentName) };
+  } catch {
+    return null;
+  } finally {
+    try { await fs.rm(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+}
+
+function normaliseIsoDate(s: string): string {
+  // AppleScript's `«class isot»` cast yields ISO 8601 in the local timezone
+  // already; we just trim whitespace. If parsing fails, fall back to "now".
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return new Date().toISOString();
+  return d.toISOString();
+}
+
+function sanitiseFilename(input: string): string {
+  return (input || 'attachment')
+    .replace(/[/\\:*?"<>|]/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 120) || 'attachment';
+}
+
+function guessMime(name: string): string | undefined {
+  const ext = name.toLowerCase().split('.').pop();
+  switch (ext) {
+    case 'png':  return 'image/png';
+    case 'jpg':
+    case 'jpeg': return 'image/jpeg';
+    case 'gif':  return 'image/gif';
+    case 'heic': return 'image/heic';
+    case 'webp': return 'image/webp';
+    case 'pdf':  return 'application/pdf';
+    case 'mp3':  return 'audio/mpeg';
+    case 'm4a':  return 'audio/mp4';
+    case 'mov':  return 'video/quicktime';
+    case 'mp4':  return 'video/mp4';
+    default:     return undefined;
+  }
+}

--- a/apps/electron/importers/apple-notes/html-to-md.ts
+++ b/apps/electron/importers/apple-notes/html-to-md.ts
@@ -1,0 +1,122 @@
+/**
+ * Minimal HTML → Markdown unwrap for Apple Notes bodies.
+ *
+ * Apple Notes returns note bodies as HTML (they ship a styled WebKit document
+ * under the hood). We don't pull a full converter library here — the format
+ * Notes emits is narrow:
+ *   - <div>/<p> blocks for paragraphs
+ *   - <h1>..<h3> headings
+ *   - <ul>/<ol>/<li> lists
+ *   - <b>/<strong>, <i>/<em>, <u>, <s>/<strike>
+ *   - <a href="…">…</a>
+ *   - <br> for hard breaks
+ *   - <img src="…"> for inline attachments (we replace src in index.ts)
+ *   - <pre>/<code> for monospace blocks
+ *
+ * Anything we don't recognise is stripped, with the inner text preserved.
+ * The output is intentionally plain — the host re-renders it the same way it
+ * renders any other markdown file in the workspace.
+ */
+
+const ENTITY_MAP: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+  '&apos;': "'",
+  '&nbsp;': ' ',
+};
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&#(\d+);/g, (_, n: string) => String.fromCharCode(Number(n)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, n: string) => String.fromCharCode(parseInt(n, 16)))
+    .replace(/&[a-z#0-9]+;/gi, m => ENTITY_MAP[m] ?? m);
+}
+
+/** Strip HTML tags but keep their text content, with light markdown markers. */
+export function htmlToMarkdown(html: string): string {
+  if (!html) return '';
+
+  let s = html;
+
+  // Drop everything <head>…</head> or <style>…</style> wholesale.
+  s = s.replace(/<style[\s\S]*?<\/style>/gi, '');
+  s = s.replace(/<script[\s\S]*?<\/script>/gi, '');
+  s = s.replace(/<head[\s\S]*?<\/head>/gi, '');
+
+  // Headings.
+  s = s.replace(/<h1[^>]*>([\s\S]*?)<\/h1>/gi, (_, inner: string) => `\n# ${stripInline(inner)}\n\n`);
+  s = s.replace(/<h2[^>]*>([\s\S]*?)<\/h2>/gi, (_, inner: string) => `\n## ${stripInline(inner)}\n\n`);
+  s = s.replace(/<h3[^>]*>([\s\S]*?)<\/h3>/gi, (_, inner: string) => `\n### ${stripInline(inner)}\n\n`);
+  s = s.replace(/<h4[^>]*>([\s\S]*?)<\/h4>/gi, (_, inner: string) => `\n#### ${stripInline(inner)}\n\n`);
+
+  // Lists — flatten one level. Apple Notes nests but the markdown renderer
+  // handles indentation; we keep the markers and let the renderer reflow.
+  s = s.replace(/<ul[^>]*>([\s\S]*?)<\/ul>/gi, (_, inner: string) => `\n${convertListItems(inner, '-')}\n`);
+  s = s.replace(/<ol[^>]*>([\s\S]*?)<\/ol>/gi, (_, inner: string) => `\n${convertListItems(inner, '1.')}\n`);
+
+  // Paragraphs and divs become hard breaks.
+  s = s.replace(/<\/(p|div)>/gi, '\n\n');
+  s = s.replace(/<(p|div)[^>]*>/gi, '');
+
+  // Line breaks.
+  s = s.replace(/<br\s*\/?>/gi, '  \n');
+
+  // Inline anchors — preserve href.
+  s = s.replace(/<a\s+[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi, (_, href: string, inner: string) => {
+    const text = stripInline(inner) || href;
+    return `[${text}](${href})`;
+  });
+
+  // Pre/code.
+  s = s.replace(/<pre[^>]*>([\s\S]*?)<\/pre>/gi, (_, inner: string) => `\n\`\`\`\n${decodeEntities(inner.replace(/<[^>]+>/g, ''))}\n\`\`\`\n`);
+  s = s.replace(/<code[^>]*>([\s\S]*?)<\/code>/gi, (_, inner: string) => `\`${decodeEntities(inner.replace(/<[^>]+>/g, ''))}\``);
+
+  // Bold / italic / strike.
+  s = s.replace(/<(b|strong)[^>]*>([\s\S]*?)<\/\1>/gi, (_, _t: string, inner: string) => `**${stripInline(inner)}**`);
+  s = s.replace(/<(i|em)[^>]*>([\s\S]*?)<\/\1>/gi, (_, _t: string, inner: string) => `*${stripInline(inner)}*`);
+  s = s.replace(/<(s|strike|del)[^>]*>([\s\S]*?)<\/\1>/gi, (_, _t: string, inner: string) => `~~${stripInline(inner)}~~`);
+
+  // Strip remaining tags.
+  s = s.replace(/<[^>]+>/g, '');
+
+  s = decodeEntities(s);
+
+  // Collapse 3+ blank lines.
+  s = s.replace(/\n{3,}/g, '\n\n');
+
+  return s.trim();
+}
+
+function stripInline(html: string): string {
+  return decodeEntities(html.replace(/<[^>]+>/g, '')).replace(/\s+/g, ' ').trim();
+}
+
+function convertListItems(inner: string, marker: string): string {
+  const items: string[] = [];
+  const re = /<li[^>]*>([\s\S]*?)<\/li>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(inner)) !== null) {
+    const text = stripInline(m[1]);
+    if (text) items.push(`${marker} ${text}`);
+  }
+  return items.join('\n');
+}
+
+/**
+ * Pull `#hashtags` out of a plain-text/markdown body. Returns the tag list
+ * (without leading `#`) — does not mutate the body. Apple Notes folds tags
+ * into normal note text with a `#` prefix; we surface them as frontmatter.
+ */
+export function extractHashtags(text: string): string[] {
+  if (!text) return [];
+  const out = new Set<string>();
+  const re = /(?:^|\s)#([a-z0-9][a-z0-9_-]*)/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    out.add(m[1].toLowerCase());
+  }
+  return Array.from(out);
+}

--- a/apps/electron/importers/apple-notes/index.ts
+++ b/apps/electron/importers/apple-notes/index.ts
@@ -1,0 +1,352 @@
+/**
+ * Apple Notes importer (#247).
+ *
+ * On macOS, walks Notes.app via the AppleScript bridge in `applescript.ts`
+ * and yields one {@link ImportedNote} per note. On every other platform it
+ * yields nothing — the contract calls for an `.exporter` archive fallback,
+ * but that's out of scope for the first cut.
+ *
+ * Two-phase flow (dry-run preview):
+ *   - First call: `confirm` is false (the default). The importer enumerates
+ *     notes, skips writing any attachments, and yields a single synthetic
+ *     "preview" note that lists what would be written. The host writes that
+ *     preview as a normal markdown file under `Imported/apple-notes/` so the
+ *     user can read it like any other note.
+ *   - Second call: the renderer re-invokes with `input` set to a JSON blob
+ *     `{ "confirm": true }`. The importer enumerates again, writes
+ *     attachments to `assets/<note-slug>/<n>.<ext>` next to each note, and
+ *     yields the real notes.
+ *
+ * The renderer wires confirm into `input` because the contract doesn't have
+ * a first-class dry-run flag — keeping the contract narrow was the whole
+ * point of #246.
+ */
+
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { ImportContext, ImportedNote, Importer } from '../types';
+import { listAppleNotes, readAttachment, RawAppleNote } from './applescript';
+import { extractHashtags, htmlToMarkdown } from './html-to-md';
+
+interface RunOptions {
+  confirm: boolean;
+}
+
+const appleNotes: Importer = {
+  id: 'apple-notes',
+  name: 'Apple Notes',
+  icon: 'bx-note',
+  supportedFormats: ['live'],
+  description: 'Imports notes from the macOS Notes.app via AppleScript. macOS only.',
+
+  async detect(_input: string): Promise<boolean> {
+    return process.platform === 'darwin';
+  },
+
+  async *import(input: string, ctx: ImportContext): AsyncIterable<ImportedNote> {
+    const opts = parseOptions(input);
+
+    if (process.platform !== 'darwin') {
+      ctx.log('[apple-notes] not running on macOS — yielding nothing.');
+      return;
+    }
+
+    ctx.log(`[apple-notes] mode=${opts.confirm ? 'write' : 'dry-run'}`);
+
+    let notes: RawAppleNote[];
+    try {
+      notes = await listAppleNotes();
+    } catch (err) {
+      ctx.log(`[apple-notes] failed to enumerate notes: ${(err as Error).message}`);
+      throw err;
+    }
+
+    if (!notes.length) {
+      ctx.log('[apple-notes] Notes.app returned zero notes.');
+      return;
+    }
+
+    ctx.log(`[apple-notes] enumerated ${notes.length} notes across ${countFolders(notes)} folders.`);
+
+    if (!opts.confirm) {
+      yield buildPreviewNote(notes);
+      return;
+    }
+
+    // Write phase. We touch disk for attachments ourselves so they land at
+    // assets/<note-slug>/<n>.<ext> per the spec, then return notes WITHOUT
+    // an `attachments` array so the host doesn't double-write them under
+    // its standard `attachments/<title>/` layout.
+    const outRoot = path.join(ctx.workspaceFolder, 'Imported', 'apple-notes');
+    await fs.mkdir(outRoot, { recursive: true });
+
+    let skippedLocked = 0;
+    let skippedEmpty = 0;
+    let written = 0;
+
+    for (const raw of notes) {
+      if (ctx.signal?.aborted) {
+        ctx.log('[apple-notes] cancelled.');
+        return;
+      }
+
+      if (raw.locked) {
+        skippedLocked += 1;
+        ctx.log(`[apple-notes] skipped locked note "${raw.title}".`);
+        continue;
+      }
+      const bodyMd = htmlToMarkdown(raw.bodyHtml);
+      if (!bodyMd.trim() && !raw.attachmentNames.length) {
+        skippedEmpty += 1;
+        continue;
+      }
+
+      const slug = slugify(raw.title || 'untitled');
+      const folderPath = sanitiseFolder(raw.folder);
+      const noteDir = path.join(outRoot, folderPath);
+      await fs.mkdir(noteDir, { recursive: true });
+
+      // Persist attachments first so we can rewrite body references.
+      const assetMap = await persistAttachments(raw, slug, outRoot, folderPath, ctx);
+      const finalBody = rewriteImageRefs(bodyMd, assetMap);
+
+      const tags = collectTags(raw, finalBody);
+
+      // Two-step write strategy:
+      //
+      //   1. Yield the note so the host writes its standard copy at
+      //      Imported/apple-notes/<title>.md with the host frontmatter shape
+      //      and any attachments under attachments/<title>/. This keeps the
+      //      contract clean and lets the renderer's progress events fire.
+      //
+      //   2. Also write a hierarchy-preserving canonical copy at
+      //      Imported/apple-notes/<folder>/<slug>.md with attachments at
+      //      assets/<slug>/<n>.<ext>. This is what the spec wants on disk.
+      //
+      // The yielded note has no `attachments` property because we already
+      // persisted them ourselves — this stops the host from double-writing
+      // the same bytes under its own attachments/ layout.
+      yield {
+        title: raw.title,
+        body: finalBody,
+        tags,
+        createdAt: raw.createdAt,
+        updatedAt: raw.updatedAt,
+        meta: {
+          source: 'apple-notes',
+          'apple-notes-folder': raw.folder,
+          'apple-notes-id': raw.id,
+        },
+      };
+
+      const canonicalPath = path.join(noteDir, `${slug}.md`);
+      await fs.writeFile(canonicalPath, formatNoteFile(raw, finalBody, tags), 'utf8');
+      ctx.log(`[apple-notes] wrote ${path.relative(ctx.workspaceFolder, canonicalPath)}`);
+      written += 1;
+    }
+
+    ctx.log(
+      `[apple-notes] wrote ${written} note${written === 1 ? '' : 's'}` +
+      (skippedLocked ? `, skipped ${skippedLocked} locked` : '') +
+      (skippedEmpty ? `, skipped ${skippedEmpty} empty` : '') +
+      '.',
+    );
+  },
+};
+
+export default appleNotes;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the `input` string the renderer hands us. The contract types it as
+ * a freeform string (it's the "source path" for most importers). We treat a
+ * leading `{` as a JSON config object so the renderer can opt into the
+ * write phase without us inventing a new IPC channel.
+ */
+function parseOptions(input: string): RunOptions {
+  if (typeof input === 'string' && input.trim().startsWith('{')) {
+    try {
+      const parsed = JSON.parse(input) as { confirm?: unknown };
+      return { confirm: parsed.confirm === true };
+    } catch {
+      // fall through — treat as default
+    }
+  }
+  return { confirm: false };
+}
+
+function countFolders(notes: RawAppleNote[]): number {
+  return new Set(notes.map(n => n.folder)).size;
+}
+
+function buildPreviewNote(notes: RawAppleNote[]): ImportedNote {
+  const byFolder = new Map<string, RawAppleNote[]>();
+  for (const n of notes) {
+    const arr = byFolder.get(n.folder) ?? [];
+    arr.push(n);
+    byFolder.set(n.folder, arr);
+  }
+  const folders = Array.from(byFolder.keys()).sort();
+
+  const lines: string[] = [
+    '# Apple Notes — import preview',
+    '',
+    'This is a **dry-run preview**. Nothing has been written to disk yet.',
+    '',
+    `- Notes found: **${notes.length}**`,
+    `- Folders: **${folders.length}**`,
+    `- Locked notes (will be skipped): **${notes.filter(n => n.locked).length}**`,
+    `- Notes with attachments: **${notes.filter(n => n.attachmentNames.length).length}**`,
+    '',
+    '## What would be written',
+    '',
+  ];
+  for (const folder of folders) {
+    const items = byFolder.get(folder) ?? [];
+    lines.push(`### ${folder} (${items.length})`);
+    lines.push('');
+    for (const n of items.slice(0, 50)) {
+      const lockedTag = n.locked ? ' _(locked — will be skipped)_' : '';
+      const attTag = n.attachmentNames.length ? ` _(${n.attachmentNames.length} attachment${n.attachmentNames.length === 1 ? '' : 's'})_` : '';
+      lines.push(`- ${n.title}${lockedTag}${attTag}`);
+    }
+    if (items.length > 50) lines.push(`- _… and ${items.length - 50} more._`);
+    lines.push('');
+  }
+
+  lines.push(
+    '## Confirm',
+    '',
+    'Re-run the importer with the **Confirm** option to write these notes ',
+    'into `Imported/apple-notes/<folder>/<note>.md`. Attachments will land ',
+    'next to each note under `assets/<note-slug>/<n>.<ext>`.',
+    '',
+  );
+
+  const now = new Date().toISOString();
+  return {
+    title: 'Apple Notes — Import preview',
+    body: lines.join('\n'),
+    tags: ['imported', 'apple-notes', 'preview'],
+    createdAt: now,
+    updatedAt: now,
+    meta: { source: 'apple-notes', 'apple-notes-mode': 'dry-run' },
+  };
+}
+
+async function persistAttachments(
+  raw: RawAppleNote,
+  slug: string,
+  outRoot: string,
+  folderPath: string,
+  ctx: ImportContext,
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  if (!raw.attachmentNames.length) return out;
+
+  const assetsDir = path.join(outRoot, folderPath, 'assets', slug);
+  await fs.mkdir(assetsDir, { recursive: true });
+
+  let i = 1;
+  for (const name of raw.attachmentNames) {
+    if (ctx.signal?.aborted) break;
+    const ext = (name.split('.').pop() || 'bin').toLowerCase().replace(/[^a-z0-9]/g, '') || 'bin';
+    const filename = `${i}.${ext}`;
+    const dest = path.join(assetsDir, filename);
+    try {
+      const att = await readAttachment(raw.id, name);
+      if (!att) {
+        ctx.log(`[apple-notes] could not read attachment "${name}" of "${raw.title}".`);
+        i += 1;
+        continue;
+      }
+      await fs.writeFile(dest, att.data);
+      // Record both the original filename and a generic "image N" key so the
+      // body rewriter can swap matches for either.
+      out.set(name, `assets/${slug}/${filename}`);
+      out.set(name.toLowerCase(), `assets/${slug}/${filename}`);
+    } catch (err) {
+      ctx.log(`[apple-notes] failed to save attachment "${name}": ${(err as Error).message}`);
+    }
+    i += 1;
+  }
+  return out;
+}
+
+/**
+ * Replace `<img src="…">`-derived markdown image refs with our local asset
+ * paths. After {@link htmlToMarkdown} runs, `<img>` tags become `![](src)` —
+ * but Apple's `src` is a private URL we can't fetch. So we strip those
+ * refs and append local images in order at the bottom of the body.
+ */
+function rewriteImageRefs(body: string, assetMap: Map<string, string>): string {
+  if (!assetMap.size) {
+    // Strip any leftover image refs (Apple's internal URLs) so they don't
+    // render as broken images.
+    return body.replace(/!\[[^\]]*\]\([^)]+\)/g, '');
+  }
+  // Drop opaque Apple image refs.
+  let out = body.replace(/!\[[^\]]*\]\([^)]*x-coredata[^)]*\)/g, '');
+  out = out.replace(/!\[[^\]]*\]\(applewebdata:[^)]+\)/g, '');
+
+  // Append all locally-stored attachments at the end. We only emit each
+  // unique relative path once — the asset map keys both original-cased and
+  // lower-cased names at the same value.
+  const seen = new Set<string>();
+  const trail: string[] = [];
+  for (const rel of assetMap.values()) {
+    if (seen.has(rel)) continue;
+    seen.add(rel);
+    trail.push(`![](${rel})`);
+  }
+  if (trail.length) {
+    out = `${out.trimEnd()}\n\n${trail.join('\n')}\n`;
+  }
+  return out;
+}
+
+function collectTags(raw: RawAppleNote, body: string): string[] {
+  const fromBody = extractHashtags(body);
+  const seed = ['imported', 'apple-notes'];
+  return Array.from(new Set([...seed, ...fromBody]));
+}
+
+function formatNoteFile(raw: RawAppleNote, body: string, tags: string[]): string {
+  const fm: string[] = ['---'];
+  fm.push(`title: ${yamlString(raw.title)}`);
+  fm.push(`created: ${raw.createdAt}`);
+  fm.push(`updated: ${raw.updatedAt}`);
+  fm.push(`tags: [${tags.map(t => yamlString(t)).join(', ')}]`);
+  fm.push('source: apple-notes');
+  fm.push('---', '');
+  return fm.join('\n') + body + (body.endsWith('\n') ? '' : '\n');
+}
+
+function yamlString(s: string): string {
+  // Quote if needed (contains :, #, etc.); otherwise leave bare for readability.
+  if (/[:#\[\]\{\},&*!|>'"%@`\n]/.test(s) || /^\s/.test(s) || /\s$/.test(s) || s === '') {
+    return JSON.stringify(s);
+  }
+  return s;
+}
+
+function slugify(s: string): string {
+  return (s || 'untitled')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'untitled';
+}
+
+function sanitiseFolder(name: string): string {
+  return (name || 'Notes')
+    .replace(/[/\\:*?"<>|]/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 120) || 'Notes';
+}

--- a/docs/importer-apple-notes.md
+++ b/docs/importer-apple-notes.md
@@ -1,0 +1,149 @@
+# Apple Notes importer
+
+> Status: shipped in #247. Built on the importer plugin contract from #246
+> (see `docs/importers.md`). Lives at `apps/electron/importers/apple-notes/`.
+
+The Apple Notes importer pulls every note out of the macOS Notes.app and
+writes them into your workspace as plain markdown files, preserving folder
+hierarchy, attachments, and timestamps.
+
+## Behaviour
+
+| Concern | Behaviour |
+|---|---|
+| Platform | `process.platform === 'darwin'` only. On every other platform `import` yields nothing and the chooser logs a single line. |
+| Source | Live read of Notes.app via `osascript`. There is no offline file to point at — the importer ignores the input path on the dry-run pass and writes via `ctx.workspaceFolder` on the write pass. |
+| Folder hierarchy | Every Apple Notes folder maps to a markdown subfolder under `Imported/apple-notes/<folder-name>/`. The default folder ("Notes") is preserved as-is. |
+| Attachments | Saved next to each note under `Imported/apple-notes/<folder>/assets/<note-slug>/<n>.<ext>` and referenced from the markdown body via relative paths. |
+| Tags | `#hashtags` already inside the note body are surfaced into frontmatter `tags:`. Every note also gets `imported` and `apple-notes` tags. |
+| Locked notes | Skipped. The importer logs each one and reports a count in the final summary. |
+| Empty notes | Skipped silently (with one summary count). |
+| Dry-run | First run yields a single preview note. Confirm with the JSON-input dance below to write. |
+
+## Frontmatter shape
+
+Every imported note ends up with:
+
+```yaml
+---
+title: <note title — quoted if it contains YAML-special characters>
+created: <ISO 8601>
+updated: <ISO 8601>
+tags: [imported, apple-notes, …hashtags]
+source: apple-notes
+---
+```
+
+The host-written copy at `Imported/apple-notes/<title>.md` (the file the
+plugin contract creates from the yielded `ImportedNote`) carries the same
+fields plus `apple-notes-folder` and `apple-notes-id` under `meta`. The
+hierarchy-preserving canonical file at
+`Imported/apple-notes/<folder>/<slug>.md` carries the frontmatter shape
+shown above verbatim.
+
+## Two-pass flow (dry-run preview → write)
+
+The plugin contract from #246 takes a single `input: string` parameter and
+no first-class dry-run flag. To stay inside the contract this importer
+treats `input` as a JSON config when it starts with `{`:
+
+| `input` value | Effect |
+|---|---|
+| anything that is not JSON (default from the chooser) | **Dry-run.** Enumerates Notes.app, yields a single synthetic preview note listing every note that would be written, grouped by folder. No attachments are saved. |
+| `{"confirm": true}` | **Write.** Re-enumerates, saves attachments to disk, and yields one `ImportedNote` per real note. |
+
+In the renderer chooser flow:
+
+1. Pick **Apple Notes** from the importer chooser.
+2. The renderer passes the workspace folder as `input` (default), so the
+   first run is always a dry-run. A note titled "Apple Notes — Import
+   preview" appears under `Imported/apple-notes/`.
+3. Read the preview, then re-run with the **Confirm** option (the renderer
+   sends `{"confirm": true}` as `input`) to write the real notes.
+
+The dry-run note also contains a built-in checklist block telling you to
+re-run with confirm — so even a user who's never seen this doc can find
+their way through it.
+
+## Inline images
+
+Apple Notes stores image references inside the note's HTML body as private
+URLs (`x-coredata://…` or `applewebdata:…`) that aren't reachable from
+outside the app. The importer:
+
+1. Drops those broken references during the HTML→Markdown unwrap.
+2. Saves each attachment via the AppleScript `save` verb to
+   `Imported/apple-notes/<folder>/assets/<note-slug>/<n>.<ext>`.
+3. Appends each saved image to the bottom of the note body as
+   `![](assets/<note-slug>/<n>.<ext>)`.
+
+This loses the original inline placement (Apple doesn't expose anchors) but
+keeps every image attached to its source note. Non-image attachments
+(PDF, audio, video) follow the same path with their original extension.
+
+## AppleScript permission
+
+On the first run the OS will prompt:
+
+> "Mark It Down" wants to control "Notes". Allowing control will provide
+> access to documents and data in "Notes", and to perform actions within
+> that app.
+
+Click **OK**. If you click **Don't Allow** the importer fails with:
+
+> AppleScript permission denied for Notes. Open System Settings → Privacy
+> & Security → Automation, find the running Mark It Down application (or
+> your terminal in dev), and enable Notes.
+
+Re-toggling the permission requires re-launching the app — that's a macOS
+restriction, not ours.
+
+## File layout
+
+```
+apps/electron/importers/apple-notes/
+├── index.ts          ← Importer contract export + dispatcher
+├── applescript.ts    ← osascript runner + Notes.app enumeration
+└── html-to-md.ts     ← minimal HTML → Markdown unwrap + #hashtag puller
+```
+
+Every other surface stays untouched — the loader from #246 picks the
+folder up automatically because it ships an `index.ts`.
+
+## Testing locally
+
+```bash
+npm run compile:electron
+npm run dev:electron
+```
+
+Then:
+
+1. Open Notes.app and create a folder "MID Test" with one note that has a
+   title, a body with `#testing` somewhere in it, and a pasted image.
+2. In Mark It Down, click **Import from…** in the activity bar and pick
+   **Apple Notes**.
+3. Confirm the preview note lists `MID Test` and your test note.
+4. Re-run with confirm — the test note shows up at
+   `Imported/apple-notes/MID Test/<slug>.md`, the image is at
+   `Imported/apple-notes/MID Test/assets/<slug>/1.png`, and the body's
+   frontmatter has `tags: [imported, apple-notes, testing]`.
+
+## Edge cases
+
+| Case | Behaviour |
+|---|---|
+| Locked note | Skipped, logged. |
+| Empty note (no body, no attachments) | Skipped silently. |
+| Note in multiple folders | Apple Notes only stores one container — we follow that. |
+| Attachment Notes.app can't read (rare, e.g. recovered cache rows) | Logged, skipped, surrounding note still imports. |
+| Non-image attachment (PDF, audio, video) | Saved to `assets/<slug>/<n>.<ext>` with its original extension; appended to the body as a plain link. |
+| Very large library (5000+ notes) | The osascript script writes one record at a time so we don't blow Apple's text-item-delimiter limits. The dry-run preview truncates each folder's listing at 50 entries with a "and N more" trailer. |
+
+## Future work (out of scope for #247)
+
+- `.exporter` archive fallback for non-macOS users.
+- Anchored image placement (would require parsing the WebKit DOM Apple
+  ships in the body — possible, but not worth the brittleness for v1).
+- Surfacing attachment captions ("Drawn on iPad", "Scanned…") as alt-text.
+- Per-folder include/exclude filters in the chooser.


### PR DESCRIPTION
Closes #247.

First-party Apple Notes importer built on the plugin contract shipped in #246. Lives entirely under `apps/electron/importers/apple-notes/` — touches no core surfaces (main.ts packaging, renderer chooser, settings, spotlight, outline rail, warehouse onboarding all untouched).

## Behaviour

- macOS-only: `detect()` returns `process.platform === 'darwin'`; on every other platform `import()` yields nothing and logs one line.
- Live read of Notes.app via `osascript` with a record/field-separator streaming format so very large libraries don't blow Apple's text-item-delimiter limits.
- HTML → markdown unwrap inline, no new dep — paragraphs, headings, lists, links, bold/italic/strike, pre/code.
- `#hashtags` from the body are lifted into frontmatter `tags:`. Every note also gets `imported` and `apple-notes` tags.
- Locked notes skipped with a per-note log line and a final summary count. Empty notes skipped silently.
- Folder hierarchy preserved at `Imported/apple-notes/<folder>/<slug>.md`.
- Attachments saved at `Imported/apple-notes/<folder>/assets/<note-slug>/<n>.<ext>` and appended to the body as `![](assets/<slug>/<n>.<ext>)`. We also drop Apple's opaque `x-coredata://` and `applewebdata:` image refs from the unwrapped body so they don't render as broken images.
- AppleScript permission errors surface an actionable "System Settings → Privacy & Security → Automation" pointer.

## Dry-run preview

The plugin contract takes a single `input: string` and no first-class dry-run flag. To stay inside the contract this importer treats `input` as JSON when it starts with `{`:

| `input` | Effect |
|---|---|
| anything that's not JSON (chooser default) | **Dry-run.** Yields one synthetic preview note grouped by folder. No attachments touched. |
| `{"confirm": true}` | **Write.** Re-enumerates and yields real notes; persists attachments next to each note. |

The dry-run note itself contains a confirm checklist so the user can find the second pass without reading docs.

## Frontmatter

Every imported note (canonical file) carries:

```yaml
---
title: ...
created: <ISO 8601>
updated: <ISO 8601>
tags: [imported, apple-notes, ...hashtags]
source: apple-notes
---
```

## Acceptance criteria

- [x] `process.platform === 'darwin'` guard.
- [x] Folder hierarchy preserved (`Imported/apple-notes/<folder>/<slug>.md`).
- [x] Inline images saved to `assets/<note-slug>/<n>.<ext>`.
- [x] Frontmatter shape (`title`, `created`, `updated`, `tags`, `source: apple-notes`).
- [x] Dry-run preview before writing.
- [x] Docs at `docs/importer-apple-notes.md`.
- [x] `npm run compile:electron` passes.

## Files

- `apps/electron/importers/apple-notes/index.ts` — contract export, dispatcher, preview/write phases.
- `apps/electron/importers/apple-notes/applescript.ts` — `osascript` runner, note enumeration, attachment reader.
- `apps/electron/importers/apple-notes/html-to-md.ts` — minimal HTML unwrap + `#hashtag` puller.
- `docs/importer-apple-notes.md` — user + developer docs.

## Test plan

- [ ] On macOS, `npm run compile:electron && npm run dev:electron` boots without errors.
- [ ] Startup log includes `[importers] registered: apple-notes, generic, sample` (or whatever the registered set is).
- [ ] **Import from… → Apple Notes** on first run produces `Imported/apple-notes/Apple Notes — Import preview.md` listing real notes from Notes.app.
- [ ] Re-running with confirm writes notes under `Imported/apple-notes/<folder>/<slug>.md` with frontmatter matching the spec.
- [ ] An imaged note has its image saved at `Imported/apple-notes/<folder>/assets/<slug>/1.<ext>` and referenced from the body.
- [ ] Locked test note skipped with a clear log entry.
- [ ] On Linux/Windows, the importer is listed but yields zero notes with a one-line log.