### PR TITLE
chore(release): v0.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mark-it-down",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mark-it-down",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mark-it-down",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "l10n": "./l10n",
   "publisher": "fadymondy",
   "engines": {


### PR DESCRIPTION
## Summary
Ship since v0.2.2:
- **#288/#289/#291** — MCP auto-start fix (\`ELECTRON_RUN_AS_NODE=1\`), onboarding visibility (welcome CTA), workspace-switch indexing loader.
- **#189** — drag-drop file → activity-bar pinned folder v2.
- **#282** — spotlight visual polish.
- **#255** — typed notes MVP (registry + filter strip + secret key/value view).

\`package.json\` 0.2.2 → 0.2.3.

## After merge
\`\`\`bash
git checkout main && git pull && git tag v0.2.3 && git push origin v0.2.3
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)