### PR TITLE
fix(desktop): Spotlight visual polish — input-row search icon + inline scope pills + two-line rows

### DIFF
--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -82,11 +82,14 @@
   </nav>
   <dialog id="mid-spotlight" class="mid-spotlight">
     <div class="mid-spotlight-frame">
-      <div class="mid-spotlight-tabs">
-        <button class="mid-spotlight-tab is-active" data-spotlight-scope="workspace">Workspace</button>
-        <button class="mid-spotlight-tab" data-spotlight-scope="file">Current file</button>
+      <div class="mid-spotlight-input-row">
+        <span id="mid-spotlight-input-icon" class="mid-spotlight-input-icon" aria-hidden="true"></span>
+        <input id="mid-spotlight-input" class="mid-spotlight-input" type="text" placeholder="Type to search…" autocomplete="off" />
       </div>
-      <input id="mid-spotlight-input" class="mid-spotlight-input" type="text" placeholder="Type to search…" autocomplete="off" />
+      <div class="mid-spotlight-tabs" role="tablist" aria-label="Search scope">
+        <button class="mid-spotlight-tab is-active" data-spotlight-scope="workspace" role="tab" aria-selected="true">Workspace</button>
+        <button class="mid-spotlight-tab" data-spotlight-scope="file" role="tab" aria-selected="false">Current file</button>
+      </div>
       <div id="mid-spotlight-results" class="mid-spotlight-results"></div>
       <div id="mid-spotlight-footer" class="mid-spotlight-footer">
         <span class="mid-spotlight-hint"><kbd class="mid-spotlight-kbd">↑↓</kbd> navigate</span>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -339,34 +339,63 @@ body.has-sidebar .mid-shell {
   box-shadow: var(--mid-shadow-lg);
   overflow: hidden;
 }
-.mid-spotlight-tabs {
+.mid-spotlight-input-row {
   display: flex;
-  gap: 2px;
-  padding: var(--mid-space-2) var(--mid-space-3);
+  align-items: center;
+  gap: var(--mid-space-2);
+  padding: 0 var(--mid-space-4);
   border-bottom: 1px solid var(--mid-border);
+  background: var(--mid-bg);
+}
+.mid-spotlight-input-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--mid-fg-muted);
+}
+.mid-spotlight-input-icon .mid-icon { width: 16px; height: 16px; }
+.mid-spotlight-input {
+  flex: 1;
+  min-width: 0;
+  padding: var(--mid-space-3) 0;
+  font-family: inherit;
+  font-size: var(--mid-font-size-lg);
+  color: var(--mid-fg);
+  background: transparent;
+  border: 0;
+  outline: none;
+}
+.mid-spotlight-input::placeholder { color: var(--mid-fg-muted); opacity: 0.7; }
+.mid-spotlight-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin: var(--mid-space-2) var(--mid-space-3);
+  padding: 2px;
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: 999px;
+  width: max-content;
 }
 .mid-spotlight-tab {
   padding: 4px var(--mid-space-3);
   font-family: inherit;
-  font-size: var(--mid-font-size-sm);
+  font-size: var(--mid-font-size-xs);
+  font-weight: var(--mid-weight-medium);
   color: var(--mid-fg-muted);
   background: transparent;
   border: 0;
-  border-radius: var(--mid-radius-sm);
+  border-radius: 999px;
   cursor: pointer;
+  line-height: 1.4;
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
-.mid-spotlight-tab:hover { background: var(--mid-surface); color: var(--mid-fg); }
-.mid-spotlight-tab.is-active { background: var(--mid-surface); color: var(--mid-fg); }
-.mid-spotlight-input {
-  width: 100%;
-  padding: var(--mid-space-3) var(--mid-space-4);
-  font-family: inherit;
-  font-size: var(--mid-font-size-lg);
-  color: var(--mid-fg);
+.mid-spotlight-tab:hover { color: var(--mid-fg); }
+.mid-spotlight-tab.is-active {
   background: var(--mid-bg);
-  border: 0;
-  border-bottom: 1px solid var(--mid-border);
-  outline: none;
+  color: var(--mid-fg);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
 }
 .mid-spotlight-results {
   max-height: 50vh;
@@ -384,10 +413,9 @@ body.has-sidebar .mid-shell {
   color: var(--mid-fg-muted);
 }
 .mid-spotlight-row {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
+  display: flex;
   align-items: center;
-  gap: var(--mid-space-2);
+  gap: var(--mid-space-3);
   width: 100%;
   padding: var(--mid-space-2) var(--mid-space-3);
   background: transparent;
@@ -398,10 +426,43 @@ body.has-sidebar .mid-shell {
   color: var(--mid-fg);
   text-align: left;
 }
+.mid-spotlight-row > .mid-icon { flex-shrink: 0; }
 .mid-spotlight-row:hover { background: var(--mid-surface); }
 .mid-spotlight-row.is-active { background: var(--mid-accent-soft, var(--mid-surface)); outline: 1px solid var(--mid-accent, var(--mid-border)); }
-.mid-spotlight-row-name { font-weight: var(--mid-weight-medium); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.mid-spotlight-row-path { font-family: var(--mid-font-mono); font-size: var(--mid-font-size-xs); color: var(--mid-fg-muted); white-space: nowrap; }
+.mid-spotlight-row-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  overflow: hidden;
+}
+.mid-spotlight-row-name {
+  font-weight: var(--mid-weight-regular, 400);
+  font-size: var(--mid-font-size-sm);
+  color: var(--mid-fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.3;
+}
+.mid-spotlight-row-desc {
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.3;
+}
+.mid-spotlight-row-path {
+  font-family: var(--mid-font-mono);
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.3;
+}
 .mid-spotlight-empty { padding: var(--mid-space-4); text-align: center; color: var(--mid-fg-muted); font-size: var(--mid-font-size-sm); }
 .mid-spotlight-match { font-weight: var(--mid-weight-bold, 700); color: var(--mid-accent, var(--mid-fg)); background: var(--mid-accent-soft, transparent); border-radius: 2px; padding: 0 1px; }
 .mid-spotlight-row.is-active .mid-spotlight-match { color: inherit; }

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -1973,13 +1973,13 @@ function openRepoPicker(repos: { nameWithOwner: string; description: string; vis
       // Always offer "Create new repo…" at the top
       const createRow = document.createElement('button');
       createRow.className = 'mid-spotlight-row';
-      createRow.innerHTML = `${iconHTML('plus', 'mid-icon--sm mid-icon--muted')}<span class="mid-spotlight-row-name">Create new repo…</span><span class="mid-spotlight-row-path">${q ? escapeHTML(q) : 'enter name'}</span>`;
+      createRow.innerHTML = `${iconHTML('plus', 'mid-icon--sm mid-icon--muted')}<span class="mid-spotlight-row-body"><span class="mid-spotlight-row-name">Create new repo…</span><span class="mid-spotlight-row-desc">${q ? escapeHTML(q) : 'enter name'}</span></span>`;
       createRow.addEventListener('click', () => { void onCreateNew(q || ''); });
       results.appendChild(createRow);
       for (const r of matches.slice(0, 50)) {
         const row = document.createElement('button');
         row.className = 'mid-spotlight-row';
-        row.innerHTML = `${iconHTML('github', 'mid-icon--sm mid-icon--muted')}<span class="mid-spotlight-row-name">${escapeHTML(r.nameWithOwner)}</span><span class="mid-spotlight-row-path">${escapeHTML(r.visibility?.toLowerCase() ?? '')}</span>`;
+        row.innerHTML = `${iconHTML('github', 'mid-icon--sm mid-icon--muted')}<span class="mid-spotlight-row-body"><span class="mid-spotlight-row-name">${escapeHTML(r.nameWithOwner)}</span><span class="mid-spotlight-row-desc">${escapeHTML(r.visibility?.toLowerCase() ?? '')}</span></span>`;
         if (r.description) row.title = r.description;
         row.addEventListener('click', () => { close(r.nameWithOwner); });
         results.appendChild(row);
@@ -3388,9 +3388,13 @@ function openSpotlight(): void {
   const results = document.getElementById('mid-spotlight-results') as HTMLDivElement;
   const footer = document.getElementById('mid-spotlight-footer') as HTMLDivElement | null;
   const tabs = dlg.querySelectorAll<HTMLButtonElement>('.mid-spotlight-tab');
+  const inputIcon = document.getElementById('mid-spotlight-input-icon') as HTMLSpanElement | null;
   // Reset tabs + footer + placeholder (history viewer / repo picker mutate these).
   tabs.forEach(t => { t.style.display = ''; });
   if (footer) footer.style.display = '';
+  if (inputIcon && !inputIcon.firstChild) {
+    inputIcon.innerHTML = iconHTML('search', 'mid-icon--sm mid-icon--muted');
+  }
   input.placeholder = 'Type to search…';
 
   let scope: 'workspace' | 'file' = 'workspace';
@@ -3525,10 +3529,15 @@ function openSpotlight(): void {
       row.type = 'button';
       row.className = 'mid-spotlight-row' + (idx === activeIndex ? ' is-active' : '');
       const iconKey = item.kind === 'heading' ? 'list-ul' : item.kind === 'line' ? 'search' : 'file';
+      const descHTML = item.meta
+        ? `<span class="mid-spotlight-row-desc">${escapeHTML(item.meta)}</span>`
+        : '';
       row.innerHTML =
         `${iconHTML(iconKey, 'mid-icon--sm mid-icon--muted')}` +
-        `<span class="mid-spotlight-row-name">${spotlightHighlightedName(item.name, item.matchStart, item.matchEnd)}</span>` +
-        `<span class="mid-spotlight-row-path">${escapeHTML(item.meta)}</span>`;
+        `<span class="mid-spotlight-row-body">` +
+          `<span class="mid-spotlight-row-name">${spotlightHighlightedName(item.name, item.matchStart, item.matchEnd)}</span>` +
+          descHTML +
+        `</span>`;
       row.addEventListener('click', () => item.activate());
       row.addEventListener('mouseenter', () => {
         activeIndex = idx;


### PR DESCRIPTION
## Summary

Pure CSS/HTML polish on the spotlight modal to match the reference design (`apps/components/search/SearchSpotlight.*`). The JS logic from PR #280 already handled grouped sections, recents, fuzzy match, and scope tabs — this PR fixes the visual layer:

- **Input row** — leading `iconHTML('search', 'mid-icon--sm mid-icon--muted')` rendered inside a flex `.mid-spotlight-input-row` next to the `<input>`.
- **Scope tabs** — moved below the input and re-styled as a segmented inline pill group: rounded-full surface container, the active tab fills with `--mid-bg` and a subtle shadow.
- **Result rows** — flex layout with a stacked `.mid-spotlight-row-body`: `.mid-spotlight-row-name` (title, regular weight) on top, new `.mid-spotlight-row-desc` (muted, smaller font) below for the path or `L<n>` snippet. Old `.mid-spotlight-row-path` rule kept for any external callers but no longer emitted by `openSpotlight()`.
- **Repo picker** — updated the two row builders in `openRepoPicker()` to use the same body wrapper so the layout stays consistent when the spotlight is repurposed.

`openSpotlight()` populates the `#mid-spotlight-input-icon` lazily on first open and resets the icon HTML only when empty (avoids double-render in repurposed modes).

## Acceptance criteria

- [x] Search icon appears inside the input row.
- [x] Scope tabs render as inline pills.
- [x] Result rows are two-line: name on top, description below.
- [x] Existing keyboard nav + fuzzy match highlighting preserved.
- [x] Recents list still works.

## Test plan

- [ ] `npm run compile:electron` — passes (verified locally, esbuild + tsc both clean).
- [ ] Open spotlight via Cmd/Ctrl+K — search icon visible inside the field.
- [ ] Click between Workspace / Current file pills — active state fills, tabs stay inline.
- [ ] Type a query in workspace scope — name on top, relative path muted below; fuzzy highlight visible.
- [ ] Switch to Current file scope, search — heading + line groups render two-line (name + `L<n>`).
- [ ] Clear input — Recent files group still renders correctly.
- [ ] Trigger repo picker (gh repo flow) — rows still render with body wrapper.
- [ ] ↑/↓/Tab/Enter/Esc keyboard nav unchanged.

Closes #282