### PR TITLE
feat(desktop): typed-notes follow-ups — task-list + meeting views, user-defined types, strip prefs (#295, #296, #297, #302)

### DIFF
--- a/apps/electron/db.ts
+++ b/apps/electron/db.ts
@@ -52,6 +52,22 @@ export interface ExportHistoryRow {
   exported_at: number;
 }
 
+/**
+ * #297 — User-defined note types persisted in SQLite. Built-in rows are seeded
+ * on first read with `builtin = 1` so the settings UI can lock them down. User
+ * types appear with `builtin = 0` and may be edited / deleted.
+ */
+export interface NoteTypeRow {
+  id: string;
+  label: string;
+  icon: string;
+  color: string;
+  view_kind: string;
+  description: string | null;
+  builtin: number;
+  sort: number;
+}
+
 export function openDB(userDataDir: string): Database.Database {
   if (db) return db;
   dbPath = path.join(userDataDir, 'mid.sqlite');
@@ -124,6 +140,16 @@ function applySchema(d: Database.Database): void {
       active INTEGER NOT NULL DEFAULT 0,
       PRIMARY KEY (strip_id, idx)
     );
+    CREATE TABLE IF NOT EXISTS note_types (
+      id TEXT PRIMARY KEY,
+      label TEXT NOT NULL,
+      icon TEXT NOT NULL,
+      color TEXT NOT NULL,
+      view_kind TEXT NOT NULL,
+      description TEXT,
+      builtin INTEGER NOT NULL DEFAULT 0,
+      sort INTEGER NOT NULL DEFAULT 0
+    );
     CREATE INDEX IF NOT EXISTS idx_recent_files_opened ON recent_files(opened_at DESC);
     CREATE INDEX IF NOT EXISTS idx_export_history_exported ON export_history(exported_at DESC);
     CREATE INDEX IF NOT EXISTS idx_open_tabs_strip ON open_tabs(strip_id, idx);
@@ -162,6 +188,62 @@ export function replaceOpenTabs(rows: OpenTabRow[]): void {
     for (const r of all) stmt.run(r.strip_id, r.idx, r.path, r.active ? 1 : 0);
   });
   tx(rows);
+}
+
+/* ── note types (#297) ─────────────────────────────────── */
+
+/**
+ * Return every registered note type ordered by `sort` (ascending). Caller is
+ * expected to seed built-ins separately — `listNoteTypeRows()` is purely a
+ * persistence read; we don't merge the in-memory built-in registry here so the
+ * SQL surface stays predictable for tests.
+ */
+export function listNoteTypeRows(): NoteTypeRow[] {
+  return getDB()
+    .prepare('SELECT id, label, icon, color, view_kind, description, builtin, sort FROM note_types ORDER BY sort ASC, label ASC')
+    .all() as NoteTypeRow[];
+}
+
+/** Upsert a note type by id. `sort` is preserved if the row already exists. */
+export function upsertNoteTypeRow(row: NoteTypeRow): void {
+  getDB()
+    .prepare(`
+      INSERT INTO note_types(id, label, icon, color, view_kind, description, builtin, sort)
+      VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        label = excluded.label,
+        icon = excluded.icon,
+        color = excluded.color,
+        view_kind = excluded.view_kind,
+        description = excluded.description,
+        builtin = excluded.builtin,
+        sort = excluded.sort
+    `)
+    .run(row.id, row.label, row.icon, row.color, row.view_kind, row.description ?? null, row.builtin, row.sort);
+}
+
+/** Delete a user-defined note type. Built-in rows are protected — callers
+ * should refuse the request before reaching this helper, but we double-check
+ * here so a stray IPC can't blow away the seed. */
+export function deleteNoteTypeRow(id: string): boolean {
+  const row = getDB().prepare('SELECT builtin FROM note_types WHERE id = ?').get(id) as { builtin: number } | undefined;
+  if (!row) return false;
+  if (row.builtin === 1) return false;
+  getDB().prepare('DELETE FROM note_types WHERE id = ?').run(id);
+  return true;
+}
+
+/**
+ * Replace the `sort` column for the given ids in order (idx → sort). Used by
+ * the filter-strip drag-to-reorder control (#302). Unknown ids are skipped.
+ */
+export function reorderNoteTypeRows(orderedIds: string[]): void {
+  const d = getDB();
+  const tx = d.transaction((ids: string[]) => {
+    const stmt = d.prepare('UPDATE note_types SET sort = ? WHERE id = ?');
+    ids.forEach((id, idx) => { stmt.run(idx, id); });
+  });
+  tx(orderedIds);
 }
 
 /* ── settings (JSON-blob valued) ────────────────────────── */

--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -22,8 +22,12 @@ import {
   listOpenTabs,
   replaceOpenTabs,
   type OpenTabRow,
+  listNoteTypeRows,
+  upsertNoteTypeRow,
+  deleteNoteTypeRow,
+  reorderNoteTypeRows,
 } from './db';
-import { DEFAULT_TYPE_ID, getNoteType } from './notes/note-types';
+import { DEFAULT_TYPE_ID, getNoteType, BUILT_IN_TYPES, isBuiltinTypeId, setRegistry, type NoteType } from './notes/note-types';
 
 const execFileP = promisify(execFile);
 
@@ -126,6 +130,9 @@ app.whenReady().then(async () => {
     const result = await migrateLegacyState(app.getPath('userData'));
     if (result.error) console.warn('[mid] state.json migration warning:', result.error);
     else if (result.migrated) console.log('[mid] migrated legacy state.json into SQLite');
+    // #297 — seed the note-types table and prime the in-memory registry so
+    // `notes-create` calls before the renderer's first IPC see user types too.
+    try { refreshNoteTypeRegistry(); } catch (err) { console.warn('[mid] note-types seed failed:', err); }
   } catch (err) {
     console.error('[mid] failed to open SQLite:', err);
   }
@@ -273,9 +280,24 @@ ipcMain.handle('mid:notes-create', async (_e, workspace: string, title: string, 
   // `secrets:` frontmatter block so the renderer's secret editor has a stable
   // place to read/write to from the very first save.
   const resolved = getNoteType(type);
-  const seed = resolved.viewKind === 'secret'
-    ? `---\nsecrets: {}\n---\n\n# ${title || 'Untitled'}\n\n`
-    : `# ${title || 'Untitled'}\n\n`;
+  // Per-viewKind seed scaffolding so the typed editor has somewhere to read /
+  // write the moment the file opens. New view kinds plug in here.
+  let seed: string;
+  switch (resolved.viewKind) {
+    case 'secret':
+      seed = `---\nsecrets: {}\n---\n\n# ${title || 'Untitled'}\n\n`;
+      break;
+    case 'meeting':
+      // #296 — frontmatter holds structured meta; body holds free-form notes.
+      seed = `---\ndate: ${new Date().toISOString().slice(0, 10)}\nattendees: []\nlocation: ''\ndecisions: []\n---\n\n# ${title || 'Untitled'}\n\n## Agenda\n\n## Notes\n\n`;
+      break;
+    case 'task-list':
+      // #295 — empty list; the editor's "Add row" appends `- [ ] ...` lines.
+      seed = `# ${title || 'Untitled'}\n\n`;
+      break;
+    default:
+      seed = `# ${title || 'Untitled'}\n\n`;
+  }
   await fs.writeFile(fullPath, seed, 'utf8');
   const entry: NoteEntry = { id, title: title || 'Untitled', path: relPath, tags: [], created: now, updated: now, type: resolved.id };
   notes.push(entry);
@@ -345,6 +367,115 @@ ipcMain.handle('mid:notes-set-type', async (_e, workspace: string, id: string, t
   note.updated = new Date().toISOString();
   await writeNotes(workspace, notes);
   return note;
+});
+
+/* ── note types registry (#297) ─────────────────────────── */
+
+/**
+ * Seed the SQLite `note_types` table with the built-in registry on first read.
+ * Idempotent — re-runs only insert rows that don't already exist (so user-edits
+ * to a built-in stay intact across restarts; the only fields we never
+ * overwrite are the user-touched ones because `INSERT OR IGNORE` is a no-op
+ * when the id collides). Built-in `sort` is recomputed each time so the
+ * shipped order survives a fresh install but a user reorder via #302 is
+ * preserved (we set `sort = idx` only on first insertion).
+ */
+function seedBuiltInNoteTypes(): void {
+  const existing = new Set(listNoteTypeRows().map(r => r.id));
+  let nextSort = listNoteTypeRows().reduce((max, r) => Math.max(max, r.sort), -1) + 1;
+  for (let i = 0; i < BUILT_IN_TYPES.length; i++) {
+    const t = BUILT_IN_TYPES[i];
+    if (existing.has(t.id)) continue;
+    upsertNoteTypeRow({
+      id: t.id,
+      label: t.label,
+      icon: t.icon,
+      color: t.color,
+      view_kind: t.viewKind ?? 'markdown',
+      description: t.description ?? null,
+      builtin: 1,
+      // Built-ins keep their declaration order on a fresh install. If user
+      // types were added before re-seeding (unlikely; we seed at startup),
+      // append after the user rows so we don't clobber their sort.
+      sort: nextSort++,
+    });
+  }
+}
+
+/**
+ * Compose the runtime registry from SQLite and push it into the in-memory
+ * registry both main and renderer rely on. Renderer pulls via IPC and calls
+ * `setRegistry()` on its side too — main keeps a copy so `notes-create` and
+ * `notes-set-type` see user-defined types without an extra round-trip.
+ */
+function refreshNoteTypeRegistry(): NoteType[] {
+  seedBuiltInNoteTypes();
+  const rows = listNoteTypeRows();
+  const composed: NoteType[] = rows.map(r => ({
+    id: r.id,
+    label: r.label,
+    icon: r.icon,
+    color: r.color,
+    viewKind: r.view_kind,
+    description: r.description ?? undefined,
+    builtin: r.builtin === 1,
+  }));
+  setRegistry(composed);
+  return composed;
+}
+
+ipcMain.handle('mid:note-types-list', async (): Promise<NoteType[]> => refreshNoteTypeRegistry());
+
+ipcMain.handle('mid:note-types-upsert', async (_e, type: NoteType): Promise<{ ok: boolean; types: NoteType[]; error?: string }> => {
+  // Validate id: slug-safe, non-empty, no collision with built-in unless the
+  // caller is editing the built-in row itself (allowed for label/color tweaks).
+  const id = String(type.id || '').trim().toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+  if (!id) return { ok: false, types: refreshNoteTypeRegistry(), error: 'Type id is required.' };
+  if (id === DEFAULT_TYPE_ID && !isBuiltinTypeId(type.id ?? '')) {
+    return { ok: false, types: refreshNoteTypeRegistry(), error: `"${id}" is reserved.` };
+  }
+  const existing = listNoteTypeRows().find(r => r.id === id);
+  // Refuse to mutate a built-in's id / view_kind from this handler — built-ins
+  // own their dispatch contract. Label / icon / color / description are fair
+  // game so users can re-style them.
+  if (existing?.builtin === 1) {
+    upsertNoteTypeRow({
+      id: existing.id,
+      label: type.label || existing.label,
+      icon: type.icon || existing.icon,
+      color: type.color || existing.color,
+      view_kind: existing.view_kind, // immutable for built-ins
+      description: type.description ?? existing.description,
+      builtin: 1,
+      sort: existing.sort,
+    });
+    return { ok: true, types: refreshNoteTypeRegistry() };
+  }
+  const sort = existing?.sort ?? (listNoteTypeRows().reduce((max, r) => Math.max(max, r.sort), -1) + 1);
+  upsertNoteTypeRow({
+    id,
+    label: type.label || id,
+    icon: type.icon || 'bookmark',
+    color: type.color || '#6e7681',
+    view_kind: type.viewKind || 'markdown',
+    description: type.description ?? null,
+    builtin: 0,
+    sort,
+  });
+  return { ok: true, types: refreshNoteTypeRegistry() };
+});
+
+ipcMain.handle('mid:note-types-delete', async (_e, id: string): Promise<{ ok: boolean; types: NoteType[]; error?: string }> => {
+  if (isBuiltinTypeId(id)) {
+    return { ok: false, types: refreshNoteTypeRegistry(), error: 'Built-in types cannot be deleted.' };
+  }
+  const ok = deleteNoteTypeRow(id);
+  return { ok, types: refreshNoteTypeRegistry(), error: ok ? undefined : 'Type not found.' };
+});
+
+ipcMain.handle('mid:note-types-reorder', async (_e, orderedIds: string[]): Promise<NoteType[]> => {
+  reorderNoteTypeRows(orderedIds);
+  return refreshNoteTypeRegistry();
 });
 
 ipcMain.handle('mid:warehouses-list', async (_e, workspace: string): Promise<Warehouse[]> => {

--- a/apps/electron/notes/note-types.ts
+++ b/apps/electron/notes/note-types.ts
@@ -13,6 +13,11 @@
  * is matched in the renderer's `renderTypedView()` switch (see
  * `renderer.ts → openNote`). When you add a new viewKind, register the matching
  * renderer branch in the same PR so the type doesn't fall back silently.
+ *
+ * #297 — User-defined custom types now persist into a `note_types` SQLite table
+ * via main-process IPC (`mid:note-types-list`). The renderer hydrates the
+ * registry at startup; until that resolves the built-ins serve as a safe
+ * default so first-paint doesn't depend on the IPC round-trip.
  */
 
 export interface NoteType {
@@ -25,15 +30,20 @@ export interface NoteType {
   /** Tint colour for the type chip (CSS hex). */
   color: string;
   /** Optional custom view id; default is `'markdown'`. */
-  viewKind?: 'markdown' | 'secret' | string;
+  viewKind?: 'markdown' | 'secret' | 'task-list' | 'meeting' | string;
   /** Short descriptor shown in the type chooser modal. */
   description?: string;
+  /** True when the type is shipped with the app (#297). User types are false. */
+  builtin?: boolean;
 }
 
 /**
  * Built-in types. Order is stable — the filter strip and type-chooser modal
  * render in this order. `'note'` MUST stay first; it's the default for legacy
  * notes that were created before #255 landed.
+ *
+ * #295 / #296 — `task-list` and `meeting` now point at dedicated viewKinds
+ * with custom editors (checklist + structured meeting form respectively).
  */
 export const BUILT_IN_TYPES: readonly NoteType[] = [
   {
@@ -42,6 +52,7 @@ export const BUILT_IN_TYPES: readonly NoteType[] = [
     icon: 'bookmark',
     color: '#6e7681',
     description: 'Plain markdown — the default.',
+    builtin: true,
   },
   {
     id: 'secret',
@@ -50,20 +61,25 @@ export const BUILT_IN_TYPES: readonly NoteType[] = [
     color: '#bf8700',
     viewKind: 'secret',
     description: 'Key/value secrets editor with reveal + copy.',
+    builtin: true,
   },
   {
     id: 'task-list',
     label: 'Task list',
     icon: 'check-square',
     color: '#1a7f37',
-    description: 'Checklist of todos (uses markdown for now).',
+    viewKind: 'task-list',
+    description: 'Checklist of todos persisted as `- [ ]` markdown.',
+    builtin: true,
   },
   {
     id: 'meeting',
     label: 'Meeting',
     icon: 'calendar',
     color: '#0969da',
-    description: 'Date + attendees frontmatter (uses markdown for now).',
+    viewKind: 'meeting',
+    description: 'Structured meeting form with attendees + decisions.',
+    builtin: true,
   },
   {
     id: 'reference',
@@ -71,6 +87,7 @@ export const BUILT_IN_TYPES: readonly NoteType[] = [
     icon: 'book',
     color: '#8250df',
     description: 'Long-lived reference doc.',
+    builtin: true,
   },
   {
     id: 'snippet',
@@ -78,13 +95,45 @@ export const BUILT_IN_TYPES: readonly NoteType[] = [
     icon: 'code',
     color: '#cf222e',
     description: 'Code or shell snippet.',
+    builtin: true,
   },
 ] as const;
 
 /** Default type id assigned when a note doesn't specify one. */
 export const DEFAULT_TYPE_ID = 'note';
 
-const BY_ID = new Map<string, NoteType>(BUILT_IN_TYPES.map(t => [t.id, t]));
+/**
+ * Mutable runtime registry. Starts as the built-ins and is overwritten by
+ * `setRegistry()` once main → renderer hydration completes. We keep a separate
+ * `BY_ID` map for O(1) lookups and rebuild it on every `setRegistry` call.
+ */
+let RUNTIME_TYPES: NoteType[] = BUILT_IN_TYPES.map(t => ({ ...t }));
+let BY_ID: Map<string, NoteType> = new Map(RUNTIME_TYPES.map(t => [t.id, t]));
+
+/**
+ * Replace the live registry with `next`. The renderer calls this after
+ * fetching the merged built-in + user list from main; main can also use it on
+ * its own side after seeding the SQLite table so `getNoteType` lookups during
+ * note creation honour user-defined types too.
+ *
+ * Order is preserved verbatim — callers decide the strip / chooser sort.
+ */
+export function setRegistry(next: readonly NoteType[]): void {
+  // Always normalize the `note` default to position 0 so `DEFAULT_TYPE_ID`
+  // stays the visual default. If callers omit `note`, prepend the built-in.
+  const seen = new Set<string>();
+  const ordered: NoteType[] = [];
+  const noteEntry = next.find(t => t.id === DEFAULT_TYPE_ID) ?? BUILT_IN_TYPES[0];
+  ordered.push({ ...noteEntry });
+  seen.add(DEFAULT_TYPE_ID);
+  for (const t of next) {
+    if (seen.has(t.id)) continue;
+    seen.add(t.id);
+    ordered.push({ ...t });
+  }
+  RUNTIME_TYPES = ordered;
+  BY_ID = new Map(RUNTIME_TYPES.map(t => [t.id, t]));
+}
 
 /** Look up a type by id, falling back to the default `note` type so the UI
  * never crashes on an unknown id (e.g. when a user hand-edits notes.json). */
@@ -95,10 +144,15 @@ export function getNoteType(id: string | undefined): NoteType {
 
 /** Returns the registered ids in display order. */
 export function listNoteTypeIds(): string[] {
-  return BUILT_IN_TYPES.map(t => t.id);
+  return RUNTIME_TYPES.map(t => t.id);
 }
 
 /** All registered types in display order. */
 export function listNoteTypes(): readonly NoteType[] {
-  return BUILT_IN_TYPES;
+  return RUNTIME_TYPES;
+}
+
+/** True when the id is shipped with the app (immutable in settings UI). */
+export function isBuiltinTypeId(id: string): boolean {
+  return BUILT_IN_TYPES.some(t => t.id === id);
 }

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -86,6 +86,17 @@ contextBridge.exposeInMainWorld('mid', {
     ipcRenderer.invoke('mid:notes-tag', workspace, id, tags),
   notesSetType: (workspace: string, id: string, type: string): Promise<NoteEntry | null> =>
     ipcRenderer.invoke('mid:notes-set-type', workspace, id, type),
+  // #297 — note-type registry CRUD. The shape mirrors `NoteType` from
+  // `apps/electron/notes/note-types.ts`; we don't import the type here to keep
+  // preload free of cross-module deps.
+  noteTypesList: (): Promise<{ id: string; label: string; icon: string; color: string; viewKind?: string; description?: string; builtin?: boolean }[]> =>
+    ipcRenderer.invoke('mid:note-types-list'),
+  noteTypesUpsert: (type: { id: string; label: string; icon: string; color: string; viewKind?: string; description?: string }): Promise<{ ok: boolean; types: { id: string; label: string; icon: string; color: string; viewKind?: string; description?: string; builtin?: boolean }[]; error?: string }> =>
+    ipcRenderer.invoke('mid:note-types-upsert', type),
+  noteTypesDelete: (id: string): Promise<{ ok: boolean; types: { id: string; label: string; icon: string; color: string; viewKind?: string; description?: string; builtin?: boolean }[]; error?: string }> =>
+    ipcRenderer.invoke('mid:note-types-delete', id),
+  noteTypesReorder: (orderedIds: string[]): Promise<{ id: string; label: string; icon: string; color: string; viewKind?: string; description?: string; builtin?: boolean }[]> =>
+    ipcRenderer.invoke('mid:note-types-reorder', orderedIds),
   warehousesList: (workspace: string): Promise<Warehouse[]> =>
     ipcRenderer.invoke('mid:warehouses-list', workspace),
   warehousesAdd: (workspace: string, warehouse: Warehouse): Promise<{ ok: boolean; warehouses: Warehouse[]; error?: string }> =>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -507,6 +507,264 @@ body.has-sidebar .mid-shell {
   gap: var(--mid-space-1);
 }
 
+/* #295 — Task list custom view. Same outer shell as the secret editor; rows
+ * are draggable and lay out checkbox + text + delete in a single line. */
+.mid-task-editor {
+  max-width: 720px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-3);
+}
+.mid-task-header {
+  display: flex;
+  align-items: center;
+  gap: var(--mid-space-2);
+  padding: var(--mid-space-3);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
+}
+.mid-task-header-icon { color: #1a7f37; }
+.mid-task-header-title {
+  font-weight: var(--mid-weight-semibold);
+  font-size: var(--mid-font-size-lg);
+}
+.mid-task-header-hint {
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+  margin-left: auto;
+}
+.mid-task-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-1);
+}
+.mid-task-row {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  gap: var(--mid-space-2);
+  align-items: center;
+  padding: var(--mid-space-2);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
+  cursor: grab;
+  transition: opacity var(--mid-motion-fast) var(--mid-ease-out), border-color var(--mid-motion-fast) var(--mid-ease-out);
+}
+.mid-task-row.is-dragging { opacity: 0.4; }
+.mid-task-row.is-drop-target { border-color: var(--mid-accent); }
+.mid-task-row.is-done .mid-task-text {
+  text-decoration: line-through;
+  color: var(--mid-fg-muted);
+}
+.mid-task-handle {
+  color: var(--mid-fg-muted);
+  cursor: grab;
+  user-select: none;
+  font-size: var(--mid-font-size-sm);
+  letter-spacing: -2px;
+}
+.mid-task-check { width: 18px; height: 18px; cursor: pointer; }
+.mid-task-text {
+  font-family: inherit;
+  font-size: var(--mid-font-size-sm);
+}
+.mid-task-add {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mid-space-1);
+}
+
+/* #296 — Meeting custom view. Two-column grid for short fields, full-width
+ * for chips + textareas. */
+.mid-meeting-editor {
+  max-width: 820px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-3);
+}
+.mid-meeting-header {
+  display: flex;
+  align-items: center;
+  gap: var(--mid-space-2);
+  padding: var(--mid-space-3);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
+}
+.mid-meeting-header-icon { color: #0969da; }
+.mid-meeting-header-title {
+  font-weight: var(--mid-weight-semibold);
+  font-size: var(--mid-font-size-lg);
+}
+.mid-meeting-header-hint {
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+  margin-left: auto;
+}
+.mid-meeting-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--mid-space-3);
+}
+.mid-meeting-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-1);
+}
+.mid-meeting-field--full { grid-column: 1 / -1; }
+.mid-meeting-field-label {
+  font-size: var(--mid-font-size-xs);
+  font-weight: var(--mid-weight-semibold);
+  color: var(--mid-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.mid-meeting-textarea {
+  font-family: var(--mid-font-mono);
+  font-size: var(--mid-font-size-sm);
+  resize: vertical;
+  min-height: 100px;
+  width: 100%;
+  padding: var(--mid-space-2);
+}
+
+/* Generic chip editor (#296 — used by attendees + decisions). */
+.mid-chip-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-1);
+  padding: var(--mid-space-2);
+  background: var(--mid-bg);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
+}
+.mid-chip-editor-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--mid-space-1);
+}
+.mid-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mid-space-1);
+  padding: 2px var(--mid-space-2);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: 999px;
+  font-size: var(--mid-font-size-xs);
+}
+.mid-chip-remove {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--mid-fg-muted);
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+}
+.mid-chip-remove:hover { color: var(--mid-fg); }
+.mid-chip-editor-input {
+  border: none;
+  background: transparent;
+  font-size: var(--mid-font-size-sm);
+  outline: none;
+  width: 100%;
+}
+
+/* #297 — Note types settings list. */
+.mid-note-types-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-1);
+  margin-bottom: var(--mid-space-2);
+}
+.mid-note-type-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--mid-space-2);
+  align-items: center;
+  padding: var(--mid-space-2);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
+}
+.mid-note-type-row-icon { display: inline-flex; align-items: center; }
+.mid-note-type-row-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.mid-note-type-row-label {
+  font-weight: var(--mid-weight-semibold);
+  font-size: var(--mid-font-size-sm);
+}
+.mid-note-type-row-meta {
+  font-size: var(--mid-font-size-xs);
+  color: var(--mid-fg-muted);
+}
+.mid-note-type-row-meta code { font-family: var(--mid-font-mono); font-size: 0.92em; }
+.mid-note-type-row-actions { display: inline-flex; gap: var(--mid-space-1); }
+
+/* #297 — Note type editor modal form. */
+.mid-note-type-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-2);
+}
+.mid-note-type-form-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-1);
+}
+.mid-note-type-form-label {
+  font-size: var(--mid-font-size-xs);
+  font-weight: var(--mid-weight-semibold);
+  color: var(--mid-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* #302 — Strip pref rows in Settings → Notes → Filter strip. */
+.mid-strip-prefs {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mid-space-1);
+  margin-top: var(--mid-space-2);
+  transition: opacity var(--mid-motion-fast) var(--mid-ease-out);
+}
+.mid-strip-pref-row {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  gap: var(--mid-space-2);
+  align-items: center;
+  padding: var(--mid-space-2);
+  background: var(--mid-surface);
+  border: 1px solid var(--mid-border);
+  border-radius: var(--mid-radius-sm);
+  cursor: grab;
+}
+.mid-strip-pref-row.is-dragging { opacity: 0.4; }
+.mid-strip-pref-row.is-drop-target { border-color: var(--mid-accent); }
+.mid-strip-pref-handle {
+  color: var(--mid-fg-muted);
+  user-select: none;
+  font-size: var(--mid-font-size-sm);
+  letter-spacing: -2px;
+}
+.mid-strip-pref-icon { display: inline-flex; align-items: center; }
+.mid-strip-pref-label {
+  font-size: var(--mid-font-size-sm);
+}
+.mid-settings-checkbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
 /* Bottom status bar — shadcn v2 (background = bg, smaller chrome) */
 .mid-statusbar {
   display: flex;

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -9,7 +9,7 @@ import { Document, Paragraph, TextRun, HeadingLevel, AlignmentType, Packer, Tabl
 import { iconHTML, IconName } from '../../../packages/ui-tokens/src/icons';
 import { iconForFile } from '../../../packages/ui-tokens/src/file-icons';
 import { THEMES, ThemeDefinition } from '../../../packages/core/src/themes/themes';
-import { listNoteTypes, getNoteType, DEFAULT_TYPE_ID, type NoteType } from '../notes/note-types';
+import { listNoteTypes, getNoteType, DEFAULT_TYPE_ID, setRegistry as setNoteTypesRegistry, isBuiltinTypeId, type NoteType } from '../notes/note-types';
 
 interface TreeEntry {
   name: string;
@@ -49,6 +49,13 @@ interface AppState {
   outlineHidden?: boolean;
   /** Workspace ids that have dismissed the first-run warehouse onboarding (#236). */
   warehouseOnboardingDismissed?: string[];
+  /** #302 — hide the type-filter strip in the notes sidebar entirely. */
+  noteTypeStripHidden?: boolean;
+  /** #302 — type ids excluded from the strip even when it's visible. */
+  noteTypeStripExclude?: string[];
+  /** #302 — per-user ordering of strip entries; ids missing from this list
+   * append in registry order. */
+  noteTypeOrder?: string[];
 }
 
 interface PinnedFolder {
@@ -119,6 +126,11 @@ interface Mid {
   notesDelete(workspace: string, id: string): Promise<boolean>;
   notesTag(workspace: string, id: string, tags: string[]): Promise<NoteEntry | null>;
   notesSetType(workspace: string, id: string, type: string): Promise<NoteEntry | null>;
+  // #297 — note-type registry CRUD.
+  noteTypesList(): Promise<NoteType[]>;
+  noteTypesUpsert(type: Partial<NoteType> & { id: string }): Promise<{ ok: boolean; types: NoteType[]; error?: string }>;
+  noteTypesDelete(id: string): Promise<{ ok: boolean; types: NoteType[]; error?: string }>;
+  noteTypesReorder(orderedIds: string[]): Promise<NoteType[]>;
   warehousesList(workspace: string): Promise<Warehouse[]>;
   warehousesAdd(workspace: string, warehouse: Warehouse): Promise<{ ok: boolean; warehouses: Warehouse[]; error?: string }>;
   notesAttachWarehouse(workspace: string, id: string, warehouseId: string | null): Promise<NoteEntry | null>;
@@ -205,6 +217,11 @@ let notesTypeFilter: string | null = null;
 /** True when the active editor is rendering a typed custom view (e.g. secret).
  * Used by `setMode` to bypass the markdown editor swap. */
 let typedViewActive = false;
+/** #302 — strip preference state, hydrated from AppState on startup and
+ * mutated by the Settings → Notes → Filter strip controls. */
+let noteTypeStripHidden = false;
+let noteTypeStripExclude: string[] = [];
+let noteTypeOrder: string[] = [];
 let recentFiles: string[] = [];
 let warehouses: Warehouse[] = [];
 let pinnedFolders: PinnedFolder[] = [];
@@ -2279,6 +2296,435 @@ function renderSecretEditor(_note: NoteEntry, fullPath: string, content: string)
 
   root.replaceChildren(wrap);
   rebuildOutline(null);
+}
+
+/**
+ * #295 — Task-list custom view.
+ *
+ * Renders a checklist editor over the same `.md` file. Each row is a `- [ ]`
+ * or `- [x]` line; we parse the body on entry, render one editable row per
+ * line, and persist back to markdown on every mutation so the underlying file
+ * stays human-readable + diff-friendly + GitHub-renderable.
+ *
+ * Drag-to-reorder uses the HTML5 DnD API on the row element. We swap by
+ * mutating the in-memory array and re-rendering rather than juggling DOM
+ * positions directly — keeps state and view in sync and makes persist trivial.
+ *
+ * Frontmatter (if any) is preserved verbatim — the editor only owns the body.
+ */
+function renderTaskListEditor(_note: NoteEntry, fullPath: string, content: string): void {
+  root.classList.remove('viewing', 'editing', 'splitting');
+  root.classList.add('typed-view');
+
+  const fm = extractFrontmatter(content);
+  const body = fm.body;
+
+  interface TaskItem { text: string; done: boolean; }
+  const items: TaskItem[] = parseTaskMarkdown(body);
+
+  const wrap = document.createElement('div');
+  wrap.className = 'mid-task-editor';
+
+  const header = document.createElement('div');
+  header.className = 'mid-task-header';
+  header.innerHTML = `
+    <span class="mid-task-header-icon">${iconHTML('check-square', 'mid-icon--sm')}</span>
+    <span class="mid-task-header-title">Task list</span>
+    <span class="mid-task-header-hint">Each row is a <code>- [ ]</code> / <code>- [x]</code> line in the .md body.</span>
+  `;
+  wrap.appendChild(header);
+
+  const list = document.createElement('div');
+  list.className = 'mid-task-list';
+  wrap.appendChild(list);
+
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.className = 'mid-btn mid-task-add';
+  addBtn.innerHTML = `${iconHTML('plus', 'mid-icon--sm')}<span>Add row</span>`;
+  addBtn.addEventListener('click', () => {
+    items.push({ text: '', done: false });
+    rerender();
+    persist();
+    // Focus the new row's text input after the re-render.
+    const rows = list.querySelectorAll<HTMLInputElement>('.mid-task-text');
+    rows[rows.length - 1]?.focus();
+  });
+  wrap.appendChild(addBtn);
+
+  function persist(): void {
+    const taskBody = items
+      .filter(i => i.text.trim() !== '' || items.length === 1)
+      .map(i => `- [${i.done ? 'x' : ' '}] ${i.text}`)
+      .join('\n');
+    let next: string;
+    if (fm.meta) {
+      const yamlText = yaml.dump(fm.meta).trimEnd();
+      next = `---\n${yamlText}\n---\n\n${taskBody}\n`;
+    } else {
+      next = `${taskBody}\n`;
+    }
+    currentText = next;
+    void window.mid.writeFile(fullPath, next).then(() => updateSaveIndicator(true));
+  }
+
+  function rerender(): void {
+    list.replaceChildren();
+    items.forEach((item, idx) => list.appendChild(buildRow(item, idx)));
+  }
+
+  // Track drag-source index via a closure-shared variable rather than the
+  // DataTransfer object, which is read-only outside the dragstart handler in
+  // some Chromium configurations.
+  let dragFromIdx: number | null = null;
+
+  function buildRow(item: TaskItem, idx: number): HTMLElement {
+    const row = document.createElement('div');
+    row.className = 'mid-task-row';
+    row.draggable = true;
+    row.dataset.idx = String(idx);
+
+    const handle = document.createElement('span');
+    handle.className = 'mid-task-handle';
+    handle.title = 'Drag to reorder';
+    handle.textContent = '⋮⋮';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.className = 'mid-task-check';
+    checkbox.checked = item.done;
+    checkbox.addEventListener('change', () => {
+      item.done = checkbox.checked;
+      row.classList.toggle('is-done', item.done);
+      persist();
+    });
+
+    const text = document.createElement('input');
+    text.type = 'text';
+    text.className = 'mid-task-text mid-settings-control';
+    text.value = item.text;
+    text.placeholder = 'Task…';
+    text.addEventListener('input', () => { item.text = text.value; });
+    text.addEventListener('blur', persist);
+    text.addEventListener('keydown', e => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        items.splice(idx + 1, 0, { text: '', done: false });
+        rerender();
+        persist();
+        const rows = list.querySelectorAll<HTMLInputElement>('.mid-task-text');
+        rows[idx + 1]?.focus();
+      } else if (e.key === 'Backspace' && text.value === '' && items.length > 1) {
+        e.preventDefault();
+        items.splice(idx, 1);
+        rerender();
+        persist();
+        const rows = list.querySelectorAll<HTMLInputElement>('.mid-task-text');
+        rows[Math.max(0, idx - 1)]?.focus();
+      }
+    });
+
+    const del = document.createElement('button');
+    del.type = 'button';
+    del.className = 'mid-btn mid-btn--icon mid-btn--ghost';
+    del.title = 'Delete row';
+    del.innerHTML = iconHTML('trash', 'mid-icon--sm');
+    del.addEventListener('click', () => {
+      items.splice(idx, 1);
+      rerender();
+      persist();
+    });
+
+    if (item.done) row.classList.add('is-done');
+    row.append(handle, checkbox, text, del);
+
+    row.addEventListener('dragstart', e => {
+      dragFromIdx = idx;
+      row.classList.add('is-dragging');
+      // Required for Firefox to actually fire dragover.
+      try { e.dataTransfer?.setData('text/plain', String(idx)); } catch { /* ignore */ }
+    });
+    row.addEventListener('dragend', () => {
+      dragFromIdx = null;
+      row.classList.remove('is-dragging');
+      list.querySelectorAll('.mid-task-row').forEach(r => r.classList.remove('is-drop-target'));
+    });
+    row.addEventListener('dragover', e => {
+      e.preventDefault();
+      row.classList.add('is-drop-target');
+    });
+    row.addEventListener('dragleave', () => row.classList.remove('is-drop-target'));
+    row.addEventListener('drop', e => {
+      e.preventDefault();
+      row.classList.remove('is-drop-target');
+      if (dragFromIdx === null || dragFromIdx === idx) return;
+      const [moved] = items.splice(dragFromIdx, 1);
+      items.splice(idx, 0, moved);
+      dragFromIdx = null;
+      rerender();
+      persist();
+    });
+
+    return row;
+  }
+
+  rerender();
+  root.replaceChildren(wrap);
+  rebuildOutline(null);
+}
+
+interface TaskItemParse { text: string; done: boolean; }
+/**
+ * Pull `- [ ]` and `- [x]` lines out of a markdown body. Non-task lines are
+ * dropped — the task-list view owns the file body once active. If a user
+ * mixes prose with tasks, switching back to the markdown editor (via the
+ * Change Type menu) is the explicit escape hatch.
+ */
+function parseTaskMarkdown(body: string): TaskItemParse[] {
+  const out: TaskItemParse[] = [];
+  const rx = /^\s*[-*+]\s*\[(?<state>[ xX])\]\s?(?<text>.*)$/;
+  for (const line of body.split(/\r?\n/)) {
+    const m = rx.exec(line);
+    if (!m || !m.groups) continue;
+    out.push({ done: m.groups.state.toLowerCase() === 'x', text: m.groups.text });
+  }
+  return out;
+}
+
+/**
+ * #296 — Meeting custom view.
+ *
+ * Structured meeting form on top of the markdown file:
+ *   - Frontmatter (`date`, `attendees`, `location`, `decisions`) holds the
+ *     metadata so external tools can grep / filter on it.
+ *   - Body holds two free-form markdown areas: Agenda and Notes, separated by
+ *     `## Agenda` / `## Notes` headings so the file stays a usable artifact
+ *     even when opened in another editor.
+ *
+ * Persistence is debounced via `setTimeout` for the markdown areas (300ms)
+ * since they fire `input` on every keystroke; chip / date / location fields
+ * persist on `change` / blur.
+ */
+function renderMeetingEditor(_note: NoteEntry, fullPath: string, content: string): void {
+  root.classList.remove('viewing', 'editing', 'splitting');
+  root.classList.add('typed-view');
+
+  const fm = extractFrontmatter(content);
+  const meta = (fm.meta ?? {}) as Record<string, unknown>;
+  const date = typeof meta.date === 'string' ? meta.date : (meta.date instanceof Date ? meta.date.toISOString().slice(0, 10) : new Date().toISOString().slice(0, 10));
+  const attendees: string[] = Array.isArray(meta.attendees) ? (meta.attendees as unknown[]).map(String) : [];
+  const location = typeof meta.location === 'string' ? meta.location : '';
+  const decisions: string[] = Array.isArray(meta.decisions) ? (meta.decisions as unknown[]).map(String) : [];
+
+  const { agenda, notes } = splitAgendaNotes(fm.body);
+
+  const wrap = document.createElement('div');
+  wrap.className = 'mid-meeting-editor';
+
+  const header = document.createElement('div');
+  header.className = 'mid-meeting-header';
+  header.innerHTML = `
+    <span class="mid-meeting-header-icon">${iconHTML('calendar', 'mid-icon--sm')}</span>
+    <span class="mid-meeting-header-title">Meeting</span>
+    <span class="mid-meeting-header-hint">Metadata persists as YAML frontmatter; agenda + notes live in the body.</span>
+  `;
+  wrap.appendChild(header);
+
+  const grid = document.createElement('div');
+  grid.className = 'mid-meeting-grid';
+  wrap.appendChild(grid);
+
+  // Date
+  const dateLabel = document.createElement('label');
+  dateLabel.className = 'mid-meeting-field';
+  dateLabel.innerHTML = '<span class="mid-meeting-field-label">Date</span>';
+  const dateInput = document.createElement('input');
+  dateInput.type = 'date';
+  dateInput.className = 'mid-settings-control';
+  dateInput.value = date;
+  dateInput.addEventListener('change', persist);
+  dateLabel.appendChild(dateInput);
+  grid.appendChild(dateLabel);
+
+  // Location
+  const locLabel = document.createElement('label');
+  locLabel.className = 'mid-meeting-field';
+  locLabel.innerHTML = '<span class="mid-meeting-field-label">Location</span>';
+  const locInput = document.createElement('input');
+  locInput.type = 'text';
+  locInput.className = 'mid-settings-control';
+  locInput.placeholder = 'Zoom / Office / …';
+  locInput.value = location;
+  locInput.addEventListener('blur', persist);
+  locLabel.appendChild(locInput);
+  grid.appendChild(locLabel);
+
+  // Attendees (chips)
+  const attLabel = document.createElement('div');
+  attLabel.className = 'mid-meeting-field mid-meeting-field--full';
+  attLabel.innerHTML = '<span class="mid-meeting-field-label">Attendees</span>';
+  const attChips = buildChipEditor(attendees, persist, 'Add attendee…');
+  attLabel.appendChild(attChips.el);
+  grid.appendChild(attLabel);
+
+  // Agenda (markdown textarea)
+  const agendaLabel = document.createElement('div');
+  agendaLabel.className = 'mid-meeting-field mid-meeting-field--full';
+  agendaLabel.innerHTML = '<span class="mid-meeting-field-label">Agenda</span>';
+  const agendaTa = document.createElement('textarea');
+  agendaTa.className = 'mid-meeting-textarea mid-settings-control';
+  agendaTa.placeholder = '- Topic 1\n- Topic 2';
+  agendaTa.value = agenda;
+  agendaTa.rows = 5;
+  agendaTa.addEventListener('input', schedulePersist);
+  agendaTa.addEventListener('blur', persist);
+  agendaLabel.appendChild(agendaTa);
+  grid.appendChild(agendaLabel);
+
+  // Notes (markdown textarea)
+  const notesLabel = document.createElement('div');
+  notesLabel.className = 'mid-meeting-field mid-meeting-field--full';
+  notesLabel.innerHTML = '<span class="mid-meeting-field-label">Notes</span>';
+  const notesTa = document.createElement('textarea');
+  notesTa.className = 'mid-meeting-textarea mid-settings-control';
+  notesTa.placeholder = 'Free-form meeting notes (markdown).';
+  notesTa.value = notes;
+  notesTa.rows = 8;
+  notesTa.addEventListener('input', schedulePersist);
+  notesTa.addEventListener('blur', persist);
+  notesLabel.appendChild(notesTa);
+  grid.appendChild(notesLabel);
+
+  // Decisions (chips)
+  const decLabel = document.createElement('div');
+  decLabel.className = 'mid-meeting-field mid-meeting-field--full';
+  decLabel.innerHTML = '<span class="mid-meeting-field-label">Decisions</span>';
+  const decChips = buildChipEditor(decisions, persist, 'Add decision…');
+  decLabel.appendChild(decChips.el);
+  grid.appendChild(decLabel);
+
+  let persistTimer: number | null = null;
+  function schedulePersist(): void {
+    if (persistTimer !== null) window.clearTimeout(persistTimer);
+    persistTimer = window.setTimeout(() => { persist(); persistTimer = null; }, 300);
+  }
+
+  function persist(): void {
+    if (persistTimer !== null) { window.clearTimeout(persistTimer); persistTimer = null; }
+    const nextMeta: Record<string, unknown> = {
+      ...meta,
+      date: dateInput.value,
+      attendees: attChips.values(),
+      location: locInput.value,
+      decisions: decChips.values(),
+    };
+    const yamlText = yaml.dump(nextMeta).trimEnd();
+    const body = `## Agenda\n\n${agendaTa.value.trim()}\n\n## Notes\n\n${notesTa.value.trim()}\n`;
+    const next = `---\n${yamlText}\n---\n\n${body}`;
+    currentText = next;
+    void window.mid.writeFile(fullPath, next).then(() => updateSaveIndicator(true));
+  }
+
+  root.replaceChildren(wrap);
+  rebuildOutline(null);
+}
+
+/**
+ * Split a meeting body into the `## Agenda` and `## Notes` sections. If the
+ * file has no headings (e.g. a freshly created note imported from elsewhere),
+ * the entire body becomes the Notes section so we don't lose content.
+ */
+function splitAgendaNotes(body: string): { agenda: string; notes: string } {
+  const agendaRx = /^##\s*Agenda\s*$/im;
+  const notesRx = /^##\s*Notes\s*$/im;
+  const agendaMatch = agendaRx.exec(body);
+  const notesMatch = notesRx.exec(body);
+  if (!agendaMatch && !notesMatch) {
+    return { agenda: '', notes: body.replace(/^#\s+.+\n+/, '').trim() };
+  }
+  let agenda = '';
+  let notes = '';
+  if (agendaMatch && notesMatch) {
+    if (agendaMatch.index < notesMatch.index) {
+      agenda = body.slice(agendaMatch.index + agendaMatch[0].length, notesMatch.index).trim();
+      notes = body.slice(notesMatch.index + notesMatch[0].length).trim();
+    } else {
+      notes = body.slice(notesMatch.index + notesMatch[0].length, agendaMatch.index).trim();
+      agenda = body.slice(agendaMatch.index + agendaMatch[0].length).trim();
+    }
+  } else if (agendaMatch) {
+    agenda = body.slice(agendaMatch.index + agendaMatch[0].length).trim();
+  } else if (notesMatch) {
+    notes = body.slice(notesMatch.index + notesMatch[0].length).trim();
+  }
+  return { agenda, notes };
+}
+
+interface ChipEditor { el: HTMLElement; values(): string[]; }
+/**
+ * Generic chip editor used by the meeting view for attendees / decisions.
+ * Returns the wrapper element and a `values()` accessor for persistence.
+ */
+function buildChipEditor(initial: string[], onChange: () => void, placeholder: string): ChipEditor {
+  const list = initial.slice();
+  const wrap = document.createElement('div');
+  wrap.className = 'mid-chip-editor';
+
+  const chipsBox = document.createElement('div');
+  chipsBox.className = 'mid-chip-editor-chips';
+  wrap.appendChild(chipsBox);
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'mid-chip-editor-input mid-settings-control';
+  input.placeholder = placeholder;
+  wrap.appendChild(input);
+
+  function commit(value: string): void {
+    const v = value.trim();
+    if (!v) return;
+    list.push(v);
+    input.value = '';
+    rerender();
+    onChange();
+  }
+
+  input.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      commit(input.value);
+    } else if (e.key === 'Backspace' && input.value === '' && list.length > 0) {
+      list.pop();
+      rerender();
+      onChange();
+    }
+  });
+  input.addEventListener('blur', () => { if (input.value.trim()) commit(input.value); });
+
+  function rerender(): void {
+    chipsBox.replaceChildren();
+    list.forEach((value, idx) => {
+      const chip = document.createElement('span');
+      chip.className = 'mid-chip';
+      const text = document.createElement('span');
+      text.textContent = value;
+      const remove = document.createElement('button');
+      remove.type = 'button';
+      remove.className = 'mid-chip-remove';
+      remove.title = 'Remove';
+      remove.innerHTML = iconHTML('x', 'mid-icon--sm');
+      remove.addEventListener('click', () => {
+        list.splice(idx, 1);
+        rerender();
+        onChange();
+      });
+      chip.append(text, remove);
+      chipsBox.appendChild(chip);
+    });
+  }
+  rerender();
+
+  return { el: wrap, values: () => list.slice() };
 }
 
 function renderEdit(): void {
@@ -4413,7 +4859,9 @@ function setSidebarMode(mode: 'files' | 'notes'): void {
   sidebarNotesHeader.hidden = mode !== 'notes';
   treeRoot.hidden = mode !== 'files';
   notesListEl.hidden = mode !== 'notes';
-  notesTypesEl.hidden = mode !== 'notes';
+  // #302 — strip is gated by both the sidebar mode AND the per-user master
+  // toggle. Either being false hides the strip.
+  notesTypesEl.hidden = mode !== 'notes' || noteTypeStripHidden;
   if (mode === 'notes') {
     renderNoteTypesStrip();
     void loadNotes();
@@ -4460,10 +4908,19 @@ function renderNotes(): void {
  * #255 — render the horizontal type-filter strip at the top of the notes
  * sidebar. One button per registered type; clicking toggles the filter, and
  * clicking the active type clears the filter.
+ *
+ * #302 — the strip now honours three persisted prefs:
+ *   - `noteTypeStripHidden` — master toggle, gated by `setSidebarMode`.
+ *   - `noteTypeStripExclude` — type ids to omit even when the strip is on.
+ *   - `noteTypeOrder` — explicit ordering; types not listed append in the
+ *     registry's declaration order so newly added types stay discoverable.
  */
 function renderNoteTypesStrip(): void {
+  // Re-evaluate the master toggle in case it changed without a mode flip.
+  notesTypesEl.hidden = sidebarMode !== 'notes' || noteTypeStripHidden;
+  if (notesTypesEl.hidden) return;
   const buttons: HTMLElement[] = [];
-  for (const t of listNoteTypes()) {
+  for (const t of orderedStripTypes()) {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'mid-notes-type-chip';
@@ -4486,6 +4943,32 @@ function renderNoteTypesStrip(): void {
     buttons.push(btn);
   }
   notesTypesEl.replaceChildren(...buttons);
+}
+
+/**
+ * Apply `noteTypeOrder` + `noteTypeStripExclude` to the registry to produce
+ * the ordered, filtered list the strip should display. Centralised so the
+ * settings drag-reorder UI and the strip render share one source of truth.
+ */
+function orderedStripTypes(): NoteType[] {
+  const all = listNoteTypes();
+  const byId = new Map(all.map(t => [t.id, t] as const));
+  const out: NoteType[] = [];
+  const seen = new Set<string>();
+  for (const id of noteTypeOrder) {
+    const t = byId.get(id);
+    if (!t || seen.has(id)) continue;
+    seen.add(id);
+    if (noteTypeStripExclude.includes(id)) continue;
+    out.push(t);
+  }
+  for (const t of all) {
+    if (seen.has(t.id)) continue;
+    seen.add(t.id);
+    if (noteTypeStripExclude.includes(t.id)) continue;
+    out.push(t);
+  }
+  return out;
 }
 
 function renderNoteRow(note: NoteEntry): HTMLElement {
@@ -4771,14 +5254,20 @@ async function openNote(note: NoteEntry): Promise<void> {
   const content = await window.mid.readFile(fullPath);
   const noteType = getNoteType(note.type);
   // #255 — typed custom views. Markdown is the default; named viewKinds
-  // dispatch to a dedicated renderer that owns the root element.
-  if (noteType.viewKind === 'secret') {
+  // dispatch to a dedicated renderer that owns the root element. New view
+  // kinds (#295 task-list, #296 meeting) plug in here.
+  const customRenderer: ((n: NoteEntry, p: string, c: string) => void) | null =
+    noteType.viewKind === 'secret' ? renderSecretEditor
+      : noteType.viewKind === 'task-list' ? renderTaskListEditor
+      : noteType.viewKind === 'meeting' ? renderMeetingEditor
+      : null;
+  if (customRenderer) {
     typedViewActive = true;
     currentText = content;
     currentPath = fullPath;
     filenameEl.textContent = note.title;
     highlightActiveTreeItem();
-    renderSecretEditor(note, fullPath, content);
+    customRenderer(note, fullPath, content);
     updateSaveIndicator(true);
     pushRecent(fullPath);
     renderNotes();
@@ -5421,16 +5910,394 @@ function renderEditorSection(main: HTMLElement): void {
 }
 
 /* ── Notes ─────────────────────────────────────────────── */
+/**
+ * #297 + #302 — Notes settings panel.
+ *
+ * Two groups live here:
+ *   1. **Note types** — list of every registered type (built-ins read-only,
+ *      user-defined editable + deletable). "Add type…" opens a modal that
+ *      writes a new row into the SQLite `note_types` table via the IPC bridge
+ *      added in main.ts.
+ *   2. **Filter strip** — master toggle, per-type "Show in strip" checkbox,
+ *      drag-to-reorder. Persisted via three AppState keys read by
+ *      `renderNoteTypesStrip()`.
+ */
 function renderNotesSection(main: HTMLElement): void {
   const wrap = document.createElement('div');
   wrap.className = 'mid-settings-form';
-  const grp = makeGroup('Notes', 'Workspace-scoped notes and tag behavior.');
-  const note = document.createElement('p');
-  note.className = 'mid-settings-empty';
-  note.textContent = 'Notes are managed inline from the activity bar. Defaults for auto-tag, default folder, and push behavior will surface here as they ship.';
-  grp.body.appendChild(note);
-  wrap.appendChild(grp.card);
+
+  // ─── Group 1: Note types ──────────────────────────────────────────────────
+  const typesGroup = makeGroup('Note types', 'Built-in types are locked; user types can be edited or deleted. New types appear in the create-note chooser, filter strip, and the per-row Change Type menu.');
+  const typesList = document.createElement('div');
+  typesList.className = 'mid-note-types-list';
+  typesGroup.body.appendChild(typesList);
+
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.className = 'mid-btn mid-btn--primary';
+  addBtn.innerHTML = `${iconHTML('plus', 'mid-icon--sm')}<span>Add type…</span>`;
+  addBtn.addEventListener('click', async () => {
+    const created = await openNoteTypeEditor(null);
+    if (!created) return;
+    await refreshNoteTypesUI();
+  });
+  typesGroup.body.appendChild(addBtn);
+  wrap.appendChild(typesGroup.card);
+
+  // ─── Group 2: Filter strip ────────────────────────────────────────────────
+  const stripGroup = makeGroup('Filter strip', 'Controls the horizontal type chips above the notes sidebar.');
+  // Master toggle.
+  const masterToggle = document.createElement('input');
+  masterToggle.type = 'checkbox';
+  masterToggle.className = 'mid-settings-control mid-settings-checkbox';
+  masterToggle.checked = !noteTypeStripHidden;
+  masterToggle.addEventListener('change', () => {
+    noteTypeStripHidden = !masterToggle.checked;
+    void window.mid.patchAppState({ noteTypeStripHidden });
+    renderNoteTypesStrip();
+    perTypeBox.style.opacity = noteTypeStripHidden ? '0.5' : '1';
+    perTypeBox.style.pointerEvents = noteTypeStripHidden ? 'none' : 'auto';
+  });
+  stripGroup.body.appendChild(makeRow(
+    { label: 'Show type filter strip in notes sidebar', description: 'Master switch. Off hides the strip even when individual types are visible.', inline: true },
+    masterToggle,
+  ));
+
+  // Per-type visibility + drag-reorder list.
+  const perTypeBox = document.createElement('div');
+  perTypeBox.className = 'mid-strip-prefs';
+  perTypeBox.style.opacity = noteTypeStripHidden ? '0.5' : '1';
+  perTypeBox.style.pointerEvents = noteTypeStripHidden ? 'none' : 'auto';
+  stripGroup.body.appendChild(perTypeBox);
+  wrap.appendChild(stripGroup.card);
+
   main.appendChild(wrap);
+
+  // ─── Renderers + helpers ──────────────────────────────────────────────────
+  function renderTypesList(): void {
+    typesList.replaceChildren();
+    for (const t of listNoteTypes()) {
+      const row = document.createElement('div');
+      row.className = 'mid-note-type-row';
+      row.innerHTML = `
+        <span class="mid-note-type-row-icon" style="color:${t.color}">${iconHTML(t.icon as IconName, 'mid-icon--md')}</span>
+        <span class="mid-note-type-row-text">
+          <span class="mid-note-type-row-label">${escapeHTML(t.label)}</span>
+          <span class="mid-note-type-row-meta">id <code>${escapeHTML(t.id)}</code> · view <code>${escapeHTML(t.viewKind ?? 'markdown')}</code>${t.builtin ? ' · <em>built-in</em>' : ''}</span>
+        </span>
+      `;
+      const actions = document.createElement('span');
+      actions.className = 'mid-note-type-row-actions';
+      const edit = document.createElement('button');
+      edit.type = 'button';
+      edit.className = 'mid-btn mid-btn--icon mid-btn--ghost';
+      edit.title = isBuiltinTypeId(t.id) ? 'Edit label / icon / color (view kind is locked for built-ins)' : 'Edit type';
+      edit.innerHTML = iconHTML('edit', 'mid-icon--sm');
+      edit.addEventListener('click', async () => {
+        const updated = await openNoteTypeEditor(t);
+        if (!updated) return;
+        await refreshNoteTypesUI();
+      });
+      actions.appendChild(edit);
+      if (!isBuiltinTypeId(t.id)) {
+        const del = document.createElement('button');
+        del.type = 'button';
+        del.className = 'mid-btn mid-btn--icon mid-btn--ghost';
+        del.title = 'Delete user type';
+        del.innerHTML = iconHTML('trash', 'mid-icon--sm');
+        del.addEventListener('click', async () => {
+          const ok = await midConfirm('Delete type?', `"${t.label}" — existing notes keep their type id but will fall back to the default note view.`);
+          if (!ok) return;
+          const result = await window.mid.noteTypesDelete(t.id);
+          if (!result.ok) {
+            flashStatus(result.error ?? 'Delete failed');
+            return;
+          }
+          setNoteTypesRegistry(result.types);
+          await refreshNoteTypesUI();
+        });
+        actions.appendChild(del);
+      }
+      row.appendChild(actions);
+      typesList.appendChild(row);
+    }
+  }
+
+  function renderStripPrefs(): void {
+    perTypeBox.replaceChildren();
+    const all = listNoteTypes();
+    // Build the ordered list using current `noteTypeOrder`, appending unseen.
+    const byId = new Map(all.map(t => [t.id, t] as const));
+    const ordered: NoteType[] = [];
+    const seen = new Set<string>();
+    for (const id of noteTypeOrder) {
+      const t = byId.get(id);
+      if (t && !seen.has(id)) { ordered.push(t); seen.add(id); }
+    }
+    for (const t of all) { if (!seen.has(t.id)) { ordered.push(t); seen.add(t.id); } }
+
+    let dragFromIdx: number | null = null;
+    ordered.forEach((t, idx) => {
+      const row = document.createElement('div');
+      row.className = 'mid-strip-pref-row';
+      row.draggable = true;
+      row.dataset.idx = String(idx);
+
+      const handle = document.createElement('span');
+      handle.className = 'mid-strip-pref-handle';
+      handle.title = 'Drag to reorder';
+      handle.textContent = '⋮⋮';
+
+      const iconSpan = document.createElement('span');
+      iconSpan.className = 'mid-strip-pref-icon';
+      iconSpan.style.color = t.color;
+      iconSpan.innerHTML = iconHTML(t.icon as IconName, 'mid-icon--sm');
+
+      const label = document.createElement('span');
+      label.className = 'mid-strip-pref-label';
+      label.textContent = t.label;
+
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.className = 'mid-settings-control mid-settings-checkbox';
+      checkbox.checked = !noteTypeStripExclude.includes(t.id);
+      checkbox.title = 'Show in strip';
+      checkbox.addEventListener('change', () => {
+        const set = new Set(noteTypeStripExclude);
+        if (checkbox.checked) set.delete(t.id); else set.add(t.id);
+        noteTypeStripExclude = Array.from(set);
+        void window.mid.patchAppState({ noteTypeStripExclude });
+        renderNoteTypesStrip();
+      });
+
+      row.append(handle, iconSpan, label, checkbox);
+
+      row.addEventListener('dragstart', e => {
+        dragFromIdx = idx;
+        row.classList.add('is-dragging');
+        try { e.dataTransfer?.setData('text/plain', String(idx)); } catch { /* ignore */ }
+      });
+      row.addEventListener('dragend', () => {
+        dragFromIdx = null;
+        row.classList.remove('is-dragging');
+        perTypeBox.querySelectorAll('.mid-strip-pref-row').forEach(r => r.classList.remove('is-drop-target'));
+      });
+      row.addEventListener('dragover', e => { e.preventDefault(); row.classList.add('is-drop-target'); });
+      row.addEventListener('dragleave', () => row.classList.remove('is-drop-target'));
+      row.addEventListener('drop', e => {
+        e.preventDefault();
+        row.classList.remove('is-drop-target');
+        if (dragFromIdx === null || dragFromIdx === idx) return;
+        const [moved] = ordered.splice(dragFromIdx, 1);
+        ordered.splice(idx, 0, moved);
+        noteTypeOrder = ordered.map(t => t.id);
+        void window.mid.patchAppState({ noteTypeOrder });
+        renderStripPrefs();
+        renderNoteTypesStrip();
+      });
+
+      perTypeBox.appendChild(row);
+    });
+  }
+
+  async function refreshNoteTypesUI(): Promise<void> {
+    // Refresh from main so we don't drift from the SQLite truth source.
+    try {
+      const fresh = await window.mid.noteTypesList();
+      if (Array.isArray(fresh)) setNoteTypesRegistry(fresh);
+    } catch { /* keep existing */ }
+    renderTypesList();
+    renderStripPrefs();
+    renderNoteTypesStrip();
+  }
+
+  void refreshNoteTypesUI();
+}
+
+/**
+ * #297 — Note type editor modal. Pass `null` to create a new type, or an
+ * existing `NoteType` to edit. Built-in entries lock the id + view-kind
+ * fields; everything else is editable.
+ */
+function openNoteTypeEditor(initial: NoteType | null): Promise<NoteType | null> {
+  return new Promise(resolve => {
+    const isEdit = !!initial;
+    const isBuiltin = !!initial && isBuiltinTypeId(initial.id);
+
+    const backdrop = document.createElement('div');
+    backdrop.className = 'mid-type-chooser-backdrop';
+    const modal = document.createElement('div');
+    modal.className = 'mid-type-chooser';
+    modal.style.maxWidth = '560px';
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-label', isEdit ? 'Edit note type' : 'Add note type');
+
+    const header = document.createElement('div');
+    header.className = 'mid-type-chooser-header';
+    header.textContent = isEdit ? `Edit type — ${initial!.label}` : 'Add note type';
+    modal.appendChild(header);
+
+    // Form scaffold.
+    const form = document.createElement('div');
+    form.className = 'mid-note-type-form';
+    modal.appendChild(form);
+
+    const idInput = labelledInput('Id', 'slug-id (lowercase, hyphens)', initial?.id ?? '', isEdit);
+    form.appendChild(idInput.row);
+    const labelInput = labelledInput('Label', 'Human-readable name', initial?.label ?? '');
+    form.appendChild(labelInput.row);
+    const descInput = labelledInput('Description', 'Optional — shown in the type chooser.', initial?.description ?? '');
+    form.appendChild(descInput.row);
+
+    // Icon picker (reuses PIN_ICON_CHOICES + the built-in note-type icons).
+    let chosenIcon = initial?.icon ?? 'bookmark';
+    const iconRow = document.createElement('div');
+    iconRow.className = 'mid-note-type-form-row';
+    iconRow.innerHTML = '<span class="mid-note-type-form-label">Icon</span>';
+    const iconGrid = document.createElement('div');
+    iconGrid.className = 'mid-pin-icons';
+    const iconChoices: IconName[] = [
+      'bookmark', 'lock', 'check-square', 'calendar', 'book', 'code',
+      'tag', 'list-ul', 'github', 'image', 'link', 'folder',
+      'file', 'cog', 'search', 'markdown', 'typescript', 'python',
+    ];
+    for (const ic of iconChoices) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'mid-pin-icon-btn' + (ic === chosenIcon ? ' is-active' : '');
+      btn.dataset.icon = ic;
+      btn.innerHTML = iconHTML(ic);
+      btn.addEventListener('click', () => {
+        chosenIcon = ic;
+        iconGrid.querySelectorAll('.mid-pin-icon-btn').forEach(b => b.classList.toggle('is-active', (b as HTMLElement).dataset.icon === ic));
+      });
+      iconGrid.appendChild(btn);
+    }
+    iconRow.appendChild(iconGrid);
+    form.appendChild(iconRow);
+
+    // Color picker.
+    let chosenColor = initial?.color ?? '#6e7681';
+    const colorRow = document.createElement('div');
+    colorRow.className = 'mid-note-type-form-row';
+    colorRow.innerHTML = '<span class="mid-note-type-form-label">Color</span>';
+    const colorGrid = document.createElement('div');
+    colorGrid.className = 'mid-pin-colors';
+    const colorChoices = [
+      '#6e7681', '#bf8700', '#1a7f37', '#0969da', '#8250df', '#cf222e',
+      '#2563eb', '#16a34a', '#dc2626', '#ca8a04', '#9333ea', '#db2777',
+    ];
+    for (const col of colorChoices) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'mid-pin-color-btn' + (col === chosenColor ? ' is-active' : '');
+      btn.style.background = col;
+      btn.dataset.color = col;
+      btn.title = col;
+      btn.addEventListener('click', () => {
+        chosenColor = col;
+        colorGrid.querySelectorAll('.mid-pin-color-btn').forEach(b => b.classList.toggle('is-active', (b as HTMLElement).dataset.color === col));
+      });
+      colorGrid.appendChild(btn);
+    }
+    colorRow.appendChild(colorGrid);
+    form.appendChild(colorRow);
+
+    // View kind dropdown — locked for built-ins (their renderer dispatch is
+    // wired in code; changing it would silently break the editor).
+    const viewRow = document.createElement('div');
+    viewRow.className = 'mid-note-type-form-row';
+    viewRow.innerHTML = '<span class="mid-note-type-form-label">View kind</span>';
+    const viewSelect = document.createElement('select');
+    viewSelect.className = 'mid-settings-control';
+    for (const [v, l] of [
+      ['markdown', 'Markdown editor (default)'],
+      ['task-list', 'Task list (checklist)'],
+      ['secret', 'Secret (key/value)'],
+      ['meeting', 'Meeting (structured form)'],
+    ] as const) {
+      const opt = document.createElement('option');
+      opt.value = v;
+      opt.textContent = l;
+      viewSelect.appendChild(opt);
+    }
+    viewSelect.value = initial?.viewKind ?? 'markdown';
+    if (isBuiltin) viewSelect.disabled = true;
+    viewRow.appendChild(viewSelect);
+    form.appendChild(viewRow);
+
+    // Footer.
+    const footer = document.createElement('div');
+    footer.className = 'mid-type-chooser-footer';
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'mid-btn';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', () => close(null));
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.className = 'mid-btn mid-btn--primary';
+    saveBtn.textContent = isEdit ? 'Save' : 'Create';
+    saveBtn.addEventListener('click', async () => {
+      const id = idInput.input.value.trim();
+      const label = labelInput.input.value.trim();
+      if (!id) { flashStatus('Id is required'); return; }
+      if (!label) { flashStatus('Label is required'); return; }
+      const payload: NoteType = {
+        id,
+        label,
+        icon: chosenIcon,
+        color: chosenColor,
+        viewKind: viewSelect.value,
+        description: descInput.input.value.trim() || undefined,
+      };
+      const result = await window.mid.noteTypesUpsert(payload);
+      if (!result.ok) {
+        flashStatus(result.error ?? 'Failed to save type');
+        return;
+      }
+      setNoteTypesRegistry(result.types);
+      const saved = result.types.find(t => t.id === id) ?? payload;
+      close(saved);
+    });
+    footer.append(cancelBtn, saveBtn);
+    modal.appendChild(footer);
+
+    backdrop.appendChild(modal);
+    document.body.appendChild(backdrop);
+
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') { e.preventDefault(); close(null); }
+    };
+    backdrop.addEventListener('click', e => { if (e.target === backdrop) close(null); });
+    document.addEventListener('keydown', onKey);
+
+    // Focus the first editable field.
+    setTimeout(() => (isEdit ? labelInput.input : idInput.input).focus(), 50);
+
+    function close(value: NoteType | null): void {
+      document.removeEventListener('keydown', onKey);
+      backdrop.remove();
+      resolve(value);
+    }
+  });
+}
+
+interface LabelledInput { row: HTMLElement; input: HTMLInputElement; }
+function labelledInput(label: string, placeholder: string, initial: string, readOnly = false): LabelledInput {
+  const row = document.createElement('div');
+  row.className = 'mid-note-type-form-row';
+  const labelEl = document.createElement('span');
+  labelEl.className = 'mid-note-type-form-label';
+  labelEl.textContent = label;
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'mid-settings-control';
+  input.placeholder = placeholder;
+  input.value = initial;
+  if (readOnly) { input.readOnly = true; input.style.opacity = '0.6'; }
+  row.append(labelEl, input);
+  return { row, input };
 }
 
 /* ── GitHub ────────────────────────────────────────────── */
@@ -5546,6 +6413,17 @@ void window.mid.readAppState().then(async state => {
   if (typeof state.outlineHidden === 'boolean') {
     outlineHidden = state.outlineHidden;
   }
+  // #302 — strip preferences. Default: visible, no excludes, no custom order.
+  if (typeof state.noteTypeStripHidden === 'boolean') noteTypeStripHidden = state.noteTypeStripHidden;
+  if (Array.isArray(state.noteTypeStripExclude)) noteTypeStripExclude = state.noteTypeStripExclude.slice();
+  if (Array.isArray(state.noteTypeOrder)) noteTypeOrder = state.noteTypeOrder.slice();
+  // #297 — hydrate the registry from SQLite before any note view tries to
+  // dispatch on viewKind. Failures fall back to the built-ins shipped in the
+  // bundle; the renderer never blocks on this round-trip.
+  try {
+    const types = await window.mid.noteTypesList();
+    if (Array.isArray(types) && types.length > 0) setNoteTypesRegistry(types);
+  } catch (err) { console.debug('[mid] noteTypesList failed:', err); }
   applyOutlineVisibility();
   // Auto-register the lastFolder as a workspace if it's not in the list yet.
   if (state.lastFolder && !workspaces.find(w => w.path === state.lastFolder)) {

--- a/docs/desktop-typed-notes-meeting.md
+++ b/docs/desktop-typed-notes-meeting.md
@@ -1,0 +1,64 @@
+# Meeting custom view (#296)
+
+Follow-up to the typed-notes MVP (#255 / #294). Notes whose `type` is `meeting` now open in a structured form on top of the markdown file instead of the plain markdown editor.
+
+## What it looks like
+
+When the active note's type is `meeting`, the right pane shows a structured grid:
+
+- Header chip identifies the view (blue calendar icon).
+- **Date** — native `<input type="date">`.
+- **Location** — text input.
+- **Attendees** — chip editor; type a name + Enter (or comma) to add. Backspace in an empty input removes the last chip.
+- **Agenda** — multi-line markdown textarea.
+- **Notes** — multi-line markdown textarea.
+- **Decisions** — chip editor (same shape as Attendees).
+
+## Persistence
+
+The view writes one round-trip per mutation. Date / location / chip changes persist on `change` / `blur`; markdown areas debounce at 300ms while typing, then flush on blur.
+
+The file shape stays a usable markdown artifact:
+
+```markdown
+---
+date: 2026-05-15
+attendees:
+  - Fady
+  - Nada
+location: Cairo office
+decisions:
+  - Ship the PR by EOW
+  - Defer plugin marketplace to v0.3
+---
+
+## Agenda
+
+- Review tab manager work
+- Greenlight typed-notes follow-ups
+
+## Notes
+
+Discussed scope & risk. Tab manager is on a separate branch; we won't merge into typed-notes until #287 lands.
+```
+
+Structured metadata lives in the YAML frontmatter so external tooling (gh CLI search, `grep`, custom MCP queries) can filter on `date`, `attendees`, etc. Free-form content lives in the body under `## Agenda` and `## Notes` headings, which the splitter looks for on every load — if the headings are missing (e.g. an externally-edited file), the entire body is treated as Notes so nothing is dropped.
+
+## Code surface
+
+| File | What changed |
+| ---- | ------------ |
+| `apps/electron/notes/note-types.ts` | `meeting` entry now declares `viewKind: 'meeting'`. |
+| `apps/electron/renderer/renderer.ts` | New `renderMeetingEditor()`, `splitAgendaNotes()`, and `buildChipEditor()`; `openNote()` dispatches when `viewKind === 'meeting'`. |
+| `apps/electron/renderer/renderer.css` | New `.mid-meeting-*` and `.mid-chip*` styles. |
+| `apps/electron/main.ts` | `notes-create` seeds new `meeting` notes with frontmatter (`date`, `attendees`, `location`, `decisions`) plus stub `## Agenda` / `## Notes` sections. |
+
+## Switching back to markdown
+
+Right-click the note row → **Change type…** → pick anything other than Meeting. The full file (frontmatter + body) opens unchanged in the markdown editor.
+
+## Out of scope
+
+- Recurring meetings — single-occurrence only.
+- Calendar integration (sync to system Calendar.app / Google Calendar). The frontmatter is intentionally simple so a downstream importer can do that work without us baking it in.
+- Per-attendee role chips. Attendees are flat strings; if you need richer attendee metadata, hand-edit the frontmatter.

--- a/docs/desktop-typed-notes-tasklist.md
+++ b/docs/desktop-typed-notes-tasklist.md
@@ -1,0 +1,54 @@
+# Task-list custom view (#295)
+
+Follow-up to the typed-notes MVP (#255 / #294). Notes whose `type` is `task-list` now open in a dedicated checklist editor instead of the plain markdown editor.
+
+## What it looks like
+
+When the active note's type is `task-list`, the right pane swaps the markdown editor for a checklist editor:
+
+- Header chip identifies the view (green check-square icon).
+- One row per task, each with:
+  - drag handle,
+  - native checkbox (checked = `[x]`),
+  - free-text input for the task body,
+  - delete button.
+- "Add row" button at the bottom appends a fresh empty row.
+
+## Persistence
+
+The view writes the file back to disk on every mutation via the same `mid:write-file` IPC the markdown editor uses, so existing GitHub push / file-history flows keep working unchanged.
+
+The body is plain markdown — one task per line:
+
+```markdown
+- [ ] Pull latest main
+- [x] Run npm test
+- [ ] Open the PR
+```
+
+Frontmatter, if present, is preserved verbatim — only the body is owned by the view.
+
+## Editing UX
+
+- **Enter** in a task input creates a new row below it and focuses it.
+- **Backspace** in an empty row deletes that row and focuses the row above.
+- **Drag a row** by its `⋮⋮` handle to reorder. The drop target highlights with the accent border.
+- **Toggle the checkbox** to mark done — the text greys out + strikes through.
+
+## Code surface
+
+| File | What changed |
+| ---- | ------------ |
+| `apps/electron/notes/note-types.ts` | `task-list` entry now declares `viewKind: 'task-list'`. |
+| `apps/electron/renderer/renderer.ts` | New `renderTaskListEditor()` + `parseTaskMarkdown()`; `openNote()` dispatches when `viewKind === 'task-list'`. |
+| `apps/electron/renderer/renderer.css` | New `.mid-task-*` styles under the typed-view block. |
+| `apps/electron/main.ts` | `notes-create` seeds `task-list` notes with an empty body so the editor has somewhere to start. |
+
+## Switching back to markdown
+
+Right-click the note row → **Change type…** → pick anything other than Task list. The next click opens the file in the markdown editor; tasks remain as `- [ ]` lines so nothing is lost.
+
+## Out of scope
+
+- Nested checklists (sub-tasks). The parser is line-oriented and ignores indentation; sub-tasks would need a separate viewKind.
+- Due dates / per-task metadata. Tasks are pure markdown to keep the file diff-friendly; richer scheduling lives in the meeting view (#296) instead.

--- a/docs/desktop-typed-notes.md
+++ b/docs/desktop-typed-notes.md
@@ -25,14 +25,14 @@ export interface NoteType {
 
 Order in `BUILT_IN_TYPES` is stable — the filter strip and chooser modal render in declaration order. The first entry, `'note'`, is the default for legacy entries created before this feature shipped.
 
-| id          | icon          | color   | viewKind   | purpose                                   |
-| ----------- | ------------- | ------- | ---------- | ----------------------------------------- |
-| `note`      | `bookmark`    | grey    | (markdown) | Plain markdown — the default              |
-| `secret`    | `lock`        | amber   | `secret`   | Key/value secrets editor                  |
-| `task-list` | `check-square`| green   | (markdown) | Checklist (markdown view in MVP)          |
-| `meeting`   | `calendar`    | blue    | (markdown) | Date/attendees frontmatter (markdown)     |
-| `reference` | `book`        | purple  | (markdown) | Long-lived reference doc                  |
-| `snippet`   | `code`        | red     | (markdown) | Code or shell snippet                     |
+| id          | icon          | color   | viewKind    | purpose                                   |
+| ----------- | ------------- | ------- | ----------- | ----------------------------------------- |
+| `note`      | `bookmark`    | grey    | (markdown)  | Plain markdown — the default              |
+| `secret`    | `lock`        | amber   | `secret`    | Key/value secrets editor                  |
+| `task-list` | `check-square`| green   | `task-list` | Checklist editor (#295)                   |
+| `meeting`   | `calendar`    | blue    | `meeting`   | Structured meeting form (#296)            |
+| `reference` | `book`        | purple  | (markdown)  | Long-lived reference doc                  |
+| `snippet`   | `code`        | red     | (markdown)  | Code or shell snippet                     |
 
 ## Storage shape
 
@@ -70,6 +70,8 @@ Currently registered view kinds:
 
 - **`markdown`** (default) — `renderView` / `renderEdit` / `renderSplit` from the existing flow.
 - **`secret`** — `renderSecretEditor`. A key/value list backed by YAML frontmatter (`secrets: { key: value }`). Each row exposes a reveal toggle, copy-to-clipboard, and delete.
+- **`task-list`** (#295) — `renderTaskListEditor`. A checklist editor backed by plain `- [ ]` / `- [x]` markdown lines. See [`docs/desktop-typed-notes-tasklist.md`](desktop-typed-notes-tasklist.md).
+- **`meeting`** (#296) — `renderMeetingEditor`. A structured form (date, attendees, location, agenda, notes, decisions) backed by YAML frontmatter + body sections. See [`docs/desktop-typed-notes-meeting.md`](desktop-typed-notes-meeting.md).
 
 When a typed view is active:
 
@@ -98,12 +100,52 @@ That's the whole contract. The registry is intentionally kept as a TS module rat
 - bundlers can tree-shake unused metadata,
 - adding a new built-in type is a single PR (just append to `BUILT_IN_TYPES`).
 
-User-defined custom types in settings are intentionally **out of scope** for the MVP cut — see the follow-up issue noted in the original feature ticket.
+User-defined custom types are now first-class. See the next two sections.
 
-## Out of scope (MVP cut)
+## User-defined types (#297)
 
-The following pieces from the original spec are deferred to follow-ups:
+Settings → Notes → **Note types** lists every registered type. Built-in entries (the table above) are read-only — only the label / icon / color / description can be tweaked, and `id` + `viewKind` stay locked because their renderer dispatch is wired in code. User-defined entries are fully editable and can be deleted.
 
-- `task-list` custom view — currently renders as plain markdown.
-- `meeting` custom view — currently renders as plain markdown.
-- User-defined custom types in settings.
+**Storage.** A new `note_types` SQLite table holds the merged registry:
+
+```sql
+CREATE TABLE note_types (
+  id TEXT PRIMARY KEY,
+  label TEXT NOT NULL,
+  icon TEXT NOT NULL,
+  color TEXT NOT NULL,
+  view_kind TEXT NOT NULL,
+  description TEXT,
+  builtin INTEGER NOT NULL DEFAULT 0,
+  sort INTEGER NOT NULL DEFAULT 0
+);
+```
+
+Built-ins are seeded on first read (idempotent — `INSERT OR IGNORE` semantics). User edits to a built-in's appearance survive seeding because the seeder only inserts rows whose ids don't already exist. The `sort` column is preserved across restarts so user-driven reorder via the filter strip (#302) is durable.
+
+**Runtime registry.** `apps/electron/notes/note-types.ts` keeps a mutable `RUNTIME_TYPES` array that starts as the built-ins (so first paint never blocks on IPC) and is overwritten by `setRegistry()` once the renderer hydrates from `mid:note-types-list`. Main calls the same `setRegistry()` after seeding so `notes-create` and `notes-set-type` see user types without an extra round-trip.
+
+**IPC surface.**
+
+| Channel                  | Signature                                                              |
+| ------------------------ | ---------------------------------------------------------------------- |
+| `mid:note-types-list`    | `() → NoteType[]`                                                      |
+| `mid:note-types-upsert`  | `(type) → { ok, types, error? }` — built-in id refuses view_kind change |
+| `mid:note-types-delete`  | `(id) → { ok, types, error? }` — built-ins are protected               |
+| `mid:note-types-reorder` | `(orderedIds) → NoteType[]`                                            |
+
+**Settings UI.** The Note types panel renders one row per registered type with the icon swatch + id + view kind label. The "Add type…" button opens a modal with id (slug input), label, description, icon picker (12 boxicons), color picker (12 swatches), and a viewKind dropdown — initial choices are the built-in views (`markdown`, `task-list`, `secret`, `meeting`). New entries flow through the existing chip / chooser / context-menu plumbing automatically because every consumer reads `listNoteTypes()`.
+
+## Filter strip preferences (#302)
+
+The horizontal type-filter strip above the notes sidebar honours three persisted prefs:
+
+| AppState key             | Type       | Default | Purpose                                              |
+| ------------------------ | ---------- | ------- | ---------------------------------------------------- |
+| `noteTypeStripHidden`    | `boolean`  | `false` | Master toggle — hide the strip entirely              |
+| `noteTypeStripExclude`   | `string[]` | `[]`    | Type ids to omit even when the strip is visible      |
+| `noteTypeOrder`          | `string[]` | `[]`    | Explicit display order; missing ids append in registry order |
+
+The strip itself only renders when the sidebar mode is `notes` AND `noteTypeStripHidden` is false — `setSidebarMode()` enforces both. Settings → Notes → **Filter strip** exposes a master toggle, per-type "Show in strip" checkbox, and a drag-to-reorder list. Changes apply immediately (no app restart): the master toggle / checkbox / drag handler each call `renderNoteTypesStrip()` after persisting via `mid:patch-app-state`.
+
+Newly added types (whether built-in or user-defined) appear in the strip immediately because `orderedStripTypes()` appends any registry entry that's missing from `noteTypeOrder`.


### PR DESCRIPTION
Bundles four typed-notes follow-ups in one PR — they all touch the same registry / settings / secret-editor surface, so shipping them together avoids serial merge conflicts.

## What's in the box

### #295 — Task-list custom view
Notes typed `task-list` now open in a dedicated checklist editor instead of the plain markdown editor.

- One row per task: drag handle + checkbox + free-text input + delete button.
- "Add row" appends; **Enter** in a row creates a new one; **Backspace** in an empty row deletes it.
- Drag-reorder with the `⋮⋮` handle.
- Persists as `- [ ]` / `- [x]` markdown so the file stays diff-friendly.

### #296 — Meeting custom view
Notes typed `meeting` now open in a structured form.

- Date (date input), location (text), attendees (chip editor).
- Agenda + Notes (markdown textareas, debounced 300ms).
- Decisions (chip editor).
- Frontmatter holds `date`, `attendees`, `location`, `decisions`. Body holds `## Agenda` + `## Notes` sections so the file stays a usable artifact.

### #297 — User-defined custom note types in settings
- New SQLite `note_types` table seeded with built-ins on first read.
- Settings → Notes → **Note types** lists every registered type. Built-ins lock the id + view-kind; everything else editable.
- "Add type…" modal with id (slug input), label, description, icon picker, color picker, and view-kind dropdown (`markdown` / `task-list` / `secret` / `meeting`).
- New types flow through the chip / chooser / context-menu plumbing automatically — every consumer reads `listNoteTypes()`.
- IPC: `mid:note-types-{list,upsert,delete,reorder}`.

### #302 — Type-filter strip — settings control
- Strip respects three persisted prefs: `noteTypeStripHidden`, `noteTypeStripExclude`, `noteTypeOrder`.
- Settings → Notes → **Filter strip** has a master toggle, per-type "Show in strip" checkbox, and drag-to-reorder list.
- Strip already gated by sidebar mode (`mode === 'notes'`); now gated by the master toggle too. Changes apply immediately, no restart.

## Acceptance criteria

**#295**
- [x] Note with `type: task-list` opens the checklist editor instead of the markdown editor.
- [x] Add / edit / check / delete rows; drag-to-reorder works.
- [x] Persists as `- [ ]` / `- [x]` markdown body.

**#296**
- [x] Note with `type: meeting` opens the structured form.
- [x] Date, attendees, location, decisions persist as YAML frontmatter.
- [x] Agenda + notes persist as the body under `## Agenda` / `## Notes`.

**#297**
- [x] Settings → Notes → Note types lists built-ins (read-only) + user-defined (editable + deletable).
- [x] "Add type…" modal creates a new type via SQLite.
- [x] New types appear in the create-note chooser, filter strip, and Change Type menu.

**#302**
- [x] Settings → Notes → Filter strip has master toggle, per-type visibility checkbox, and drag-reorder.
- [x] Strip respects all three settings (`noteTypeStripHidden`, `noteTypeStripExclude`, `noteTypeOrder`).

## Test plan
- [x] `npm run compile:electron` — green.
- [x] `npm test` — 204 / 204 passing.
- [x] `npm run lint` — zero new warnings (only pre-existing).
- [ ] Manual smoke: launch app, create one note of each type, edit + reorder + delete, restart, verify state survives.
- [ ] Manual smoke: Settings → Notes → Add user type with `task-list` view kind, create a note of that type, confirm it opens the checklist editor.
- [ ] Manual smoke: toggle the master strip switch off, confirm the strip disappears in the notes sidebar; reorder via drag, confirm the strip order matches.

## Docs
- New: `docs/desktop-typed-notes-tasklist.md` (#295)
- New: `docs/desktop-typed-notes-meeting.md` (#296)
- Updated: `docs/desktop-typed-notes.md` (#297 + #302)

## Out of scope
- Tab manager work in `feat/287-tab-manager` — not touched.
- `apps/electron/main.ts` packaging surface — not touched.
- `package.json#build.*`, `.github/workflows/release.yml` — not touched.

Closes #295
Closes #296
Closes #297
Closes #302