### PR TITLE
feat(desktop): drag-drop file onto pinned folder to assign (v2)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -45,7 +45,16 @@ body.has-sidebar .mid-shell {
 }
 .mid-activity-btn--pinned { color: inherit; }
 .mid-activity-btn.is-dragging { opacity: 0.4; }
+/* Pin reorder drop target — solid accent fill (matches v1). */
 .mid-activity-btn.is-drop-target { background: var(--mid-accent); color: var(--mid-accent-fg); }
+/* v2 (#189): file-assignment drop target — dashed ring + tinted bg so users
+   can tell "drop file here" apart from "reorder pin". */
+.mid-activity-btn.is-file-drop-target {
+  background: color-mix(in srgb, var(--mid-accent) 18%, transparent);
+  color: var(--mid-fg);
+  outline: 2px dashed var(--mid-accent);
+  outline-offset: -3px;
+}
 .mid-activity-btn {
   width: 36px;
   height: 36px;
@@ -171,6 +180,19 @@ body.has-sidebar .mid-shell {
 .mid-tree-item .mid-tree-icon { flex-shrink: 0; width: 18px; height: 18px; }
 .mid-tree-item.is-active .mid-tree-icon { color: var(--mid-accent-fg) !important; }
 .mid-tree-children { padding-left: var(--mid-space-3); }
+/* v2 (#189): cluster sidebar — assigned files render in a dedicated section
+   above the folder subtree so users can tell pinned files apart from the
+   directory listing. */
+.mid-tree-section + .mid-tree-section { margin-top: var(--mid-space-3); }
+.mid-tree-section-header {
+  padding: var(--mid-space-1) var(--mid-space-2);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--mid-fg-muted);
+}
+.mid-tree-item--cluster .mid-tree-chevron { visibility: hidden; }
 .mid-tree-empty {
   padding: var(--mid-space-4);
   text-align: center;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -3045,45 +3045,77 @@ function invalidateTreeCache(folderPath?: string): void {
   else treeCache.clear();
 }
 
+function renderClusterFileRow(pin: PinnedFolder, filePath: string): HTMLElement {
+  const item = document.createElement('div');
+  item.className = 'mid-tree-item mid-tree-item--cluster';
+  if (currentPath === filePath) item.classList.add('is-active');
+  // Match the chevron-padded layout of regular tree rows so file names align.
+  item.insertAdjacentHTML('beforeend', '<span class="mid-tree-chevron"></span>');
+  const fileMatch = iconForFile(filePath.split('/').pop() ?? '', 'file');
+  const iconSpan = document.createElement('span');
+  iconSpan.innerHTML = iconHTML(fileMatch.icon, 'mid-icon--muted mid-tree-icon');
+  const svg = iconSpan.firstElementChild as HTMLElement | null;
+  if (svg && fileMatch.color) svg.style.color = fileMatch.color;
+  item.appendChild(iconSpan.firstElementChild!);
+  item.appendChild(document.createTextNode(` ${filePath.split('/').pop() ?? filePath}`));
+  item.title = filePath;
+  item.addEventListener('click', () => void selectTreeFile(filePath));
+  item.addEventListener('contextmenu', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    openContextMenu([
+      { icon: 'show', label: 'Open', action: () => void selectTreeFile(filePath) },
+      { icon: 'folder-open', label: 'Reveal in Finder', action: () => void window.mid.openExternal(`file://${filePath.replace(/\/[^/]+$/, '')}`) },
+      { separator: true, label: '' },
+      { icon: 'trash', label: 'Remove from pin', action: () => {
+        pin.files = (pin.files ?? []).filter(f => f !== filePath);
+        void window.mid.patchAppState({ pinnedFolders });
+        if (activeActivity === `pinned:${pin.path}`) void loadPinnedTree(pin.path);
+      } },
+    ], e.clientX, e.clientY);
+  });
+  return item;
+}
+
 async function loadPinnedTree(folderPath: string): Promise<void> {
   try {
     const pin = pinnedFolders.find(p => p.path === folderPath);
     const name = pin?.name ?? folderPath.split('/').pop() ?? folderPath;
     sidebarFolderName.textContent = name;
     sidebarFolderName.title = folderPath;
+    treeRoot.replaceChildren();
+
+    // v2 (#189): hybrid display — assigned cluster files render in their own
+    // section above the folder tree. Files can live anywhere on disk; the
+    // folder tree below keeps the directory listing intact.
     if (pin && pin.files && pin.files.length > 0) {
-      // Cluster mode — render a flat list of registered files.
-      treeRoot.replaceChildren();
+      const section = document.createElement('div');
+      section.className = 'mid-tree-section mid-tree-section--cluster';
+      const header = document.createElement('div');
+      header.className = 'mid-tree-section-header';
+      header.textContent = `Pinned files (${pin.files.length})`;
+      section.appendChild(header);
       for (const filePath of pin.files) {
-        const item = document.createElement('div');
-        item.className = 'mid-tree-item';
-        if (currentPath === filePath) item.classList.add('is-active');
-        const fileMatch = iconForFile(filePath.split('/').pop() ?? '', 'file');
-        const span = document.createElement('span');
-        span.innerHTML = iconHTML(fileMatch.icon, 'mid-icon--muted mid-tree-icon');
-        const svg = span.firstElementChild as HTMLElement | null;
-        if (svg && fileMatch.color) svg.style.color = fileMatch.color;
-        item.appendChild(span.firstElementChild!);
-        item.appendChild(document.createTextNode(` ${filePath.split('/').pop() ?? filePath}`));
-        item.addEventListener('click', () => void selectTreeFile(filePath));
-        item.addEventListener('contextmenu', e => {
-          e.preventDefault();
-          openContextMenu([
-            { icon: 'show', label: 'Open', action: () => void selectTreeFile(filePath) },
-            { icon: 'trash', label: 'Remove from cluster', action: () => {
-              pin.files = (pin.files ?? []).filter(f => f !== filePath);
-              void window.mid.patchAppState({ pinnedFolders });
-              void loadPinnedTree(folderPath);
-            } },
-          ], e.clientX, e.clientY);
-        });
-        treeRoot.appendChild(item);
+        section.appendChild(renderClusterFileRow(pin, filePath));
       }
-      return;
+      treeRoot.appendChild(section);
     }
+
+    // Folder subtree below — same listing as before so users can browse and
+    // drag additional files into the cluster from this view too.
     const tree = await loadFolderTree(folderPath);
-    treeRoot.replaceChildren(...renderTree(tree));
-    if (tree.length === 0) {
+    if (tree.length > 0) {
+      const folderSection = document.createElement('div');
+      folderSection.className = 'mid-tree-section mid-tree-section--folder';
+      if (pin && pin.files && pin.files.length > 0) {
+        const header = document.createElement('div');
+        header.className = 'mid-tree-section-header';
+        header.textContent = 'Folder contents';
+        folderSection.appendChild(header);
+      }
+      folderSection.append(...renderTree(tree));
+      treeRoot.appendChild(folderSection);
+    } else if (!pin || !pin.files || pin.files.length === 0) {
       const empty = document.createElement('div');
       empty.className = 'mid-tree-empty';
       empty.textContent = 'No markdown files in this folder.';
@@ -3124,19 +3156,40 @@ function renderActivityPinned(): void {
       e.dataTransfer?.setData('text/plain', String(idx));
       btn.classList.add('is-dragging');
     });
-    btn.addEventListener('dragend', () => btn.classList.remove('is-dragging'));
-    btn.addEventListener('dragover', e => { e.preventDefault(); btn.classList.add('is-drop-target'); });
-    btn.addEventListener('dragleave', () => btn.classList.remove('is-drop-target'));
+    btn.addEventListener('dragend', () => btn.classList.remove('is-dragging', 'is-drop-target', 'is-file-drop-target'));
+    // v2 (#189): differentiate file-assignment drop vs pin-reorder drop visually.
+    // dataTransfer.getData() returns "" during dragover for security; dataTransfer.types
+    // is the spec-blessed way to peek at what the drag carries.
+    const dragOver = (e: DragEvent): void => {
+      const dt = e.dataTransfer;
+      if (!dt) return;
+      const types = Array.from(dt.types ?? []);
+      const isFile = types.includes('application/x-mid-file');
+      const isPin = types.includes('application/x-mid-pin');
+      if (!isFile && !isPin) return;
+      e.preventDefault();
+      btn.classList.toggle('is-file-drop-target', isFile);
+      btn.classList.toggle('is-drop-target', !isFile && isPin);
+      if (dt.dropEffect !== undefined) dt.dropEffect = isFile ? 'link' : 'move';
+    };
+    btn.addEventListener('dragenter', dragOver);
+    btn.addEventListener('dragover', dragOver);
+    btn.addEventListener('dragleave', () => btn.classList.remove('is-drop-target', 'is-file-drop-target'));
     btn.addEventListener('drop', e => {
       e.preventDefault();
-      btn.classList.remove('is-drop-target');
+      btn.classList.remove('is-drop-target', 'is-file-drop-target');
       const dt = e.dataTransfer;
       if (!dt) return;
       // File drop → register in cluster
       const filePath = dt.getData('application/x-mid-file');
       if (filePath) {
         const target = pinnedFolders[idx];
+        const before = (target.files ?? []).length;
         target.files = Array.from(new Set([...(target.files ?? []), filePath]));
+        if (target.files.length === before) {
+          flashStatus(`${filePath.split('/').pop()} already in "${target.name}"`);
+          return;
+        }
         void window.mid.patchAppState({ pinnedFolders });
         flashStatus(`Added ${filePath.split('/').pop()} to "${target.name}"`);
         if (activeActivity === `pinned:${target.path}`) void loadPinnedTree(target.path);

--- a/docs/desktop-pinned-folders-v2.md
+++ b/docs/desktop-pinned-folders-v2.md
@@ -1,0 +1,109 @@
+# Pinned folders v2 — file clusters via drag-drop
+
+Issue: [#189](https://github.com/fadymondy/mark-it-down/issues/189) — follow-up to [#187](https://github.com/fadymondy/mark-it-down/issues/187) (which introduced pinned folders as activity-bar clusters) and PR #227 (the v1 drag groundwork).
+
+## What v2 adds
+
+v1 (#227) wired up the plumbing — `PinnedFolder.files: string[]`, the
+`application/x-mid-file` mime carried by file-tree drags, and a drop handler on
+each pinned activity icon. But the user-visible behavior was incomplete:
+
+1. The drop highlight was identical for "drop file here" and "reorder pin", so
+   users couldn't tell which gesture they were making.
+2. When a pin had assigned files, the sidebar showed *only* those files and
+   hid the folder subtree — there was no way to see both at once or drag
+   another file in from the same folder while in cluster view.
+3. The right-click menu on a clustered file said "Remove from cluster" instead
+   of the spec-mandated "Remove from pin".
+
+v2 closes those gaps. No schema migration: the `files_json` column on
+`pinned_folders` (added in v1) already stores the array. Persistence still
+flows through `mid:patch-app-state` → `replacePinnedFolders` in
+[`apps/electron/db.ts`](../apps/electron/db.ts).
+
+## How it works
+
+### Drag a file from the tree onto a pinned activity icon
+
+1. The file-tree row is the drag source. Each file `<div class="mid-tree-item">`
+   sets `dataTransfer.setData('application/x-mid-file', entry.path)` in its
+   `dragstart` handler ([`renderer.ts` `renderTreeEntry`](../apps/electron/renderer/renderer.ts)).
+2. The pinned activity-bar buttons are drop targets. On `dragenter`/`dragover`
+   the handler peeks at `dataTransfer.types` (because `getData()` returns `""`
+   during drag-over for security reasons) and toggles one of two CSS classes:
+   - `.is-file-drop-target` — dashed accent ring + 18% accent tint, set when
+     the drag carries `application/x-mid-file`.
+   - `.is-drop-target` — solid accent fill (the v1 behavior), set when the
+     drag carries `application/x-mid-pin` (pin reorder).
+   The handler also flips `dataTransfer.dropEffect` to `'link'` for files and
+   `'move'` for reorder so the system cursor matches the gesture.
+3. On `drop`, if `application/x-mid-file` is present we append the path to
+   `pin.files` (deduped via `Set`), persist with
+   `window.mid.patchAppState({ pinnedFolders })`, flash a toast, and
+   re-render the cluster sidebar if it's currently open. If the file was
+   already in the cluster the toast says so and the array is left alone.
+4. If only `application/x-mid-pin` is present we fall through to the v1
+   reorder path.
+
+### Hybrid sidebar display
+
+`loadPinnedTree(folderPath)` now renders **two sections** when a pin has
+assigned files:
+
+```
+┌─ Pinned files (3) ────────┐
+│  notes.md                 │  ← cluster section, files can live anywhere
+│  /elsewhere/scratch.md    │
+│  draft.md                 │
+├─ Folder contents ─────────┤
+│  ▶ src/                   │  ← regular folder subtree, unchanged from v1
+│    foo.md                 │
+│    bar.md                 │
+└───────────────────────────┘
+```
+
+If `pin.files` is empty the section header disappears and the sidebar reverts
+to the v1 folder-only listing. If both the cluster and the folder subtree are
+empty we still show the "No markdown files in this folder." empty state from
+v1.
+
+Cluster file rows reuse the standard `.mid-tree-item` look with one extra
+class (`.mid-tree-item--cluster`) that hides the leading chevron so file names
+align with chevron-padded folder rows below.
+
+### Right-click on a cluster file row
+
+Three actions, in order:
+
+- **Open** — same as a click.
+- **Reveal in Finder** — opens the parent directory.
+- **Remove from pin** — strips the file path from `pin.files`, persists, and
+  re-renders. The pin itself is untouched.
+
+## Where the code lives
+
+| Concern | File | Notes |
+| --- | --- | --- |
+| Drag source on file rows | `apps/electron/renderer/renderer.ts` `renderTreeEntry` | `application/x-mid-file` (unchanged from v1) |
+| Drop target on activity-bar pins | `apps/electron/renderer/renderer.ts` `renderActivityPinned` | `dragenter`/`dragover`/`dragleave`/`drop` |
+| Cluster sidebar render | `apps/electron/renderer/renderer.ts` `loadPinnedTree` + `renderClusterFileRow` |  |
+| Drop-target visuals | `apps/electron/renderer/renderer.css` `.mid-activity-btn.is-drop-target` / `.is-file-drop-target` |  |
+| Cluster section visuals | `apps/electron/renderer/renderer.css` `.mid-tree-section` / `.mid-tree-section-header` / `.mid-tree-item--cluster` |  |
+| Persistence | `apps/electron/db.ts` `replacePinnedFolders` (writes `files_json`); `apps/electron/main.ts` `writeAppState` / `readAppState` | unchanged from v1 |
+
+## Manual smoke test
+
+1. Open a workspace folder with a few `.md` files.
+2. Right-click a folder in the tree and pick **Pin to sidebar…**, accept
+   defaults. The pin appears in the activity bar.
+3. Drag a `.md` file from the file tree over the new pin icon. The icon
+   should show a **dashed accent ring** (file-drop), not the solid fill.
+4. Drop. A toast confirms the assignment.
+5. Click the pin in the activity bar. The sidebar should show a
+   **Pinned files (1)** section above a **Folder contents** section.
+6. Drag a different pin's icon over another pin. The hovered pin should show
+   the **solid accent fill** (reorder), not the dashed ring.
+7. Right-click a clustered file row → **Remove from pin**. Section count
+   updates. If it was the last file, the section disappears.
+8. Quit the app, reopen, click the pin — the assigned files are still there
+   (persisted in `mid.sqlite` `pinned_folders.files_json`).


### PR DESCRIPTION
## Summary

Follow-up to PR #227 (v1 of [#187](https://github.com/fadymondy/mark-it-down/issues/187)). v1 wired up the schema (`files_json` on `pinned_folders`), the file-tree drag source, and the activity-bar drop handler — but the UX had two gaps:

- Drop highlight didn't tell "assign file" apart from "reorder pin" (both used `is-drop-target`).
- Cluster mode replaced the folder tree entirely; users couldn't see assigned files alongside the directory listing.

v2 closes both, plus the spec rename ("Remove from cluster" → "Remove from pin").

## What changed

- `apps/electron/renderer/renderer.ts` — `renderActivityPinned` now inspects `dataTransfer.types` on `dragenter`/`dragover` and toggles `is-file-drop-target` (dashed accent ring) vs `is-drop-target` (solid fill) accordingly. `loadPinnedTree` was refactored into a hybrid renderer with a `Pinned files (n)` section above `Folder contents`. New helper `renderClusterFileRow` builds the cluster row and exposes Open / Reveal / **Remove from pin**.
- `apps/electron/renderer/renderer.css` — new `.is-file-drop-target` style and `.mid-tree-section` / `.mid-tree-section-header` / `.mid-tree-item--cluster` for the new layout.
- `docs/desktop-pinned-folders-v2.md` — feature doc with code map + manual smoke test.

No changes to `apps/electron/main.ts`, the spotlight dialog, settings, importer, outline rail, or warehouse onboarding. Persistence path (`mid:patch-app-state` → `replacePinnedFolders`) is reused as-is — the `files` array was already plumbed in v1.

## Acceptance criteria

- [x] Dragging a file from the tree onto a pinned-folder activity-bar icon assigns it to the pin's `files` array.
- [x] Visual highlight differentiates "file drop target" (dashed ring) from "ordering reorder" drop targets (solid fill).
- [x] Assignment persists across restart (SQLite via `mid:patch-app-state` + `pinnedFolders.files_json`).
- [x] Re-pin / remove-from-pin path works (right-click on a pinned-folder file row → **Remove from pin**).
- [x] Docs at `docs/desktop-pinned-folders-v2.md`.

## Test plan

- [x] `npm run compile:electron` passes (tsc + esbuild + asset copy).
- [ ] Manual smoke per `docs/desktop-pinned-folders-v2.md` § "Manual smoke test".

Closes #189