### PR TITLE
fix(desktop): MCP auto-start + onboarding visibility + workspace-switch loader (#288, #289, #291)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -779,14 +779,23 @@ function startMCP(): void {
   const script = resolveMCPServerScript();
   if (!script) {
     setMCPStatus('error', 'MCP server script not found');
+    console.error('[mid] MCP start failed: script not found');
     return;
   }
   const notesDir = resolveMCPNotesDir();
   let stderrTail = '';
+  console.log('[mid] starting MCP server', { script, notesDir });
   try {
+    // In packaged Electron, fork() re-launches the Electron binary (process.execPath
+    // is Electron, not Node). ELECTRON_RUN_AS_NODE=1 makes the child boot as plain
+    // Node so the MCP server actually runs instead of spawning a second app.
     mcpProcess = fork(script, ['--notes-dir', notesDir], {
       stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
-      env: { ...process.env, MID_TRAY_MANAGED: '1' },
+      env: {
+        ...process.env,
+        MID_TRAY_MANAGED: '1',
+        ELECTRON_RUN_AS_NODE: '1',
+      },
     });
     setMCPStatus('running');
     mcpProcess.stderr?.on('data', chunk => {

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -200,6 +200,29 @@ body.has-sidebar .mid-shell {
   font-size: var(--mid-font-size-sm);
 }
 
+/* Workspace-switch / folder-open indexing loader (#291) — delay-shown, disappears
+   automatically when the tree fetch resolves. */
+.mid-tree-indexing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--mid-space-3);
+  padding: var(--mid-space-6) var(--mid-space-4);
+  color: var(--mid-fg-muted);
+  font-size: var(--mid-font-size-sm);
+}
+.mid-tree-indexing-spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--mid-border);
+  border-top-color: var(--mid-fg);
+  border-radius: 50%;
+  animation: mid-spin 0.8s linear infinite;
+}
+.mid-tree-indexing-label { color: var(--mid-fg-muted); }
+@keyframes mid-spin { to { transform: rotate(360deg); } }
+
 /* Sidebar mode toggle removed — activity bar drives sidebar content (#187) */
 
 /* Notes list */

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -502,6 +502,11 @@ function welcomeHeroHTML(recent: string[]): string {
           <span class="mid-welcome-action-label">Try the sample</span>
           <span class="mid-welcome-action-kbd"></span>
         </button>
+        <button class="mid-welcome-action" data-welcome-action="connect-warehouse" ${currentFolder ? '' : 'disabled'}>
+          ${iconHTML('github')}
+          <span class="mid-welcome-action-label">Connect GitHub warehouse</span>
+          <span class="mid-welcome-action-kbd"></span>
+        </button>
       </div>
       ${recentHTML}
     </div>`;
@@ -541,6 +546,7 @@ function attachWelcomeHandlers(container: HTMLElement): void {
       else if (action === 'open-file') void openFile();
       else if (action === 'new-note') void promptCreateNote();
       else if (action === 'sample') void openSample();
+      else if (action === 'connect-warehouse') void openWarehouseOnboarding(true);
     });
   });
   container.querySelectorAll<HTMLButtonElement>('[data-recent-path]').forEach(btn => {
@@ -1866,6 +1872,9 @@ async function selectTreeFile(filePath: string): Promise<void> {
 async function openFolder(): Promise<void> {
   const result = await window.mid.openFolderDialog();
   if (!result) return;
+  // The dialog returns the tree pre-fetched, so no extra loader needed here.
+  // Cache it so a subsequent switchWorkspace to the same folder is instant.
+  treeCache.set(result.folderPath, result.tree);
   applyFolder(result.folderPath, result.tree);
 }
 
@@ -2113,16 +2122,29 @@ function isGhMissing(output: string): boolean {
 }
 
 async function shouldAutoShowOnboarding(): Promise<boolean> {
-  if (!currentFolder) return false;
+  if (!currentFolder) {
+    console.debug('[mid] onboarding skip: no current folder');
+    return false;
+  }
   const wsId = workspaceIdForCurrent();
-  if (!wsId) return false;
+  if (!wsId) {
+    console.debug('[mid] onboarding skip: no workspace id');
+    return false;
+  }
   try {
     const existing = await window.mid.warehousesList(currentFolder);
-    if (existing.length > 0) return false;
-  } catch { /* surface as 'no warehouse' */ }
+    if (existing.length > 0) {
+      console.debug('[mid] onboarding skip: warehouse already configured', existing);
+      return false;
+    }
+  } catch (err) { console.debug('[mid] warehousesList error (treating as none):', err); }
   const state = await window.mid.readAppState();
   const dismissed = Array.isArray(state.warehouseOnboardingDismissed) ? state.warehouseOnboardingDismissed : [];
-  if (dismissed.includes(wsId)) return false;
+  if (dismissed.includes(wsId)) {
+    console.debug('[mid] onboarding skip: workspace previously dismissed', wsId);
+    return false;
+  }
+  console.debug('[mid] onboarding will show for workspace', wsId);
   return true;
 }
 
@@ -3035,9 +3057,32 @@ function selectActivity(target: ActivityTarget): void {
 
 async function loadFolderTree(folderPath: string): Promise<TreeEntry[]> {
   if (treeCache.has(folderPath)) return treeCache.get(folderPath)!;
-  const tree = await window.mid.listFolderMd(folderPath);
-  treeCache.set(folderPath, tree);
-  return tree;
+  // Delayed-show loader: only flash the spinner if indexing takes >150ms,
+  // so cached / instant returns don't visually blip.
+  const showAt = window.setTimeout(() => showTreeIndexing(folderPath), 150);
+  try {
+    const tree = await window.mid.listFolderMd(folderPath);
+    treeCache.set(folderPath, tree);
+    return tree;
+  } finally {
+    window.clearTimeout(showAt);
+    hideTreeIndexing();
+  }
+}
+
+function showTreeIndexing(folderPath: string): void {
+  if (!treeRoot) return;
+  const name = folderPath.split('/').pop() ?? folderPath;
+  treeRoot.replaceChildren();
+  const overlay = document.createElement('div');
+  overlay.className = 'mid-tree-indexing';
+  overlay.id = 'mid-tree-indexing';
+  overlay.innerHTML = `<div class="mid-tree-indexing-spinner"></div><div class="mid-tree-indexing-label">Indexing ${escapeHTML(name)}…</div>`;
+  treeRoot.appendChild(overlay);
+}
+
+function hideTreeIndexing(): void {
+  document.getElementById('mid-tree-indexing')?.remove();
 }
 
 function invalidateTreeCache(folderPath?: string): void {


### PR DESCRIPTION
## Summary
Three fixes the user reported on v0.2.1.

**#289 — MCP server didn't auto-start** in packaged builds.
Root cause: \`fork()\` in packaged Electron uses \`process.execPath\` which is the Electron binary, NOT Node. Without \`ELECTRON_RUN_AS_NODE=1\` in the fork env, the child re-launches the desktop app instead of running the MCP server. Added the env var + startup log so a failure mode surfaces something useful.

**#288 — Warehouse onboarding wasn't appearing.**
Added \`console.debug\` breadcrumbs at every short-circuit in \`shouldAutoShowOnboarding()\` (no folder / no workspace id / warehouse already configured / dismissed) so we can see exactly why it skips in DevTools. Also added a *Connect GitHub warehouse* CTA on the welcome screen — \`force=true\` bypasses the dismissed-list so users can always re-trigger.

**#291 — No loader during workspace-switch indexing.**
Added a delay-shown (150ms) tree-indexing spinner inside the sidebar pane. Disappears when \`listFolderMd\` resolves. Cached folder loads stay instant (no flash). \`openFolderDialog\` also caches the pre-fetched tree.

Closes #288
Closes #289
Closes #291

## Test plan
- [ ] Packaged build → tray label flips to "● MCP server: running" within 2s; no error dialog.
- [ ] Open DevTools → console shows `[mid] starting MCP server` with the resolved script path.
- [ ] Open the welcome screen → "Connect GitHub warehouse" button visible (enabled when a folder is open). Click → onboarding modal appears.
- [ ] Open a large folder → spinner + "Indexing <name>…" appears for >150ms loads.
- [ ] Open a previously-cached folder → no spinner flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)