### PR TITLE
feat(desktop): VSCode-style tab manager — multi-file open + reorder + close + persist (MVP of #287)

### DIFF
--- a/apps/electron/db.ts
+++ b/apps/electron/db.ts
@@ -117,9 +117,51 @@ function applySchema(d: Database.Database): void {
       file_path TEXT NOT NULL,
       exported_at INTEGER NOT NULL
     );
+    CREATE TABLE IF NOT EXISTS open_tabs (
+      strip_id INTEGER NOT NULL,
+      idx INTEGER NOT NULL,
+      path TEXT NOT NULL,
+      active INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (strip_id, idx)
+    );
     CREATE INDEX IF NOT EXISTS idx_recent_files_opened ON recent_files(opened_at DESC);
     CREATE INDEX IF NOT EXISTS idx_export_history_exported ON export_history(exported_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_open_tabs_strip ON open_tabs(strip_id, idx);
   `);
+}
+
+/* ── open tabs (#287) ───────────────────────────────────── */
+
+export interface OpenTabRow {
+  strip_id: number;
+  idx: number;
+  path: string;
+  active: number;
+}
+
+/**
+ * Returns persisted tabs ordered by (strip_id, idx) so the renderer can rebuild
+ * the strip layout deterministically across restarts.
+ */
+export function listOpenTabs(): OpenTabRow[] {
+  return getDB()
+    .prepare('SELECT strip_id, idx, path, active FROM open_tabs ORDER BY strip_id ASC, idx ASC')
+    .all() as OpenTabRow[];
+}
+
+/**
+ * Atomically replace the entire persisted tab set. The renderer is the source
+ * of truth for layout — we wipe and rewrite rather than diff because the table
+ * is small (typically <30 rows) and the transaction keeps the swap consistent.
+ */
+export function replaceOpenTabs(rows: OpenTabRow[]): void {
+  const d = getDB();
+  const tx = d.transaction((all: OpenTabRow[]) => {
+    d.prepare('DELETE FROM open_tabs').run();
+    const stmt = d.prepare('INSERT INTO open_tabs(strip_id, idx, path, active) VALUES(?, ?, ?, ?)');
+    for (const r of all) stmt.run(r.strip_id, r.idx, r.path, r.active ? 1 : 0);
+  });
+  tx(rows);
 }
 
 /* ── settings (JSON-blob valued) ────────────────────────── */

--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -19,6 +19,9 @@ import {
   replaceWorkspaces,
   recordExport,
   listExportHistory,
+  listOpenTabs,
+  replaceOpenTabs,
+  type OpenTabRow,
 } from './db';
 import { DEFAULT_TYPE_ID, getNoteType } from './notes/note-types';
 
@@ -630,6 +633,22 @@ ipcMain.handle('mid:record-export', async (_e, row: { id: string; sourcePath?: s
 ipcMain.handle('mid:list-export-history', async (_e, limit?: number) => {
   try { return listExportHistory(typeof limit === 'number' ? limit : 50); }
   catch { return []; }
+});
+
+/**
+ * Open-tabs persistence (#287). The renderer owns the in-memory model and
+ * snapshots the whole set on every meaningful mutation; we wipe-and-replace
+ * because the row count is small and the transaction keeps it atomic.
+ */
+ipcMain.handle('mid:tabs-list', async () => {
+  try { return listOpenTabs(); }
+  catch { return []; }
+});
+
+ipcMain.handle('mid:tabs-replace', async (_e, rows: OpenTabRow[]) => {
+  if (!Array.isArray(rows)) return false;
+  try { replaceOpenTabs(rows); return true; }
+  catch (err) { console.warn('[mid] tabs-replace failed:', (err as Error).message); return false; }
 });
 
 ipcMain.handle('mid:save-as', async (_e, defaultName: string, content: string | ArrayBuffer, filters: Electron.FileFilter[]) => {

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -67,6 +67,11 @@ contextBridge.exposeInMainWorld('mid', {
     ipcRenderer.invoke('mid:patch-app-state', patch),
   recordExport: (row: { id: string; sourcePath?: string; format: string; filePath: string }): Promise<void> =>
     ipcRenderer.invoke('mid:record-export', row),
+  // Tab persistence (#287) — renderer owns layout, main is a dumb store.
+  tabsList: (): Promise<{ strip_id: number; idx: number; path: string; active: number }[]> =>
+    ipcRenderer.invoke('mid:tabs-list'),
+  tabsReplace: (rows: { strip_id: number; idx: number; path: string; active: number }[]): Promise<boolean> =>
+    ipcRenderer.invoke('mid:tabs-replace', rows),
   listExportHistory: (limit?: number): Promise<{ id: string; source_path: string; format: string; file_path: string; exported_at: number }[]> =>
     ipcRenderer.invoke('mid:list-export-history', limit),
   notesList: (workspace: string): Promise<NoteEntry[]> =>

--- a/apps/electron/renderer/index.html
+++ b/apps/electron/renderer/index.html
@@ -115,7 +115,10 @@
     <div class="mid-sidebar-tree" id="tree-root"></div>
     <div class="mid-notes-list" id="notes-list" hidden></div>
   </aside>
-  <main id="root" class="viewing"></main>
+  <div class="mid-editor-area" id="editor-area">
+    <div class="mid-tabstrip" id="tabstrip" role="tablist" aria-label="Open files" hidden></div>
+    <main id="root" class="viewing"></main>
+  </div>
   <aside class="mid-outline" id="outline-rail" aria-label="Document outline" hidden>
     <header class="mid-outline-header">
       <span class="mid-outline-title">Outline</span>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -2875,3 +2875,110 @@ body.settings-open .mid-statusbar { visibility: hidden; }
   background: var(--mid-surface);
 }
 .mid-onboarding-footer .mid-onboarding-spacer { flex: 1; }
+
+/* Tab manager (#287) — VSCode-style strip above the editor.
+ *
+ * The tabstrip lives inside `.mid-editor-area` (flex column) so it claims its
+ * natural height while `main#root` consumes the rest. We hide the strip when
+ * empty (no tabs) so the welcome state stays calm. */
+.mid-editor-area {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+.mid-editor-area > main { flex: 1 1 auto; min-height: 0; }
+
+.mid-tabstrip {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 0;
+  flex: 0 0 auto;
+  height: 32px;
+  background: var(--mid-surface);
+  border-bottom: 1px solid var(--mid-border);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  user-select: none;
+}
+.mid-tabstrip[hidden] { display: none; }
+
+.mid-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mid-space-2);
+  padding: 0 var(--mid-space-2) 0 var(--mid-space-3);
+  height: 100%;
+  max-width: 200px;
+  min-width: 80px;
+  border: 0;
+  border-right: 1px solid var(--mid-border);
+  background: transparent;
+  color: var(--mid-fg-muted);
+  font-size: var(--mid-font-size-sm);
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  position: relative;
+  flex: 0 0 auto;
+}
+.mid-tab:hover { background: var(--mid-surface-hover); color: var(--mid-fg); }
+.mid-tab.is-active {
+  background: var(--mid-bg);
+  color: var(--mid-fg);
+  /* Top accent bar — mirrors VSCode's active-tab affordance. */
+  box-shadow: inset 0 2px 0 0 var(--mid-accent, var(--mid-link));
+}
+.mid-tab.is-active::after {
+  /* Pulled-down divider that visually merges the active tab with the body
+   * underneath, masking the strip's bottom border. */
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 1px;
+  background: var(--mid-bg);
+}
+.mid-tab.is-dragging { opacity: 0.5; }
+.mid-tab.is-drop-before { box-shadow: inset 2px 0 0 0 var(--mid-link); }
+.mid-tab.is-drop-after { box-shadow: inset -2px 0 0 0 var(--mid-link); }
+
+.mid-tab__icon {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  color: inherit;
+}
+.mid-tab__label {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mid-tab__label.is-dirty::after {
+  content: ' •';
+  color: var(--mid-link);
+}
+.mid-tab__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  border: 0;
+  background: transparent;
+  color: var(--mid-fg-muted);
+  cursor: pointer;
+  flex: 0 0 auto;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0;
+  opacity: 0.7;
+}
+.mid-tab__close:hover { background: var(--mid-surface-hover); color: var(--mid-fg); opacity: 1; }
+.mid-tab.is-active .mid-tab__close { opacity: 1; }

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -142,6 +142,9 @@ interface Mid {
   onMenuOpenFolder(cb: () => void): () => void;
   onMenuSave(cb: () => void): () => void;
   onMenuExport(cb: (format: 'md' | 'html' | 'pdf' | 'png' | 'txt' | 'docx' | 'docx-gdocs') => void): () => void;
+  // Tab persistence (#287)
+  tabsList(): Promise<{ strip_id: number; idx: number; path: string; active: number }[]>;
+  tabsReplace(rows: { strip_id: number; idx: number; path: string; active: number }[]): Promise<boolean>;
 }
 declare const window: Window & { mid: Mid };
 
@@ -184,6 +187,7 @@ const statusOutline = document.getElementById('status-outline') as HTMLButtonEle
 const outlineRail = document.getElementById('outline-rail') as HTMLElement;
 const outlineList = document.getElementById('outline-list') as HTMLElement;
 const outlineCloseBtn = document.getElementById('outline-close') as HTMLButtonElement;
+const tabstripEl = document.getElementById('tabstrip') as HTMLDivElement;
 
 let currentText = '';
 let currentPath: string | null = null;
@@ -211,6 +215,398 @@ const outlineLinkByHeadingId = new Map<string, HTMLElement>();
 const settings = { ...DEFAULT_SETTINGS };
 const expandedDirs = new Set<string>();
 const treeCache = new Map<string, TreeEntry[]>();
+
+// ─── Tab manager (#287) ────────────────────────────────────────────────────────
+// VSCode-style multi-file editor strip. Each tab carries its own text/path/dirty/
+// scroll state; the active tab's text + path are mirrored into the legacy
+// `currentText`/`currentPath` globals so the rest of the renderer (markdown
+// rendering, save, export, spotlight, etc.) keeps working without a sweep.
+//
+// Strip 0 is the only strip in the MVP. The model carries `stripId` so a future
+// split-screen patch can introduce strip 1 without changing the wire format
+// (the SQLite `open_tabs` table is already (strip_id, idx) keyed).
+//
+// Persistence: every state mutation calls `scheduleTabsPersist`, which debounces
+// a snapshot write into the `open_tabs` table via the IPC bridge.
+interface FileTab {
+  stripId: number;
+  path: string;
+  text: string;
+  dirty: boolean;
+  /** Last known scrollTop of the editor textarea (or preview, in view mode).
+   * Restored on tab focus so reading position survives swaps. */
+  scrollTop: number;
+}
+
+const tabs: FileTab[] = [];
+let activeTabIndex = -1;
+/** LIFO of recently-closed tab paths for Cmd+Shift+T. Capped at 20 entries. */
+const recentlyClosedPaths: string[] = [];
+let tabsPersistTimer: number | null = null;
+/** True while the renderer is rehydrating tabs at startup — suppresses persist
+ * thrash and lets us assemble the strip from disk without a flicker. */
+let tabsHydrating = false;
+
+function findTabIndex(filePath: string): number {
+  return tabs.findIndex(t => t.path === filePath);
+}
+
+function activeTab(): FileTab | null {
+  return activeTabIndex >= 0 && activeTabIndex < tabs.length ? tabs[activeTabIndex] : null;
+}
+
+/** Sync the editor area's mirror state from the active tab into the legacy
+ * `currentText` / `currentPath` globals + filename label. */
+function syncMirrorFromActiveTab(): void {
+  const t = activeTab();
+  if (t) {
+    currentText = t.text;
+    currentPath = t.path;
+    filenameEl.textContent = t.path.split('/').pop() ?? 'Untitled';
+  } else {
+    currentText = '';
+    currentPath = null;
+    filenameEl.textContent = 'Untitled';
+  }
+}
+
+/** Push the current legacy `currentText` back onto the active tab. Call this
+ * before swapping tabs so unsaved edits survive the swap. */
+function syncActiveTabFromMirror(): void {
+  const t = activeTab();
+  if (!t) return;
+  if (t.text !== currentText) {
+    t.text = currentText;
+    if (!t.dirty) {
+      t.dirty = true;
+      renderTabstrip();
+    }
+  }
+}
+
+/** Open a new tab or focus an existing one for `filePath`.
+ * Returns the active tab. */
+function openTab(filePath: string, content: string): FileTab {
+  // Save scroll + edits on the outgoing tab before we swap.
+  syncActiveTabFromMirror();
+  captureScrollPosition();
+
+  const existing = findTabIndex(filePath);
+  if (existing !== -1) {
+    activeTabIndex = existing;
+    const t = tabs[existing];
+    // Only refresh content from disk on a focus if the user hasn't dirtied it.
+    if (!t.dirty) t.text = content;
+    return t;
+  }
+  const tab: FileTab = { stripId: 0, path: filePath, text: content, dirty: false, scrollTop: 0 };
+  tabs.push(tab);
+  activeTabIndex = tabs.length - 1;
+  return tab;
+}
+
+/** Close the tab at `idx`. Adjusts `activeTabIndex` and pushes the path onto
+ * the recently-closed stack so Cmd+Shift+T can resurrect it. */
+function closeTabAt(idx: number): void {
+  if (idx < 0 || idx >= tabs.length) return;
+  const closed = tabs[idx];
+  recentlyClosedPaths.push(closed.path);
+  if (recentlyClosedPaths.length > 20) recentlyClosedPaths.shift();
+  tabs.splice(idx, 1);
+  if (tabs.length === 0) {
+    activeTabIndex = -1;
+    syncMirrorFromActiveTab();
+    if (currentMode === 'view') renderView();
+    else if (currentMode === 'edit') renderEdit();
+    else renderSplit();
+    renderTabstrip();
+    schedulePersistTabs();
+    return;
+  }
+  // Keep the same visual position when the active tab closes; clamp at end.
+  if (idx < activeTabIndex) {
+    activeTabIndex--;
+  } else if (idx === activeTabIndex) {
+    if (activeTabIndex >= tabs.length) activeTabIndex = tabs.length - 1;
+  }
+  syncMirrorFromActiveTab();
+  // Re-render the editor area against the new active tab.
+  if (currentMode === 'view') renderView();
+  else if (currentMode === 'edit') renderEdit();
+  else renderSplit();
+  highlightActiveTreeItem();
+  updateWordCount();
+  updateSaveIndicator(true);
+  restoreScrollPosition();
+  renderTabstrip();
+  schedulePersistTabs();
+}
+
+/** Cycle to next/previous tab. `delta` is +1 or -1. Wraps around. */
+function cycleTab(delta: number): void {
+  if (tabs.length === 0) return;
+  syncActiveTabFromMirror();
+  captureScrollPosition();
+  const next = ((activeTabIndex + delta) % tabs.length + tabs.length) % tabs.length;
+  focusTabAt(next);
+}
+
+function focusTabAt(idx: number): void {
+  if (idx < 0 || idx >= tabs.length) return;
+  if (idx === activeTabIndex) return;
+  syncActiveTabFromMirror();
+  captureScrollPosition();
+  activeTabIndex = idx;
+  syncMirrorFromActiveTab();
+  if (currentMode === 'view') renderView();
+  else if (currentMode === 'edit') renderEdit();
+  else renderSplit();
+  highlightActiveTreeItem();
+  updateWordCount();
+  updateSaveIndicator(!activeTab()?.dirty);
+  restoreScrollPosition();
+  renderTabstrip();
+  schedulePersistTabs();
+}
+
+/** Reopen the most-recently-closed tab. */
+async function reopenLastClosedTab(): Promise<void> {
+  while (recentlyClosedPaths.length > 0) {
+    const p = recentlyClosedPaths.pop()!;
+    if (findTabIndex(p) !== -1) continue; // already open — try next
+    try {
+      const content = await window.mid.readFile(p);
+      loadFileContent(p, content);
+      return;
+    } catch {
+      // file gone — fall through to try the next entry
+      continue;
+    }
+  }
+  flashStatus('Nothing to reopen');
+}
+
+/** Capture the editor or preview scroll position into the active tab. */
+function captureScrollPosition(): void {
+  const t = activeTab();
+  if (!t) return;
+  const scroller =
+    root.querySelector<HTMLElement>('textarea') ??
+    root.querySelector<HTMLElement>('.mid-preview') ??
+    root;
+  if (scroller) t.scrollTop = scroller.scrollTop || 0;
+}
+
+/** Restore the active tab's scroll position into whichever scroller is live. */
+function restoreScrollPosition(): void {
+  const t = activeTab();
+  if (!t) return;
+  // Defer one frame so the freshly-rendered DOM has its layout. Without this
+  // the assignment lands before the scroller has measurable height.
+  requestAnimationFrame(() => {
+    const scroller =
+      root.querySelector<HTMLElement>('textarea') ??
+      root.querySelector<HTMLElement>('.mid-preview') ??
+      root;
+    if (scroller) scroller.scrollTop = t.scrollTop;
+  });
+}
+
+/** Move the tab at `from` to position `to` (insert-before semantics). */
+function moveTab(from: number, to: number): void {
+  if (from === to || from < 0 || from >= tabs.length) return;
+  const [moved] = tabs.splice(from, 1);
+  // After removing `from`, the target index shifts left by one if `to` was
+  // after `from`; clamp into bounds.
+  const insertAt = Math.max(0, Math.min(tabs.length, to > from ? to - 1 : to));
+  tabs.splice(insertAt, 0, moved);
+  // Track the active tab through the move so focus survives a drag.
+  if (from === activeTabIndex) {
+    activeTabIndex = insertAt;
+  } else if (from < activeTabIndex && insertAt >= activeTabIndex) {
+    activeTabIndex--;
+  } else if (from > activeTabIndex && insertAt <= activeTabIndex) {
+    activeTabIndex++;
+  }
+  renderTabstrip();
+  schedulePersistTabs();
+}
+
+function renderTabstrip(): void {
+  if (!tabstripEl) return;
+  if (tabs.length === 0) {
+    tabstripEl.hidden = true;
+    tabstripEl.replaceChildren();
+    return;
+  }
+  tabstripEl.hidden = false;
+  const frag = document.createDocumentFragment();
+  tabs.forEach((tab, idx) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'mid-tab' + (idx === activeTabIndex ? ' is-active' : '');
+    btn.dataset.tabIndex = String(idx);
+    btn.dataset.tabPath = tab.path;
+    btn.draggable = true;
+    btn.setAttribute('role', 'tab');
+    btn.setAttribute('aria-selected', String(idx === activeTabIndex));
+    btn.title = tab.path;
+
+    const fileMatch = iconForFile(tab.path.split('/').pop() ?? '', 'file');
+    const iconWrap = document.createElement('span');
+    iconWrap.className = 'mid-tab__icon';
+    iconWrap.innerHTML = iconHTML(fileMatch.icon, 'mid-icon--sm');
+    if (fileMatch.color) {
+      const svg = iconWrap.firstElementChild as HTMLElement | null;
+      if (svg) svg.style.color = fileMatch.color;
+    }
+
+    const label = document.createElement('span');
+    label.className = 'mid-tab__label' + (tab.dirty ? ' is-dirty' : '');
+    label.textContent = tab.path.split('/').pop() ?? tab.path;
+
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'mid-tab__close';
+    closeBtn.title = 'Close (Cmd/Ctrl+W)';
+    closeBtn.setAttribute('aria-label', `Close ${tab.path.split('/').pop() ?? tab.path}`);
+    closeBtn.textContent = '×';
+    closeBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      closeTabAt(idx);
+    });
+
+    btn.addEventListener('click', () => focusTabAt(idx));
+    // Middle-click closes the tab — VSCode parity.
+    btn.addEventListener('mousedown', e => {
+      if (e.button === 1) {
+        e.preventDefault();
+        closeTabAt(idx);
+      }
+    });
+    btn.addEventListener('contextmenu', e => {
+      e.preventDefault();
+      openContextMenu([
+        { icon: 'x', label: 'Close', action: () => closeTabAt(idx) },
+        { icon: 'x', label: 'Close others', action: () => closeOtherTabs(idx) },
+        { icon: 'x', label: 'Close all', action: () => closeAllTabs() },
+        { separator: true, label: '' },
+        { icon: 'folder-open', label: 'Reveal in Finder', action: () => void window.mid.openExternal(`file://${tab.path.replace(/\/[^/]+$/, '')}`) },
+      ], e.clientX, e.clientY);
+    });
+
+    // Drag-to-reorder within the strip. We use HTML5 DnD; the dragover handler
+    // computes whether the cursor sits in the left or right half of the target
+    // tab to draw the appropriate insertion-line indicator.
+    btn.addEventListener('dragstart', ev => {
+      ev.dataTransfer?.setData('application/x-mid-tab', String(idx));
+      ev.dataTransfer!.effectAllowed = 'move';
+      btn.classList.add('is-dragging');
+    });
+    btn.addEventListener('dragend', () => {
+      btn.classList.remove('is-dragging');
+      tabstripEl.querySelectorAll('.mid-tab').forEach(el => {
+        el.classList.remove('is-drop-before', 'is-drop-after');
+      });
+    });
+    btn.addEventListener('dragover', ev => {
+      if (!ev.dataTransfer?.types.includes('application/x-mid-tab')) return;
+      ev.preventDefault();
+      ev.dataTransfer.dropEffect = 'move';
+      const rect = btn.getBoundingClientRect();
+      const before = ev.clientX < rect.left + rect.width / 2;
+      tabstripEl.querySelectorAll('.mid-tab').forEach(el => {
+        el.classList.remove('is-drop-before', 'is-drop-after');
+      });
+      btn.classList.add(before ? 'is-drop-before' : 'is-drop-after');
+    });
+    btn.addEventListener('dragleave', () => {
+      btn.classList.remove('is-drop-before', 'is-drop-after');
+    });
+    btn.addEventListener('drop', ev => {
+      const raw = ev.dataTransfer?.getData('application/x-mid-tab');
+      if (raw == null || raw === '') return;
+      ev.preventDefault();
+      const from = parseInt(raw, 10);
+      if (Number.isNaN(from)) return;
+      const rect = btn.getBoundingClientRect();
+      const before = ev.clientX < rect.left + rect.width / 2;
+      const to = before ? idx : idx + 1;
+      moveTab(from, to);
+    });
+
+    btn.append(iconWrap, label, closeBtn);
+    frag.appendChild(btn);
+  });
+  tabstripEl.replaceChildren(frag);
+  // Scroll the active tab into view (e.g. after Cmd+Alt+Right cycles past the
+  // visible window).
+  const activeEl = tabstripEl.querySelector<HTMLElement>('.mid-tab.is-active');
+  activeEl?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+}
+
+function closeOtherTabs(keepIdx: number): void {
+  if (keepIdx < 0 || keepIdx >= tabs.length) return;
+  const keepPath = tabs[keepIdx].path;
+  for (let i = tabs.length - 1; i >= 0; i--) {
+    if (tabs[i].path !== keepPath) closeTabAt(i);
+  }
+}
+
+function closeAllTabs(): void {
+  for (let i = tabs.length - 1; i >= 0; i--) closeTabAt(i);
+}
+
+function schedulePersistTabs(): void {
+  if (tabsHydrating) return;
+  if (tabsPersistTimer !== null) window.clearTimeout(tabsPersistTimer);
+  tabsPersistTimer = window.setTimeout(() => {
+    tabsPersistTimer = null;
+    const rows = tabs.map((t, i) => ({
+      strip_id: t.stripId,
+      idx: i,
+      path: t.path,
+      active: i === activeTabIndex ? 1 : 0,
+    }));
+    void window.mid.tabsReplace(rows).catch(() => undefined);
+  }, 200);
+}
+
+/** Restore tabs from SQLite at startup. Best-effort: a missing file is dropped
+ * silently so a restart doesn't crash the renderer. */
+async function hydrateTabs(): Promise<void> {
+  let rows: { strip_id: number; idx: number; path: string; active: number }[];
+  try { rows = await window.mid.tabsList(); }
+  catch { return; }
+  if (!rows || rows.length === 0) return;
+  tabsHydrating = true;
+  let pendingActive = -1;
+  for (const r of rows) {
+    try {
+      const content = await window.mid.readFile(r.path);
+      const tab: FileTab = { stripId: r.strip_id, path: r.path, text: content, dirty: false, scrollTop: 0 };
+      tabs.push(tab);
+      if (r.active) pendingActive = tabs.length - 1;
+    } catch {
+      // file gone — skip it; the next persist will drop it from the table.
+      continue;
+    }
+  }
+  tabsHydrating = false;
+  if (tabs.length === 0) return;
+  activeTabIndex = pendingActive >= 0 ? pendingActive : 0;
+  syncMirrorFromActiveTab();
+  highlightActiveTreeItem();
+  updateWordCount();
+  updateSaveIndicator(true);
+  renderTabstrip();
+  // Re-render the editor area against the active tab.
+  if (currentMode === 'view') renderView();
+  else if (currentMode === 'edit') renderEdit();
+  else renderSplit();
+  // Persist a clean snapshot (drops missing files from the table).
+  schedulePersistTabs();
+}
 
 function applyTheme(isDark: boolean): void {
   osIsDark = isDark;
@@ -1941,6 +2337,13 @@ function buildEditor(): HTMLTextAreaElement {
     currentText = ta.value;
     updateWordCount();
     updateSaveIndicator(false);
+    // #287 — mark the active tab dirty + flash the strip so the unsaved dot
+    // appears immediately as the user types.
+    const t = activeTab();
+    if (t && (t.text !== ta.value || !t.dirty)) {
+      t.text = ta.value;
+      if (!t.dirty) { t.dirty = true; renderTabstrip(); }
+    }
     maybeShowMermaidPopout(ta);
   });
   const onCursor = (): void => {
@@ -2019,13 +2422,20 @@ function loadFileContent(filePath: string, content: string): void {
   // the markdown editor would never come back after the user clicked away
   // from a secret note via the file tree.
   typedViewActive = false;
-  currentText = content;
-  currentPath = filePath;
-  filenameEl.textContent = filePath.split('/').pop() ?? 'Untitled';
+  // #287 — route the open through the tab manager. `openTab` either focuses an
+  // existing tab (preserving its dirty edits) or appends a new one and makes
+  // it active. We then mirror the active-tab state into the legacy globals so
+  // the rest of the renderer keeps reading/writing through `currentText` and
+  // `currentPath` unchanged.
+  openTab(filePath, content);
+  syncMirrorFromActiveTab();
   highlightActiveTreeItem();
   setMode(currentMode);
   updateWordCount();
-  updateSaveIndicator(true);
+  updateSaveIndicator(!activeTab()?.dirty);
+  restoreScrollPosition();
+  renderTabstrip();
+  schedulePersistTabs();
   pushRecent(filePath);
 }
 
@@ -2878,6 +3288,10 @@ async function saveFile(): Promise<void> {
     await window.mid.writeFile(currentPath, currentText);
     flashStatus(`Saved ${currentPath.split('/').pop()}`);
     updateSaveIndicator(true);
+    // #287 — clear the active tab's dirty bit + refresh the strip so the dot
+    // disappears immediately on save.
+    const t = activeTab();
+    if (t) { t.text = currentText; t.dirty = false; renderTabstrip(); }
     return;
   }
   const saved = await window.mid.saveFileDialog('untitled.md', currentText);
@@ -3946,6 +4360,47 @@ document.addEventListener('keydown', e => {
       e.preventDefault();
       setSidebarMode('notes');
       void promptCreateNote();
+    }
+  }
+});
+
+// Tab manager keyboard shortcuts (#287). We intentionally listen at document
+// level so the bindings fire from inside the textarea editor too. Cmd+Shift+T
+// pulls the most-recently-closed tab back; Cmd+W closes the active tab; the
+// Cmd+Alt+Arrow pair cycles, matching VSCode's "Next/Previous Editor in Group".
+document.addEventListener('keydown', e => {
+  const isMod = e.metaKey || e.ctrlKey;
+  if (!isMod) return;
+  // Cmd/Ctrl+W — close active tab. (Electron's accelerator system also closes
+  // the window with the same chord; the tab close runs first via this DOM
+  // listener and we preventDefault to swallow the menu accelerator.)
+  if (e.key.toLowerCase() === 'w' && !e.shiftKey && !e.altKey) {
+    if (tabs.length > 0) {
+      e.preventDefault();
+      e.stopPropagation();
+      closeTabAt(activeTabIndex);
+    }
+    return;
+  }
+  // Cmd/Ctrl+Shift+T — reopen the most-recently-closed tab.
+  if (e.key.toLowerCase() === 't' && e.shiftKey && !e.altKey) {
+    e.preventDefault();
+    void reopenLastClosedTab();
+    return;
+  }
+  // Cmd/Ctrl+Alt+ArrowRight / ArrowLeft — cycle tabs.
+  if (e.altKey && (e.key === 'ArrowRight' || e.key === 'ArrowLeft')) {
+    if (tabs.length > 1) {
+      e.preventDefault();
+      cycleTab(e.key === 'ArrowRight' ? 1 : -1);
+    }
+    return;
+  }
+  // Cmd/Ctrl+Tab style — also support Cmd+PageDown / PageUp for trackpad users.
+  if (e.key === 'PageDown' || e.key === 'PageUp') {
+    if (tabs.length > 1) {
+      e.preventDefault();
+      cycleTab(e.key === 'PageDown' ? 1 : -1);
     }
   }
 });
@@ -5111,6 +5566,9 @@ void window.mid.readAppState().then(async state => {
     }
   }
   setMode(currentMode);
+  // #287 — restore the open-tabs strip from SQLite. Done after the folder
+  // applies so the tree's active-row highlight has a chance to attach.
+  await hydrateTabs();
   // #303 — if the launched workspace has no warehouse, force-open the
   // onboarding modal regardless of the dismissed list. The dismissed list
   // only suppresses *during* a session (re-triggers from the welcome CTA,

--- a/docs/desktop-tabs.md
+++ b/docs/desktop-tabs.md
@@ -1,0 +1,170 @@
+# Desktop tabs
+
+VSCode-style multi-file tab manager for the Electron app (#287).
+
+## What ships in v0.2.5 (MVP)
+
+- Tab strip above the editor when at least one file is open
+- Click any file in the tree → opens in the active strip
+- Clicking a file that is already open focuses its existing tab (no duplicate)
+- Per-tab close button + middle-click + `Cmd/Ctrl+W`
+- `Cmd/Ctrl+Shift+T` reopens the most-recently-closed tab (LIFO depth 20)
+- `Cmd/Ctrl+Alt+ArrowLeft` / `ArrowRight` cycles tabs, with wrap-around
+- `Cmd/Ctrl+PageUp` / `PageDown` is the trackpad-friendly alias
+- Drag a tab inside the strip to reorder
+- Right-click a tab for **Close**, **Close others**, **Close all**, **Reveal in Finder**
+- The unsaved-changes bullet (`•`) appears next to the filename label
+- Tabs persist across restart via the SQLite `open_tabs` table — including which
+  tab was active
+
+## Out of scope (deferred follow-ups)
+
+- **Window detach** — drag a tab outside the window to spawn a new
+  `BrowserWindow`. The IPC contract is sketched below; the wiring needs
+  main-process work that wasn't worth bundling into the MVP.
+- **Split-screen** — drop a tab onto the right edge of the strip to create a
+  second column. The model already carries `stripId` so this is a renderer-only
+  change once the drop-target UI lands.
+
+Both follow-ups are filed as separate issues so the MVP ships green.
+
+## Layout model
+
+```
+┌──────────────────────────── Window ────────────────────────────┐
+│  Titlebar                                                      │
+├────────┬────────────┬─────────────────────────────────────────┤
+│        │            │  ┌─ Tab strip (.mid-tabstrip) ────────┐ │
+│ Activ. │  Sidebar   │  │ [README.md ×] [notes.md ×]         │ │
+│  bar   │            │  └────────────────────────────────────┘ │
+│        │            │  ┌─ Editor area (#root) ──────────────┐ │
+│        │            │  │   markdown view / edit / split     │ │
+│        │            │  │                                    │ │
+│        │            │  └────────────────────────────────────┘ │
+└────────┴────────────┴─────────────────────────────────────────┘
+```
+
+The tabstrip lives inside a new `.mid-editor-area` flex column wrapper that
+holds the strip on top and `<main id="root">` underneath. The strip is
+`hidden` whenever the tab array is empty so the welcome state stays calm.
+
+## In-memory model
+
+```ts
+interface FileTab {
+  stripId: number;        // 0 in the MVP. Future split: 0 left, 1 right.
+  path: string;           // absolute file path on disk
+  text: string;           // current buffer (may differ from disk if dirty)
+  dirty: boolean;         // unsaved changes since last load/save
+  scrollTop: number;      // last known scroller position; restored on focus
+}
+
+const tabs: FileTab[];
+let activeTabIndex: number;
+```
+
+Strip 0 is the only strip in the MVP. The single strip persists into rows of
+`open_tabs` keyed by `(strip_id, idx)`, so multi-strip is a renderer-only
+expansion that doesn't break the wire format.
+
+### Mirror state
+
+The renderer historically read `currentText` and `currentPath` as globals.
+Rather than sweep ~70 references across `renderer.ts`, the tab manager mirrors
+the active tab's `text`/`path` into those globals on every focus/close/swap:
+
+- `syncMirrorFromActiveTab()` — pulls active tab → globals
+- `syncActiveTabFromMirror()` — pushes globals → active tab (called before swaps
+  so unsaved edits survive a focus change)
+
+Existing render code (`renderView`, `renderEdit`, `renderSplit`,
+`saveFile`, exports, spotlight, etc.) keeps reading/writing `currentText` and
+`currentPath` unchanged.
+
+## Persistence (SQLite)
+
+```sql
+CREATE TABLE open_tabs (
+  strip_id INTEGER NOT NULL,   -- 0 in MVP; reserved for split (1, 2, …)
+  idx      INTEGER NOT NULL,   -- ordering inside the strip
+  path     TEXT    NOT NULL,
+  active   INTEGER NOT NULL DEFAULT 0,  -- 1 for the focused tab in its strip
+  PRIMARY KEY (strip_id, idx)
+);
+CREATE INDEX idx_open_tabs_strip ON open_tabs(strip_id, idx);
+```
+
+The renderer is the source of truth: every meaningful mutation
+(open/close/move/cycle) calls `schedulePersistTabs()`, which debounces a 200ms
+snapshot and writes the entire set via `mid:tabs-replace`. We wipe-and-replace
+because the row count is small (typically <30) and the transaction keeps the
+swap atomic.
+
+On startup the renderer calls `mid:tabs-list`, reads each file from disk, and
+silently drops any path that no longer exists. The next persist tick collapses
+the table back to the live set, so a deleted file naturally cleans itself up.
+
+## IPC contract
+
+| Channel              | Direction              | Payload / Result |
+|----------------------|------------------------|------------------|
+| `mid:tabs-list`      | renderer → main        | `() → OpenTabRow[]` |
+| `mid:tabs-replace`   | renderer → main        | `(rows: OpenTabRow[]) → boolean` |
+
+```ts
+interface OpenTabRow {
+  strip_id: number;
+  idx: number;
+  path: string;
+  active: number;       // 0 | 1
+}
+```
+
+The main process is intentionally dumb — it owns the SQLite write, nothing
+else. All ordering, dirty tracking, and active-tab arithmetic happens in the
+renderer.
+
+## Future: window detach (deferred)
+
+When a tab is dragged outside the window bounds, the renderer should:
+
+1. Detect the drag-end at a point outside `window.innerWidth/Height`
+2. `await window.mid.tabsDetach({ path, scrollTop })`
+3. Locally `closeTabAt(idx)` (without pushing onto the recently-closed stack)
+
+The proposed main-side handler:
+
+```ts
+ipcMain.handle('mid:tabs-detach', async (_e, payload: { path: string; scrollTop: number }) => {
+  const w = new BrowserWindow({
+    width: 720, height: 600,
+    webPreferences: { preload, contextIsolation: true, nodeIntegration: false, sandbox: true },
+  });
+  await w.loadFile(rendererIndexPath, { query: { detachedPath: payload.path } });
+  // The renderer in the new window inspects `window.location.search` on boot
+  // and opens that single file as its only tab.
+  return { ok: true, windowId: w.id };
+});
+```
+
+The detached window is a regular renderer instance with `tabs = [thatOne]`,
+so the existing strip + view/edit/split code "just works." A future enhancement
+re-attaches a tab if the user drags it back into the main window's strip — but
+that requires a cross-window drag protocol which Electron doesn't ship out of
+the box (we'd hand-roll it via `screen.getCursorScreenPoint()` polling on
+`dragend`).
+
+## Future: split-screen (deferred)
+
+When a tab is dropped onto the right edge of the existing strip, the renderer
+should:
+
+1. Allocate `stripId = 1`
+2. Move the dropped tab into strip 1 (re-index, mark active)
+3. Re-render `.mid-editor-area` as a horizontal `display: flex; row` of two
+   columns, each with its own strip + `#root`-equivalent
+
+The CSS already accommodates a column-flex container. The bigger lift is
+splitting the renderer code into a `TabStrip` class so two instances can
+coexist and the active-strip routing can drive `currentText`/`currentPath`
+correctly. The wire format (`(strip_id, idx, path, active)`) is unchanged.


### PR DESCRIPTION
Closes #287 (MVP cut). Window detach + split-screen are deferred as #308 and #309.

## Summary

Introduces a tab strip above the editor so the renderer can hold N markdown files at once instead of the previous single-file model.

- Tab strip (\`.mid-tabstrip\`) renders above \`#root\` whenever ≥1 file is open
- Click a tree row → opens in active strip; clicking an already-open file focuses its existing tab (no duplicate)
- Per-tab close button, middle-click close, \`Cmd/Ctrl+W\`
- \`Cmd/Ctrl+Shift+T\` reopens the most-recently-closed tab (LIFO depth 20)
- \`Cmd/Ctrl+Alt+ArrowLeft / ArrowRight\` cycles tabs with wrap-around
- \`Cmd/Ctrl+PageUp / PageDown\` is the trackpad alias
- Drag a tab inside the strip to reorder
- Right-click context menu: Close, Close others, Close all, Reveal in Finder
- Unsaved-changes bullet (\`•\`) next to the filename label
- SQLite \`open_tabs\` table persists the strip across restarts (including which tab was active)

## Architecture

- New \`FileTab\` model carries \`stripId\` so the deferred split-screen and window-detach follow-ups become renderer-only / IPC-additive patches; the wire format \`(strip_id, idx, path, active)\` is unchanged
- The active tab's \`text\` / \`path\` are mirrored into the legacy \`currentText\` / \`currentPath\` globals on every focus/close/swap, so existing render code (view/edit/split, save, exports, spotlight) keeps working without touching ~70 references
- Persistence is debounced (200ms) and atomic (wipe-and-replace inside a SQLite transaction)

## Files

- \`apps/electron/db.ts\` — \`open_tabs\` table + \`listOpenTabs\` / \`replaceOpenTabs\`
- \`apps/electron/main.ts\` — \`mid:tabs-list\` / \`mid:tabs-replace\` IPC handlers
- \`apps/electron/preload.ts\` — \`tabsList\` / \`tabsReplace\` bridge
- \`apps/electron/renderer/index.html\` — wraps \`#root\` in \`.mid-editor-area\` with the strip on top
- \`apps/electron/renderer/renderer.css\` — \`.mid-tabstrip\` + \`.mid-tab\` styles (active accent, dirty bullet, drag indicators)
- \`apps/electron/renderer/renderer.ts\` — tab manager module + keyboard shortcuts + hydration on launch
- \`docs/desktop-tabs.md\` — layout model, persisted state shape, IPC contract for the deferred follow-ups

## Out of scope (filed as follow-ups)

- #308 — Window detach (drag tab outside → new BrowserWindow). IPC contract sketched in docs/desktop-tabs.md.
- #309 — Split-screen (drop tab onto strip edge → second column). Foundation in place; needs \`TabStrip\` class extraction.

## Acceptance

- [x] Tab strip appears above the editor when ≥1 file open
- [x] Multi-file open works; clicking tree opens new tab
- [x] Same file across tabs focuses existing tab (not duplicate)
- [x] Drag tab → reorder
- [x] Per-tab close button + middle-click close + Cmd+W
- [x] Cmd+Shift+T reopens last closed
- [x] Tabs persist across restart via SQLite \`open_tabs\` table
- [x] Docs at \`docs/desktop-tabs.md\`
- [x] Out-of-scope (detach + split) filed as new follow-up issues with the IPC spec sketched (#308, #309)

## Test plan

- [ ] \`npm run compile:electron\` passes (verified locally)
- [ ] Open multiple .md files from the tree → strip shows them in order
- [ ] Reopen the app → previously-open tabs restore + active tab focuses
- [ ] Cmd+W closes the active tab; if none remain, welcome state returns
- [ ] Cmd+Shift+T resurrects the last closed tab
- [ ] Cmd+Alt+ArrowRight cycles forward; Cmd+Alt+ArrowLeft cycles back; both wrap
- [ ] Drag a tab left/right → drops into new position
- [ ] Edit a tab → unsaved bullet appears; save → bullet clears
- [ ] Switch tabs while editing → edits survive on the outgoing tab