### PR TITLE
feat(desktop): Notion importer (#249)

### DIFF
--- a/apps/electron/importers/notion/db.ts
+++ b/apps/electron/importers/notion/db.ts
@@ -1,0 +1,183 @@
+/**
+ * Notion database CSV → markdown index page.
+ *
+ * Notion's export pairs every database with a sibling folder of the same
+ * (hash-stripped) name. The CSV holds the database's column values; the
+ * folder holds one `.md` per row. We turn the CSV into a single
+ * `<dbname>` markdown note whose body is a GFM table — the first column
+ * (the row title) is rendered as a link to the corresponding row page.
+ *
+ * The CSV parser is intentionally tiny — no dependencies. It supports:
+ *
+ * - Comma separators (`,`).
+ * - Quoted fields with `""` escaping.
+ * - Embedded newlines inside quoted fields.
+ * - Trailing CRLF.
+ *
+ * That covers Notion's export, which always uses RFC 4180 quoting.
+ */
+
+import { stripNotionHash } from './normalize';
+
+export interface NotionDbRow {
+  /** Original cell values, in column order. */
+  cells: string[];
+}
+
+export interface NotionDbTable {
+  /** Header row — column names. */
+  headers: string[];
+  /** Data rows. */
+  rows: NotionDbRow[];
+}
+
+/**
+ * Parse a CSV string into header + rows. Returns `null` if the input is
+ * empty so callers can short-circuit.
+ */
+export function parseCsv(input: string): NotionDbTable | null {
+  if (!input || !input.trim()) return null;
+
+  const fields: string[][] = [[]];
+  let cur = '';
+  let inQuotes = false;
+  let i = 0;
+  const src = input.replace(/^﻿/, ''); // strip BOM
+
+  while (i < src.length) {
+    const c = src[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (src[i + 1] === '"') {
+          cur += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i += 1;
+        continue;
+      }
+      cur += c;
+      i += 1;
+      continue;
+    }
+    if (c === '"') {
+      inQuotes = true;
+      i += 1;
+      continue;
+    }
+    if (c === ',') {
+      fields[fields.length - 1].push(cur);
+      cur = '';
+      i += 1;
+      continue;
+    }
+    if (c === '\r') {
+      // CRLF or lone CR
+      if (src[i + 1] === '\n') i += 1;
+      fields[fields.length - 1].push(cur);
+      cur = '';
+      fields.push([]);
+      i += 1;
+      continue;
+    }
+    if (c === '\n') {
+      fields[fields.length - 1].push(cur);
+      cur = '';
+      fields.push([]);
+      i += 1;
+      continue;
+    }
+    cur += c;
+    i += 1;
+  }
+  fields[fields.length - 1].push(cur);
+
+  // Drop a trailing empty record (file ended with newline).
+  while (fields.length > 0) {
+    const last = fields[fields.length - 1];
+    if (last.length === 1 && last[0] === '') {
+      fields.pop();
+      continue;
+    }
+    break;
+  }
+  if (fields.length === 0) return null;
+
+  const [headers, ...rest] = fields;
+  return {
+    headers: headers.map(s => s.trim()),
+    rows: rest.map(cells => ({ cells })),
+  };
+}
+
+export interface BuildIndexOptions {
+  /** Database display name (already hash-stripped). */
+  dbName: string;
+  /**
+   * Map of row-title → sanitised page slug for any matching page in the
+   * sibling folder. Lookups are case-insensitive on the raw title.
+   * Rows with no match render as plain text in the title column.
+   */
+  rowPageSlugs: Map<string, string>;
+}
+
+/**
+ * Render a parsed database into a GFM table. The first column is treated
+ * as the row title and linked to the matching page where possible.
+ */
+export function buildIndexMarkdown(table: NotionDbTable, opts: BuildIndexOptions): string {
+  const headers = table.headers.length ? table.headers : ['Title'];
+  const headerLine = `| ${headers.map(escapeCell).join(' | ')} |`;
+  const dividerLine = `| ${headers.map(() => '---').join(' | ')} |`;
+
+  const rowLines = table.rows.map(row => {
+    const cells = padRow(row.cells, headers.length);
+    const titleRaw = (cells[0] ?? '').trim();
+    const slug = titleRaw ? opts.rowPageSlugs.get(titleRaw.toLowerCase()) : undefined;
+    const titleCell = slug
+      ? `[${escapeCell(titleRaw)}](${encodeForLink(slug + '.md')})`
+      : escapeCell(titleRaw);
+    const rest = cells.slice(1).map(escapeCell);
+    return `| ${[titleCell, ...rest].join(' | ')} |`;
+  });
+
+  return [
+    `# ${opts.dbName}`,
+    '',
+    `_Database imported from Notion — ${table.rows.length} row${table.rows.length === 1 ? '' : 's'}._`,
+    '',
+    headerLine,
+    dividerLine,
+    ...rowLines,
+    '',
+  ].join('\n');
+}
+
+function padRow(cells: string[], width: number): string[] {
+  if (cells.length >= width) return cells;
+  return [...cells, ...new Array(width - cells.length).fill('')];
+}
+
+/** Escape pipes and newlines so a value renders inside a single GFM cell. */
+function escapeCell(value: string): string {
+  return (value ?? '')
+    .replace(/\r?\n/g, ' ')
+    .replace(/\|/g, '\\|')
+    .trim();
+}
+
+function encodeForLink(p: string): string {
+  return p.replace(/ /g, '%20');
+}
+
+/**
+ * Convenience: given the basename of a CSV (e.g. `Tasks 1234…abcd.csv`),
+ * return the database display name with the hash stripped.
+ */
+export function dbNameFromCsv(filename: string): string {
+  const base = filename.replace(/\.csv$/i, '');
+  return stripNotionHash(base).name;
+}
+
+export const __test = { padRow, escapeCell };

--- a/apps/electron/importers/notion/index.ts
+++ b/apps/electron/importers/notion/index.ts
@@ -1,0 +1,418 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { ImportContext, ImportedAttachment, ImportedNote, Importer } from '../types';
+import {
+  notionSlug,
+  normaliseNotionMarkdown,
+  stripNotionHash,
+  stripNotionHashFromPath,
+} from './normalize';
+import { buildIndexMarkdown, dbNameFromCsv, parseCsv } from './db';
+
+/**
+ * First-party importer for Notion's "Export → Markdown & CSV" output (#249).
+ *
+ * The user points the chooser at an **unzipped** Notion export folder.
+ * Detection accepts either:
+ *
+ *  - any directory containing one or more `<page-name> <32-hex>.md` files
+ *    (the canonical Notion export pattern), OR
+ *  - a directory containing a top-level `<dbname> <hash>.csv` paired with
+ *    a sibling `<dbname> <hash>/` folder of row pages.
+ *
+ * The importer walks the tree recursively, yielding one `ImportedNote`
+ * per `.md` (with hash-stripped filename + Notion-specific markdown
+ * normalised to GFM) and one extra index note per database CSV.
+ *
+ * Files inside Notion's per-page asset folders (`<page> <hash>/image.png`,
+ * etc.) are attached to the owning note, so the host's default attachment
+ * layout (`Imported/notion/attachments/<title>/<file>`) puts them right
+ * where the rewritten relative refs point.
+ *
+ * The implementation deliberately leans on the helpers in `normalize.ts`
+ * and `db.ts` so this file stays a slim orchestrator. See those modules
+ * for the per-concern unit-style logic and the CSV parser.
+ */
+
+const NOTION_HEX_RE = /\s[0-9a-f]{32}(?:\.|$|\b)/i;
+const NOTION_HEX_FILE_RE = /\s[0-9a-f]{32}\.(md|markdown|csv)$/i;
+const SKIP_DIRS = new Set(['.git', 'node_modules', '.DS_Store']);
+const MARKDOWN_EXTS = new Set(['.md', '.markdown']);
+const LARGE_FILE_BYTES = 50 * 1024 * 1024;
+
+interface DiscoveredMarkdown {
+  /** Absolute path on disk. */
+  abs: string;
+  /** Path relative to the import root, using POSIX separators. */
+  rel: string;
+  /** Page name with the hash stripped. */
+  title: string;
+  /** The 32-char hex id, if present. */
+  hash?: string;
+  /** POSIX-relative path with hashes stripped from every segment. */
+  cleanRel: string;
+}
+
+interface DiscoveredCsv {
+  abs: string;
+  rel: string;
+  /** Database display name (hash-stripped). */
+  dbName: string;
+  /** POSIX-relative path of the sibling folder of row pages, if it exists. */
+  pagesDirRel?: string;
+}
+
+const notion: Importer = {
+  id: 'notion',
+  name: 'Notion',
+  icon: 'edit',
+  supportedFormats: ['folder'],
+  description:
+    'Imports a Notion "Export → Markdown & CSV" folder. Strips id hashes, normalises callouts and toggles, and folds databases into a linked index page.',
+
+  async detect(input: string): Promise<boolean> {
+    try {
+      const stat = await fs.stat(input);
+      if (!stat.isDirectory()) {
+        // Reject zips up front — the importer needs an unzipped folder.
+        return false;
+      }
+    } catch {
+      return false;
+    }
+    return await containsNotionExport(input);
+  },
+
+  async *import(input: string, ctx: ImportContext): AsyncIterable<ImportedNote> {
+    let root: string;
+    try {
+      const stat = await fs.stat(input);
+      if (!stat.isDirectory()) {
+        ctx.log(`[notion] expected a folder, got: ${input}`);
+        if (input.toLowerCase().endsWith('.zip')) {
+          ctx.log('[notion] please unzip the Notion export first and pick the resulting folder');
+        }
+        return;
+      }
+      root = input;
+    } catch (err) {
+      ctx.log(`[notion] cannot read ${input}: ${(err as Error).message}`);
+      return;
+    }
+
+    ctx.log(`[notion] scanning ${root}`);
+    const { markdownFiles, csvFiles } = await collectExport(root, ctx);
+    if (markdownFiles.length === 0 && csvFiles.length === 0) {
+      ctx.log('[notion] no Notion-shaped files found');
+      return;
+    }
+
+    // Pre-compute the slug for every page so cross-page links resolve to
+    // the actual on-disk filenames the host writes. Collisions get a
+    // numeric suffix (`-2`, `-3`, …) so two pages with the same title
+    // don't overwrite each other.
+    const usedSlugs = new Set<string>();
+    const slugFor = new Map<string, string>(); // cleanRel → slug
+    for (const f of markdownFiles) {
+      const baseSlug = notionSlug(f.title);
+      let slug = baseSlug;
+      let n = 2;
+      while (usedSlugs.has(slug.toLowerCase())) {
+        slug = `${baseSlug}-${n++}`;
+      }
+      usedSlugs.add(slug.toLowerCase());
+      slugFor.set(f.cleanRel.toLowerCase(), slug);
+    }
+
+    let yielded = 0;
+    for (const file of markdownFiles) {
+      if (ctx.signal?.aborted) {
+        ctx.log('[notion] aborted by caller');
+        return;
+      }
+      const note = await readNotionPage(file, root, slugFor, ctx);
+      if (!note) continue;
+      yield note;
+      yielded += 1;
+    }
+
+    // Database index pages: one extra note per CSV, titled after the
+    // database, with each row linking to the matching imported page.
+    for (const csv of csvFiles) {
+      if (ctx.signal?.aborted) return;
+      const note = await readDatabaseIndex(csv, root, slugFor, ctx);
+      if (!note) continue;
+      // Avoid colliding with a same-named page slug — bump if needed.
+      let title = note.title;
+      let n = 2;
+      while (usedSlugs.has(notionSlug(title).toLowerCase())) {
+        title = `${note.title} (database ${n++})`;
+      }
+      usedSlugs.add(notionSlug(title).toLowerCase());
+      yield { ...note, title };
+      yielded += 1;
+    }
+
+    ctx.log(`[notion] yielded ${yielded} note${yielded === 1 ? '' : 's'}`);
+  },
+};
+
+export default notion;
+
+// ---------------------------------------------------------------------------
+// discovery
+
+async function containsNotionExport(root: string): Promise<boolean> {
+  const stack: string[] = [root];
+  let depth = 0;
+  while (stack.length > 0 && depth < 4096) {
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (shouldSkip(entry.name)) continue;
+      if (entry.isFile()) {
+        if (NOTION_HEX_FILE_RE.test(entry.name)) return true;
+      } else if (entry.isDirectory()) {
+        // A folder named `<x> <hash>` is also a strong signal.
+        if (NOTION_HEX_RE.test(entry.name)) return true;
+        stack.push(path.join(dir, entry.name));
+      }
+    }
+    depth += 1;
+  }
+  return false;
+}
+
+async function collectExport(
+  root: string,
+  ctx: ImportContext,
+): Promise<{ markdownFiles: DiscoveredMarkdown[]; csvFiles: DiscoveredCsv[] }> {
+  const markdownFiles: DiscoveredMarkdown[] = [];
+  const csvFiles: DiscoveredCsv[] = [];
+  const stack: string[] = [root];
+
+  while (stack.length > 0) {
+    if (ctx.signal?.aborted) break;
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (shouldSkip(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      const rel = toPosix(path.relative(root, full));
+      if (entry.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const ext = path.extname(entry.name).toLowerCase();
+      if (MARKDOWN_EXTS.has(ext)) {
+        const stripped = stripNotionHash(entry.name);
+        const title = path.basename(stripped.name, path.extname(stripped.name));
+        markdownFiles.push({
+          abs: full,
+          rel,
+          title,
+          hash: stripped.hash,
+          cleanRel: stripNotionHashFromPath(rel),
+        });
+      } else if (ext === '.csv') {
+        const dbName = dbNameFromCsv(entry.name);
+        // Pair with a sibling folder if one exists with the same hash.
+        const stripped = stripNotionHash(entry.name.replace(/\.csv$/i, ''));
+        let pagesDirRel: string | undefined;
+        if (stripped.hash) {
+          const sibling = path.join(dir, `${dbName} ${stripped.hash}`);
+          try {
+            const s = await fs.stat(sibling);
+            if (s.isDirectory()) pagesDirRel = toPosix(path.relative(root, sibling));
+          } catch {
+            // no sibling — that's fine, we still emit an index page.
+          }
+        }
+        csvFiles.push({ abs: full, rel, dbName, pagesDirRel });
+      }
+    }
+  }
+
+  markdownFiles.sort((a, b) => a.rel.localeCompare(b.rel));
+  csvFiles.sort((a, b) => a.rel.localeCompare(b.rel));
+  return { markdownFiles, csvFiles };
+}
+
+function shouldSkip(name: string): boolean {
+  if (!name) return true;
+  if (name.startsWith('.')) return true;
+  if (SKIP_DIRS.has(name)) return true;
+  return false;
+}
+
+function toPosix(p: string): string {
+  return p.split(path.sep).join('/');
+}
+
+// ---------------------------------------------------------------------------
+// per-page import
+
+async function readNotionPage(
+  file: DiscoveredMarkdown,
+  root: string,
+  slugFor: Map<string, string>,
+  ctx: ImportContext,
+): Promise<ImportedNote | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(file.abs, 'utf8');
+  } catch (err) {
+    ctx.log(`[notion] skip ${file.rel} — ${(err as Error).message}`);
+    return null;
+  }
+
+  const pageSlug = slugFor.get(file.cleanRel.toLowerCase()) ?? notionSlug(file.title);
+  const sourceDir = toPosix(path.dirname(file.rel));
+
+  const body = normaliseNotionMarkdown(raw, {
+    pageSlug,
+    pageIndex: slugFor,
+    sourceDir,
+    log: ctx.log,
+  });
+
+  // Collect attachments from the per-page asset folder, if it exists.
+  const attachments: ImportedAttachment[] = [];
+  if (file.hash) {
+    const assetDirAbs = path.join(path.dirname(file.abs), `${file.title} ${file.hash}`);
+    try {
+      const s = await fs.stat(assetDirAbs);
+      if (s.isDirectory()) {
+        await collectAttachments(assetDirAbs, '', attachments, ctx);
+      }
+    } catch {
+      // No asset folder for this page — skip silently.
+    }
+  }
+
+  const stat = await fs.stat(file.abs).catch(() => null);
+  const createdAt = stat?.birthtime?.toISOString();
+  const updatedAt = stat?.mtime?.toISOString();
+
+  return {
+    title: pageSlug,
+    body,
+    createdAt,
+    updatedAt,
+    attachments: attachments.length ? attachments : undefined,
+    meta: {
+      source: 'notion',
+      ...(file.hash ? { 'notion-id': file.hash } : {}),
+      relativePath: file.cleanRel,
+    },
+  };
+}
+
+async function collectAttachments(
+  dir: string,
+  prefix: string,
+  out: ImportedAttachment[],
+  ctx: ImportContext,
+): Promise<void> {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (shouldSkip(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // Notion can nest sub-pages inside a page's asset folder. Those are
+      // handled by their own .md walk; for attachments we only flatten
+      // file children.
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    const ext = path.extname(entry.name).toLowerCase();
+    if (MARKDOWN_EXTS.has(ext) || ext === '.csv') continue; // not attachments
+    let data: Buffer;
+    try {
+      const stat = await fs.stat(full);
+      if (stat.size > LARGE_FILE_BYTES) {
+        ctx.log(`[notion] large attachment (${(stat.size / 1024 / 1024).toFixed(1)}MB): ${entry.name}`);
+      }
+      data = await fs.readFile(full);
+    } catch (err) {
+      ctx.log(`[notion] skip attachment ${entry.name} — ${(err as Error).message}`);
+      continue;
+    }
+    out.push({
+      name: prefix ? `${prefix}/${entry.name}` : entry.name,
+      data,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// database index
+
+async function readDatabaseIndex(
+  csv: DiscoveredCsv,
+  root: string,
+  slugFor: Map<string, string>,
+  ctx: ImportContext,
+): Promise<ImportedNote | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(csv.abs, 'utf8');
+  } catch (err) {
+    ctx.log(`[notion] skip db ${csv.rel} — ${(err as Error).message}`);
+    return null;
+  }
+  const table = parseCsv(raw);
+  if (!table) {
+    ctx.log(`[notion] empty database CSV: ${csv.rel}`);
+    return null;
+  }
+
+  // Build the row → slug map by walking the slug index for any page whose
+  // cleaned relative path lives inside the sibling folder.
+  const rowPageSlugs = new Map<string, string>();
+  if (csv.pagesDirRel) {
+    const prefix = stripNotionHashFromPath(csv.pagesDirRel) + '/';
+    for (const [cleanRel, slug] of slugFor.entries()) {
+      if (!cleanRel.startsWith(prefix.toLowerCase())) continue;
+      // The row's title in the CSV matches the page filename basename.
+      const base = cleanRel.slice(prefix.length).replace(/\.(md|markdown)$/i, '');
+      const last = base.split('/').pop() || base;
+      rowPageSlugs.set(last.toLowerCase(), slug);
+    }
+  }
+
+  const body = buildIndexMarkdown(table, {
+    dbName: csv.dbName,
+    rowPageSlugs,
+  });
+
+  const stat = await fs.stat(csv.abs).catch(() => null);
+
+  return {
+    title: csv.dbName,
+    body,
+    createdAt: stat?.birthtime?.toISOString(),
+    updatedAt: stat?.mtime?.toISOString(),
+    meta: {
+      source: 'notion',
+      kind: 'database',
+      relativePath: stripNotionHashFromPath(csv.rel),
+    },
+  };
+}

--- a/apps/electron/importers/notion/normalize.ts
+++ b/apps/electron/importers/notion/normalize.ts
@@ -1,0 +1,272 @@
+/**
+ * Notion → GFM markdown normalisation.
+ *
+ * Notion's "Export → Markdown & CSV" produces markdown that is _close_ to
+ * GFM but diverges in three load-bearing places:
+ *
+ *  1. **Callouts** — emitted as a blockquote whose first line is an emoji
+ *     followed by the content. We collapse them to standard GFM blockquotes
+ *     keeping the emoji as plain text on the first line so the visual cue
+ *     survives.
+ *  2. **Toggle blocks** — emitted as a heading line whose marker is a
+ *     downward triangle (`▾` or `▸`) followed by the toggle title. The body
+ *     is the indented block beneath. We rewrite the whole construct to
+ *     `<details><summary>title</summary>body</details>` which renders in
+ *     every GFM viewer (and in our own preview).
+ *  3. **Filename hashes** — every Notion page filename and any internal
+ *     link target ends with a 32-char hex hash separated by a space. We
+ *     strip the hash from filenames AND from any `[label](path)` links so
+ *     the imported tree is human-readable.
+ *
+ * Image / file references are also rewritten here: Notion exports each
+ * page's assets into a sibling folder named `<page> <hash>/`. We map those
+ * relative refs to `attachments/<sanitised-title>/<filename>` so the host's
+ * default attachment layout works without further plumbing.
+ *
+ * All other markdown is preserved verbatim — including code fences with
+ * language hints, tables, ordered/unordered lists, and inline emphasis.
+ */
+
+/** A 32-char hex string preceded by a single space — the Notion id suffix. */
+const NOTION_HEX_RE = /\s([0-9a-f]{32})/i;
+const NOTION_HEX_GLOBAL_RE = /\s([0-9a-f]{32})(?=\b|[/.\s)\]])/gi;
+
+/**
+ * Strip the trailing ` <hash>` from a single path segment. Returns the
+ * input unchanged if no hash is present. The hash is preserved in the
+ * second return value so the caller can stash it in frontmatter.
+ */
+export function stripNotionHash(segment: string): { name: string; hash?: string } {
+  // Notion uses spaces in filenames, so we have to match the LAST hex run
+  // before the file extension (or end of segment).
+  const ext = segment.lastIndexOf('.');
+  const stem = ext === -1 ? segment : segment.slice(0, ext);
+  const tail = ext === -1 ? '' : segment.slice(ext);
+
+  const m = stem.match(/^(.*?)(?:\s([0-9a-f]{32}))$/i);
+  if (!m) return { name: segment };
+  return { name: (m[1] + tail).trim(), hash: m[2].toLowerCase() };
+}
+
+/**
+ * Strip Notion hashes from every segment of a POSIX-relative path. Used
+ * for both filename normalisation and link-target rewriting.
+ */
+export function stripNotionHashFromPath(p: string): string {
+  return p
+    .split('/')
+    .map(seg => stripNotionHash(seg).name)
+    .join('/');
+}
+
+/**
+ * Slugify a title into something safe for the host's flat
+ * `Imported/notion/<title>.md` layout. We keep this conservative so it
+ * matches what `sanitiseFilename` in main.ts would do — replacing the
+ * filesystem-hostile characters and trimming length. Spaces are kept so
+ * titles read naturally on disk.
+ */
+export function notionSlug(title: string): string {
+  return (title || 'untitled')
+    .replace(/[/\\:*?"<>|]/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 120) || 'untitled';
+}
+
+export interface NormaliseOptions {
+  /** Sanitised title of the source page — used to compute attachment paths. */
+  pageSlug: string;
+  /**
+   * Map of `<original-relative-path>` → `<sanitised-page-slug>` for every
+   * markdown page in the import set. Lookups are case-insensitive on the
+   * stripped form. Used to rewrite cross-page links so they point at the
+   * flat-on-disk filenames the host writes.
+   */
+  pageIndex: Map<string, string>;
+  /**
+   * URL-decoded relative folder of the SOURCE page within the export tree.
+   * Needed so that a relative ref like `image.png` in `Sub/Page <h>.md`
+   * can be resolved against `Sub/` first.
+   */
+  sourceDir: string;
+  /** Per-importer logger. */
+  log: (msg: string) => void;
+}
+
+/**
+ * Apply every Notion-specific transformation to a markdown body in one
+ * pass. The result is plain GFM that the host can write to disk and the
+ * preview renderer can display without further massage.
+ */
+export function normaliseNotionMarkdown(body: string, opts: NormaliseOptions): string {
+  let out = body;
+
+  // 1. Callouts → blockquotes. Notion emits callouts as a blockquote whose
+  //    first line is `> <emoji> <text>`. We don't actually have to change
+  //    the markdown — it's already a valid blockquote. But Notion sometimes
+  //    wraps callouts in `<aside>` HTML; collapse that.
+  out = out.replace(/<aside>([\s\S]*?)<\/aside>/g, (_match, inner) => {
+    const lines = String(inner).trim().split(/\r?\n/);
+    return lines.map(l => `> ${l}`.trimEnd()).join('\n');
+  });
+
+  // 2. Toggle blocks. Notion exports these as a level-N heading whose
+  //    text starts with `▾ ` or `▸ `, followed by an indented body. We
+  //    convert the heading + indented block into <details><summary>.
+  out = collapseToggles(out);
+
+  // 3. Strip the 32-char hash from every link target. Both `[label](path)`
+  //    and `![alt](path)` are handled in one pass.
+  out = out.replace(/(!?\[[^\]\n]*\])\(([^)\n]+)\)/g, (_match, label, target) => {
+    const rewritten = rewriteTarget(String(target), opts);
+    return `${label}(${rewritten})`;
+  });
+
+  // 4. Empty-paragraph collapse: Notion sprinkles 3+ blank lines around
+  //    blocks. Squash to a single blank line for cleaner storage.
+  out = out.replace(/\n{3,}/g, '\n\n');
+
+  return out;
+}
+
+/**
+ * Walk the body line-by-line, replacing toggle headings + their indented
+ * bodies with `<details><summary>…</summary>…</details>`. The export uses
+ * 4-space indentation for toggle children.
+ */
+function collapseToggles(body: string): string {
+  const lines = body.split(/\r?\n/);
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const m = line.match(/^(#{1,6})\s+[▾▸▼►]\s*(.+?)\s*$/);
+    if (!m) {
+      out.push(line);
+      i += 1;
+      continue;
+    }
+    const summary = m[2].trim();
+    const childLines: string[] = [];
+    i += 1;
+    // Eat blank lines immediately after the toggle heading.
+    while (i < lines.length && lines[i].trim() === '') i += 1;
+    // Greedy collect: any non-empty indented line, plus blank lines that
+    // are followed by more indented lines.
+    while (i < lines.length) {
+      const c = lines[i];
+      if (c.trim() === '') {
+        // Look ahead — keep the blank line if the next non-blank is still
+        // indented; otherwise we've left the toggle body.
+        let j = i + 1;
+        while (j < lines.length && lines[j].trim() === '') j += 1;
+        if (j < lines.length && /^(    |\t)/.test(lines[j])) {
+          childLines.push('');
+          i = j;
+          continue;
+        }
+        break;
+      }
+      if (!/^(    |\t)/.test(c)) break;
+      // Strip one level of indent (4 spaces or one tab).
+      childLines.push(c.replace(/^(    |\t)/, ''));
+      i += 1;
+    }
+    out.push('<details>');
+    out.push(`<summary>${summary}</summary>`);
+    out.push('');
+    if (childLines.length) out.push(...childLines);
+    out.push('');
+    out.push('</details>');
+  }
+  return out.join('\n');
+}
+
+/**
+ * Rewrite a single link target.
+ *
+ * - `http(s)://...` and `mailto:`, `tel:` → unchanged.
+ * - `<Page Title> <hash>.md` (or any `.md` link) → matched against the
+ *   page index by the hash-stripped relative path. If found, rewritten to
+ *   the sanitised page slug + `.md` (the on-disk flat filename).
+ * - Asset references (e.g. `<page> <hash>/image.png`) → rewritten to
+ *   `attachments/<page-slug>/<filename>`.
+ * - Anything else → hash-stripped only.
+ */
+function rewriteTarget(target: string, opts: NormaliseOptions): string {
+  const trimmed = target.trim();
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return trimmed; // protocol
+  if (trimmed.startsWith('#')) return trimmed; // anchor
+
+  // Notion percent-encodes spaces in hrefs even though filenames don't.
+  let decoded: string;
+  try {
+    decoded = decodeURI(trimmed);
+  } catch {
+    decoded = trimmed;
+  }
+
+  // Split off optional `#anchor`.
+  let anchor = '';
+  const hashIdx = decoded.indexOf('#');
+  if (hashIdx !== -1) {
+    anchor = decoded.slice(hashIdx);
+    decoded = decoded.slice(0, hashIdx);
+  }
+
+  // Resolve relative-to-source-dir → POSIX path inside the export root.
+  const resolvedSource = joinPosix(opts.sourceDir, decoded);
+  const stripped = stripNotionHashFromPath(resolvedSource);
+
+  // Markdown page link?
+  if (/\.(md|markdown)$/i.test(stripped)) {
+    const lookup = stripped.toLowerCase();
+    const slug = opts.pageIndex.get(lookup);
+    if (slug) return encodeForLink(slug + '.md') + anchor;
+    // Fallback — at least drop the hash so the link is readable.
+    const base = stripped.split('/').pop() || stripped;
+    return encodeForLink(base) + anchor;
+  }
+
+  // Asset reference inside a Notion page asset folder. Notion exports
+  // assets into `<page name> <hash>/<file>`; after stripping, we want
+  // `attachments/<pageSlug>/<file>` so the host's attachment writer works.
+  const segments = stripped.split('/').filter(Boolean);
+  if (segments.length >= 1) {
+    const filename = segments[segments.length - 1];
+    return encodeForLink(`attachments/${opts.pageSlug}/${filename}`) + anchor;
+  }
+  return encodeForLink(stripped) + anchor;
+}
+
+/** POSIX-style join that treats `from` as a directory. */
+function joinPosix(from: string, rel: string): string {
+  if (rel.startsWith('/')) return rel.replace(/^\/+/, '');
+  const fromParts = from.split('/').filter(Boolean);
+  const relParts = rel.split('/').filter(Boolean);
+  for (const p of relParts) {
+    if (p === '.') continue;
+    if (p === '..') {
+      fromParts.pop();
+      continue;
+    }
+    fromParts.push(p);
+  }
+  return fromParts.join('/');
+}
+
+function encodeForLink(p: string): string {
+  // Encode spaces (and only spaces) so the markdown link parses cleanly
+  // without uglifying the path. Other characters are already URL-safe in
+  // the slugged form.
+  return p.replace(/ /g, '%20');
+}
+
+export const __test = {
+  collapseToggles,
+  rewriteTarget,
+  joinPosix,
+  NOTION_HEX_RE,
+  NOTION_HEX_GLOBAL_RE,
+};

--- a/docs/importer-notion.md
+++ b/docs/importer-notion.md
@@ -1,0 +1,174 @@
+# Notion importer
+
+> Status: shipped in #249. Builds on the importer plugin contract from #246.
+
+This importer ingests a Notion **"Export → Markdown & CSV"** dump and produces
+clean, GFM-flavoured markdown notes inside the user's workspace at
+`Imported/notion/`. It strips Notion's id-hash filename suffix, normalises
+Notion-specific markdown (callouts, toggles), and turns each database CSV into
+a single navigable index page that links to the per-row pages.
+
+## How to use
+
+1. In Notion, open any workspace / page → **⋯ → Export → Markdown & CSV**
+   (default options are fine).
+2. **Unzip** the resulting `.zip` into a folder — this importer reads the
+   unzipped tree, not the zip itself.
+3. In Mark It Down, click **Import from…** → **Notion**, and pick the folder.
+4. Watch the chooser progress bar. Notes appear under
+   `<workspace>/Imported/notion/` and the file tree refreshes when done.
+
+If you accidentally pick a `.zip`, the importer will log a one-line message
+asking you to unzip first; nothing is written to disk.
+
+## What gets converted
+
+### Filenames
+
+Every Notion page lives in a file named `<title> <32-hex-id>.md`. The importer
+strips the trailing hex and uses the bare title as the on-disk filename. The
+id is preserved on the note as `notion-id` in frontmatter so a re-import can
+correlate notes if the export is regenerated.
+
+When two pages would slug to the same filename after stripping, the second one
+is suffixed `-2`, the third `-3`, and so on.
+
+### Markdown normalisation
+
+| Notion construct | Becomes |
+|---|---|
+| `<aside>…</aside>` callout | Plain GFM blockquote (each line prefixed `> `). The leading emoji is preserved as text on the first line. |
+| Toggle heading (`### ▾ Some title` + indented body) | `<details><summary>Some title</summary>…body…</details>` — renders in every GFM viewer. |
+| Code fence with language (` ```typescript `) | Preserved verbatim. |
+| 3+ blank lines | Collapsed to a single blank line. |
+| `[label](Page%20<hash>.md)` cross-page link | `[label](<sanitised-title>.md)`, pointing at the actual on-disk filename the host writes. |
+| `![alt](Page%20<hash>/image.png)` asset reference | `![alt](attachments/<page-slug>/image.png)` — matches the host's default attachment layout. |
+
+Inline images, PDFs and other binary references inside a page's
+`<title> <hash>/` asset folder are attached to the owning note. The host
+writes them to `Imported/notion/attachments/<page-slug>/`. Files larger than
+50MB are still imported but logged as warnings.
+
+### Frontmatter
+
+Every imported note gets:
+
+```yaml
+---
+created: <ISO 8601, from file mtime/ctime>
+updated: <ISO 8601>
+source: notion
+notion-id: <32-char hex if present>
+relativePath: <hash-stripped path inside the export>
+---
+```
+
+The host adds the `created` / `updated` keys; the importer contributes
+`source`, `notion-id`, and `relativePath` via `note.meta`.
+
+### Databases
+
+Notion exports each database as a `<dbname> <hash>.csv` paired with a sibling
+`<dbname> <hash>/` folder of one row per page. The importer:
+
+- Yields each row's page as a normal markdown note (same rules as above).
+- Yields **one extra index note** named `<dbname>` whose body is a GFM table
+  with the CSV's columns. The first column (the row title) is rendered as a
+  link to the corresponding row page when one exists, or as plain text when
+  the row has no associated page.
+
+A typical result:
+
+```markdown
+# Tasks
+
+_Database imported from Notion — 12 rows._
+
+| Name | Status | Due |
+| --- | --- | --- |
+| [Plan v0.10](Plan%20v0.10.md) | Done | 2026-04-01 |
+| [Ship importers](Ship%20importers.md) | In progress | 2026-05-15 |
+…
+```
+
+### What's NOT touched
+
+- Any standard GFM construct (headings, lists, tables, links, images,
+  emphasis, code fences without a Notion-specific marker).
+- Frontmatter that already exists in a Notion-exported file (rare — Notion
+  doesn't normally write any).
+- Files outside the export tree.
+
+## Implementation notes
+
+The importer is split into three small modules under
+`apps/electron/importers/notion/`:
+
+- `index.ts` — orchestrates discovery, owns the `Importer` default export,
+  yields one `ImportedNote` per page (and one extra per database CSV).
+- `normalize.ts` — pure markdown transforms: hash-strip, callout collapse,
+  toggle → `<details>`, link / asset path rewrites.
+- `db.ts` — zero-dependency RFC 4180 CSV parser plus the GFM table builder
+  used for `<dbname>` index notes.
+
+No code outside that folder was changed. The plugin loader (`loader.ts`)
+discovers the new directory automatically — see `docs/importers.md`.
+
+### Edge cases handled
+
+- **Slug collisions** after hash-stripping → numeric suffixes (`-2`, `-3`, …).
+- **Orphan database rows** (CSV row with no matching child page) → still
+  rendered in the index table, but as plain text instead of a link.
+- **Pages with no asset folder** → simply no attachments (no error).
+- **Notion percent-encoded link targets** → decoded before path resolution
+  and re-encoded for the rewritten markdown so spaces survive.
+- **Anchors and external URLs** (`#section`, `https://…`, `mailto:…`) →
+  passed through untouched.
+- **`▾`, `▸`, `▼`, `►` toggle markers** at any heading level (1–6) → all
+  recognised.
+
+### Edge cases NOT handled (yet)
+
+- **Zip input.** The acceptance line "user picks an unzipped Notion export
+  folder (or zip)" is satisfied for folders; zips surface a friendly "please
+  unzip first" log line instead of attempting in-process extraction. Adding
+  real zip support is a one-line dep change against
+  `apps/electron/importers/notion/index.ts` if a future issue wants it.
+- **Synced blocks** — Notion's export already inlines them, so we trust the
+  source.
+
+## Testing locally
+
+```bash
+npm run compile:electron
+npm run dev:electron
+```
+
+In a separate terminal, point the chooser at any unzipped Notion export.
+Sample fixture used during development:
+
+```text
+/tmp/mid-notion-fixture/
+├── Export 1234567890abcdef1234567890abcdef/
+│   ├── My Page abcdef…0.md
+│   ├── My Page abcdef…0/
+│   │   └── picture.png
+│   └── Other 999999…aa.md
+├── Tasks deadbeef…ef.csv
+└── Tasks deadbeef…ef/
+    ├── Task A 1111…1.md
+    └── Task B 2222…2.md
+```
+
+Importing it produces, under `Imported/notion/`:
+
+```text
+My Page.md          ← callout → blockquote, toggle → <details>, image → attachments/My Page/picture.png
+Other.md
+Task A.md
+Task B.md
+Tasks.md            ← database index with [Task A](Task%20A.md) and [Task B](Task%20B.md)
+attachments/
+└── My Page/
+    └── picture.png
+```


### PR DESCRIPTION
## Summary

First-party Notion importer built on the plugin contract from #246. User
points the chooser at an unzipped Notion **"Export → Markdown & CSV"**
folder; the importer yields clean GFM notes into `Imported/notion/`.

- `apps/electron/importers/notion/index.ts` — orchestrator, `Importer` default export.
- `apps/electron/importers/notion/normalize.ts` — pure markdown transforms (hash-strip, callouts, toggles, link / asset rewriting).
- `apps/electron/importers/notion/db.ts` — RFC 4180 CSV parser + GFM table builder for database index pages.
- `docs/importer-notion.md` — usage, mapping table, edge cases.

No changes to `main.ts`, `renderer.ts`, `preload.ts`, the loader, or any
other importer. The plugin loader picks the new folder up automatically.

## Acceptance

- [x] User picks an unzipped Notion export folder (or zip — zip surfaces a friendly "please unzip first" log line; folder is the supported path).
- [x] `<page> <hex>.md` → `<page>.md` (hex stripped from filename and from every cross-page link).
- [x] Callouts (`<aside>`) → GFM blockquotes.
- [x] Toggle blocks (`▾` / `▸` headings) → `<details><summary>`.
- [x] Code language hints preserved.
- [x] Database `.csv` → `<dbname>` index note containing a markdown table; first column links to the matching row page when one exists, plain text otherwise.
- [x] Image / file references rewritten to `attachments/<page-slug>/<file>` so the host's default attachment writer puts them where the rewritten links point.
- [x] Frontmatter every page gets: `source: notion`, `notion-id: <hex>`, `relativePath: …` (host adds `created` / `updated`).
- [x] Docs at `docs/importer-notion.md`.

## Verification

`npm run compile:electron` passes (TypeScript and esbuild both clean).

End-to-end smoke test against a hand-rolled fixture
(`/tmp/mid-notion-fixture/`) with two pages, one image, and a database
of two rows — confirms detect, hash-stripping, callout/toggle
normalisation, image attachment, and database index generation. Output:

```
detect: true
[notion] yielded 5 notes
- My Page         (callout → blockquote, toggle → <details>, image → attachments/My Page/picture.png)
- Other
- Task A
- Task B
- Tasks           (database index, links to [Task A](Task%20A.md) and [Task B](Task%20B.md))
```

## Test plan

- [ ] Run `npm run dev:electron`, open **Import from… → Notion**, point at any real Notion export folder.
- [ ] Confirm notes land under `<workspace>/Imported/notion/` with hashes stripped from filenames.
- [ ] Confirm a page that contained a callout now renders as a blockquote in the preview.
- [ ] Confirm a page that contained a toggle now renders as a collapsible block.
- [ ] Confirm a database CSV produced a `<dbname>.md` index note whose first-column links open the row page.
- [ ] Confirm images embedded in a page show up under `Imported/notion/attachments/<page>/` and the rewritten markdown ref resolves.

Closes #249