### PR TITLE
feat(desktop): tab manager — window detach (drag tab outside → new BrowserWindow) (#308)

### DIFF
--- a/apps/electron/db.ts
+++ b/apps/electron/db.ts
@@ -134,11 +134,12 @@ function applySchema(d: Database.Database): void {
       exported_at INTEGER NOT NULL
     );
     CREATE TABLE IF NOT EXISTS open_tabs (
+      window_id INTEGER NOT NULL DEFAULT 0,
       strip_id INTEGER NOT NULL,
       idx INTEGER NOT NULL,
       path TEXT NOT NULL,
       active INTEGER NOT NULL DEFAULT 0,
-      PRIMARY KEY (strip_id, idx)
+      PRIMARY KEY (window_id, strip_id, idx)
     );
     CREATE TABLE IF NOT EXISTS note_types (
       id TEXT PRIMARY KEY,
@@ -152,13 +153,25 @@ function applySchema(d: Database.Database): void {
     );
     CREATE INDEX IF NOT EXISTS idx_recent_files_opened ON recent_files(opened_at DESC);
     CREATE INDEX IF NOT EXISTS idx_export_history_exported ON export_history(exported_at DESC);
-    CREATE INDEX IF NOT EXISTS idx_open_tabs_strip ON open_tabs(strip_id, idx);
+    CREATE INDEX IF NOT EXISTS idx_open_tabs_window ON open_tabs(window_id, strip_id, idx);
   `);
+  // #308 — additive migration for installs that pre-date the multi-window
+  // tab manager. We add `window_id` if missing and default existing rows to 0
+  // (the main window's bucket) so the strip rehydrates the same as before.
+  // ALTER TABLE ADD COLUMN is safe to run repeatedly because we guard via the
+  // pragma list — SQLite has no IF NOT EXISTS for columns.
+  const cols = d.prepare('PRAGMA table_info(open_tabs)').all() as { name: string }[];
+  if (!cols.some(c => c.name === 'window_id')) {
+    d.exec(`ALTER TABLE open_tabs ADD COLUMN window_id INTEGER NOT NULL DEFAULT 0;`);
+  }
 }
 
-/* ── open tabs (#287) ───────────────────────────────────── */
+/* ── open tabs (#287, #308) ─────────────────────────────── */
 
 export interface OpenTabRow {
+  /** #308 — window scope. The main window persists under id 0; detached
+   * windows persist under their own slot id (allocated by main process). */
+  window_id: number;
   strip_id: number;
   idx: number;
   path: string;
@@ -166,28 +179,52 @@ export interface OpenTabRow {
 }
 
 /**
- * Returns persisted tabs ordered by (strip_id, idx) so the renderer can rebuild
- * the strip layout deterministically across restarts.
+ * Returns persisted tabs for a single window scope, ordered by (strip_id, idx).
+ * #308 — every window owns its own row bucket so detached windows can persist
+ * their own strip without trampling the main window's rows.
  */
-export function listOpenTabs(): OpenTabRow[] {
+export function listOpenTabs(windowId: number = 0): OpenTabRow[] {
   return getDB()
-    .prepare('SELECT strip_id, idx, path, active FROM open_tabs ORDER BY strip_id ASC, idx ASC')
-    .all() as OpenTabRow[];
+    .prepare('SELECT window_id, strip_id, idx, path, active FROM open_tabs WHERE window_id = ? ORDER BY strip_id ASC, idx ASC')
+    .all(windowId) as OpenTabRow[];
 }
 
 /**
- * Atomically replace the entire persisted tab set. The renderer is the source
- * of truth for layout — we wipe and rewrite rather than diff because the table
- * is small (typically <30 rows) and the transaction keeps the swap consistent.
+ * Returns every persisted window-id with at least one tab row. Useful at
+ * launch when the main process decides which detached windows to re-spawn.
  */
-export function replaceOpenTabs(rows: OpenTabRow[]): void {
+export function listOpenTabWindowIds(): number[] {
+  const rows = getDB()
+    .prepare('SELECT DISTINCT window_id FROM open_tabs ORDER BY window_id ASC')
+    .all() as { window_id: number }[];
+  return rows.map(r => r.window_id);
+}
+
+/**
+ * Atomically replace the persisted tab set for a single window. The renderer
+ * is the source of truth for layout — we wipe + rewrite *only the rows for
+ * this window* rather than the whole table, so a snapshot from window A never
+ * deletes window B's rows.
+ */
+export function replaceOpenTabs(windowId: number, rows: OpenTabRow[]): void {
   const d = getDB();
   const tx = d.transaction((all: OpenTabRow[]) => {
-    d.prepare('DELETE FROM open_tabs').run();
-    const stmt = d.prepare('INSERT INTO open_tabs(strip_id, idx, path, active) VALUES(?, ?, ?, ?)');
-    for (const r of all) stmt.run(r.strip_id, r.idx, r.path, r.active ? 1 : 0);
+    d.prepare('DELETE FROM open_tabs WHERE window_id = ?').run(windowId);
+    const stmt = d.prepare('INSERT INTO open_tabs(window_id, strip_id, idx, path, active) VALUES(?, ?, ?, ?, ?)');
+    for (const r of all) stmt.run(windowId, r.strip_id, r.idx, r.path, r.active ? 1 : 0);
   });
   tx(rows);
+}
+
+/**
+ * Drop every row for `windowId`. Called when a detached window closes so its
+ * slot can be reused by a future detach. The main window (id 0) is never
+ * cleared by this path — closing it shuts the app down on non-mac platforms
+ * and we want the strip to rehydrate on next launch.
+ */
+export function clearOpenTabsForWindow(windowId: number): void {
+  if (windowId === 0) return;
+  getDB().prepare('DELETE FROM open_tabs WHERE window_id = ?').run(windowId);
 }
 
 /* ── note types (#297) ─────────────────────────────────── */

--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -20,7 +20,9 @@ import {
   recordExport,
   listExportHistory,
   listOpenTabs,
+  listOpenTabWindowIds,
   replaceOpenTabs,
+  clearOpenTabsForWindow,
   type OpenTabRow,
   listNoteTypeRows,
   upsertNoteTypeRow,
@@ -45,6 +47,46 @@ let mcpProcess: ChildProcess | null = null;
 type MCPStatus = 'stopped' | 'running' | 'error';
 let mcpStatus: MCPStatus = 'stopped';
 let mcpLastError: string | null = null;
+
+/**
+ * #308 — multi-window registry. Every BrowserWindow this process owns has a
+ * stable, monotonically-allocated `windowSlotId` we use as the SQLite scope
+ * for `open_tabs`. The main window always claims slot 0 (its strip predates
+ * the multi-window era and existing rows live under window_id = 0). Detached
+ * windows allocate the smallest free slot ≥ 1, so closing + re-detaching
+ * reuses ids and the table stays compact.
+ *
+ * We key by `webContents.id` because that's what arrives on the IPC event
+ * sender — translating it to the slot id keeps the wire format clean (the
+ * renderer never has to know its slot, it just calls tabsList/Replace).
+ */
+const windowSlotByWebContentsId = new Map<number, number>();
+const windowsBySlotId = new Map<number, BrowserWindow>();
+
+function nextFreeSlotId(): number {
+  let candidate = 1;
+  while (windowsBySlotId.has(candidate)) candidate += 1;
+  return candidate;
+}
+
+function trackWindow(win: BrowserWindow, slotId: number): void {
+  windowSlotByWebContentsId.set(win.webContents.id, slotId);
+  windowsBySlotId.set(slotId, win);
+  win.on('closed', () => {
+    windowSlotByWebContentsId.delete(win.webContents.id);
+    windowsBySlotId.delete(slotId);
+    // Detached windows release their persisted strip on close. Re-opening
+    // the app should not re-spawn the detached window with stale rows; the
+    // user is closing the window, so the intent is "drop these tabs".
+    if (slotId !== 0) {
+      try { clearOpenTabsForWindow(slotId); } catch { /* ignore */ }
+    }
+  });
+}
+
+function slotIdForSender(sender: Electron.WebContents): number {
+  return windowSlotByWebContentsId.get(sender.id) ?? 0;
+}
 
 /**
  * Resolve a path relative to the repo root for both dev and packaged builds.
@@ -83,11 +125,36 @@ function resolveAppIcon(): string | undefined {
   return undefined;
 }
 
-async function createWindow(): Promise<void> {
+/**
+ * Build the renderer index path once — both the main window and any detached
+ * windows reuse it. Centralised because the path is identical and we want a
+ * single source of truth.
+ */
+function rendererIndexPath(): string {
+  return path.join(__dirname, 'renderer', 'index.html');
+}
+
+interface CreateWindowOptions {
+  /** #308 — when set, the new window opens with this single file pre-loaded
+   * as its only tab. Passed via the file URL hash so the sandboxed renderer
+   * can read it from `window.location` without an extra IPC round-trip. */
+  detachedPath?: string;
+  /** #308 — explicit slot id for re-spawning a detached window with its
+   * persisted strip on app launch. When omitted we treat this as the main
+   * window (slot 0) or allocate a fresh slot for an interactive detach. */
+  slotId?: number;
+  /** Optional bounds for detached windows so they pop near the cursor. */
+  bounds?: { x?: number; y?: number; width?: number; height?: number };
+}
+
+async function createWindow(opts: CreateWindowOptions = {}): Promise<BrowserWindow> {
   const iconPath = resolveAppIcon();
-  mainWindow = new BrowserWindow({
-    width: 1280,
-    height: 820,
+  const isDetached = opts.detachedPath != null || (opts.slotId != null && opts.slotId !== 0);
+  const win = new BrowserWindow({
+    width: opts.bounds?.width ?? (isDetached ? 720 : 1280),
+    height: opts.bounds?.height ?? (isDetached ? 600 : 820),
+    x: opts.bounds?.x,
+    y: opts.bounds?.y,
     minWidth: 720,
     minHeight: 480,
     backgroundColor: nativeTheme.shouldUseDarkColors ? '#0d1117' : '#ffffff',
@@ -101,20 +168,42 @@ async function createWindow(): Promise<void> {
     },
   });
 
-  await mainWindow.loadFile(path.join(__dirname, 'renderer', 'index.html'));
+  // The first window we create is the "main" one. Subsequent windows are
+  // detached. We register the slot mapping *before* loadFile so the renderer's
+  // first IPC (tabsList) sees the correct scope.
+  let slotId: number;
+  if (opts.slotId != null) {
+    slotId = opts.slotId;
+  } else if (!mainWindow) {
+    slotId = 0;
+    mainWindow = win;
+  } else {
+    slotId = nextFreeSlotId();
+  }
+  trackWindow(win, slotId);
+
+  // Pass the detached path via URL hash. Hash survives loadFile, isn't part of
+  // the file:// path so CSP stays happy, and the renderer reads it from
+  // `window.location.hash` on boot.
+  const hashParts: string[] = [];
+  if (opts.detachedPath) hashParts.push(`detachedPath=${encodeURIComponent(opts.detachedPath)}`);
+  const loadOpts = hashParts.length ? { hash: hashParts.join('&') } : undefined;
+  await win.loadFile(rendererIndexPath(), loadOpts);
 
   if (isDev) {
-    mainWindow.webContents.openDevTools({ mode: 'detach' });
+    win.webContents.openDevTools({ mode: 'detach' });
   }
 
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+  win.webContents.setWindowOpenHandler(({ url }) => {
     shell.openExternal(url);
     return { action: 'deny' };
   });
 
-  mainWindow.on('closed', () => {
-    mainWindow = null;
+  win.on('closed', () => {
+    if (mainWindow === win) mainWindow = null;
   });
+
+  return win;
 }
 
 app.whenReady().then(async () => {
@@ -141,6 +230,17 @@ app.whenReady().then(async () => {
   buildTray();
   startMCP();
   void initImporters();
+  // #308 — re-spawn any persisted detached windows. Each non-zero window slot
+  // means the user had a detached window open last session; we open one
+  // BrowserWindow per slot so the strip rehydrates the same as before.
+  try {
+    for (const slot of listOpenTabWindowIds()) {
+      if (slot === 0) continue;
+      void createWindow({ slotId: slot });
+    }
+  } catch (err) {
+    console.warn('[mid] detached-window re-spawn failed:', err);
+  }
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) void createWindow();
   });
@@ -767,20 +867,60 @@ ipcMain.handle('mid:list-export-history', async (_e, limit?: number) => {
 });
 
 /**
- * Open-tabs persistence (#287). The renderer owns the in-memory model and
- * snapshots the whole set on every meaningful mutation; we wipe-and-replace
- * because the row count is small and the transaction keeps it atomic.
+ * Open-tabs persistence (#287, #308). The renderer owns the in-memory model
+ * and snapshots its strip on every meaningful mutation. We wipe-and-replace
+ * the rows for that window only — atomicity comes from the SQLite transaction.
+ *
+ * The window-id scope is derived from the IPC sender's webContents, *not*
+ * trusted from the renderer payload. That keeps a misbehaving renderer from
+ * trampling another window's persisted rows.
  */
-ipcMain.handle('mid:tabs-list', async () => {
-  try { return listOpenTabs(); }
+ipcMain.handle('mid:tabs-list', async (e) => {
+  const slot = slotIdForSender(e.sender);
+  try { return listOpenTabs(slot); }
   catch { return []; }
 });
 
-ipcMain.handle('mid:tabs-replace', async (_e, rows: OpenTabRow[]) => {
+ipcMain.handle('mid:tabs-replace', async (e, rows: OpenTabRow[]) => {
   if (!Array.isArray(rows)) return false;
-  try { replaceOpenTabs(rows); return true; }
+  const slot = slotIdForSender(e.sender);
+  try { replaceOpenTabs(slot, rows); return true; }
   catch (err) { console.warn('[mid] tabs-replace failed:', (err as Error).message); return false; }
 });
+
+/**
+ * #308 — Detach a tab into its own BrowserWindow.
+ *
+ * The renderer calls this when the user drags a tab outside the window's
+ * bounds. We spawn a fresh BrowserWindow with the path passed via URL hash;
+ * the new renderer reads the hash on boot and seeds its strip with that one
+ * file. The origin renderer is responsible for closing the source tab — we
+ * don't reach across into its strip from main because the renderer already
+ * owns the open-tabs model and any side-channel mutation would race with its
+ * persist debounce.
+ */
+ipcMain.handle('mid:tabs-detach', async (_e, payload: { path: string; bounds?: { x?: number; y?: number } }) => {
+  if (!payload || typeof payload.path !== 'string' || !payload.path) {
+    return { ok: false, error: 'detach payload missing path' };
+  }
+  try {
+    const win = await createWindow({
+      detachedPath: payload.path,
+      bounds: { width: 900, height: 700, x: payload.bounds?.x, y: payload.bounds?.y },
+    });
+    return { ok: true, windowId: win.id };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+});
+
+/**
+ * #308 — Tell the renderer which window slot it belongs to. The renderer
+ * uses this to namespace any per-window UI state (e.g. document title) — it
+ * does NOT need to pass the slot back to tabs-list/replace because main
+ * derives the scope from the IPC sender directly.
+ */
+ipcMain.handle('mid:get-window-id', async (e) => slotIdForSender(e.sender));
 
 ipcMain.handle('mid:save-as', async (_e, defaultName: string, content: string | ArrayBuffer, filters: Electron.FileFilter[]) => {
   const result = await dialog.showSaveDialog({ defaultPath: defaultName, filters });
@@ -853,8 +993,10 @@ ipcMain.handle('mid:update-quit-and-install', async () => {
 });
 
 nativeTheme.on('updated', () => {
-  if (mainWindow) {
-    mainWindow.webContents.send('mid:theme-changed', nativeTheme.shouldUseDarkColors);
+  // #308 — broadcast theme to every window (main + detached) so a system
+  // mode flip propagates to all open editors.
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send('mid:theme-changed', nativeTheme.shouldUseDarkColors);
   }
 });
 
@@ -924,8 +1066,10 @@ function setupAutoUpdate(): void {
 }
 
 function broadcastUpdateState(): void {
-  if (mainWindow) {
-    mainWindow.webContents.send('mid:update-state', updateState);
+  // #308 — every window listens for update-state; broadcast so detached
+  // windows can also surface the update banner.
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send('mid:update-state', updateState);
   }
   // Reflect the change in the tray menu so "Check for Updates…" → "Downloading…"
   // → "Restart and install vX.Y.Z" all without the user re-opening the menu.

--- a/apps/electron/preload.ts
+++ b/apps/electron/preload.ts
@@ -68,10 +68,22 @@ contextBridge.exposeInMainWorld('mid', {
   recordExport: (row: { id: string; sourcePath?: string; format: string; filePath: string }): Promise<void> =>
     ipcRenderer.invoke('mid:record-export', row),
   // Tab persistence (#287) — renderer owns layout, main is a dumb store.
-  tabsList: (): Promise<{ strip_id: number; idx: number; path: string; active: number }[]> =>
+  // The window scope (window_id) is derived from the IPC sender on the main
+  // side (#308), so renderers don't pass it explicitly — keeps the wire
+  // format identical to the v0.2.5 single-window contract.
+  tabsList: (): Promise<{ window_id: number; strip_id: number; idx: number; path: string; active: number }[]> =>
     ipcRenderer.invoke('mid:tabs-list'),
-  tabsReplace: (rows: { strip_id: number; idx: number; path: string; active: number }[]): Promise<boolean> =>
+  tabsReplace: (rows: { window_id?: number; strip_id: number; idx: number; path: string; active: number }[]): Promise<boolean> =>
     ipcRenderer.invoke('mid:tabs-replace', rows),
+  // #308 — Detach a tab into its own BrowserWindow. The new window opens with
+  // the file pre-loaded as its only tab; the origin renderer is responsible
+  // for closing the source tab from its own strip.
+  tabsDetach: (payload: { path: string; bounds?: { x?: number; y?: number } }): Promise<{ ok: boolean; windowId?: number; error?: string }> =>
+    ipcRenderer.invoke('mid:tabs-detach', payload),
+  /** #308 — current window's persistence slot id. 0 for the main window,
+   * 1+ for detached windows. The renderer uses this purely for diagnostics
+   * (e.g. document title suffix); persistence is scoped automatically. */
+  getWindowId: (): Promise<number> => ipcRenderer.invoke('mid:get-window-id'),
   listExportHistory: (limit?: number): Promise<{ id: string; source_path: string; format: string; file_path: string; exported_at: number }[]> =>
     ipcRenderer.invoke('mid:list-export-history', limit),
   notesList: (workspace: string): Promise<NoteEntry[]> =>

--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -3240,3 +3240,25 @@ body.settings-open .mid-statusbar { visibility: hidden; }
 }
 .mid-tab__close:hover { background: var(--mid-surface-hover); color: var(--mid-fg); opacity: 1; }
 .mid-tab.is-active .mid-tab__close { opacity: 1; }
+
+/* Tab manager: window detach (#308).
+ *
+ * `.mid-detach-edge` is an overlay rectangle pinned to the entire content
+ * area; it lights up while a tab is being dragged outside the window's
+ * bounds, telegraphing that releasing here will spawn a fresh BrowserWindow.
+ * The overlay is `pointer-events: none` so it never interferes with the
+ * native HTML5 DnD gesture.
+ */
+.mid-detach-edge {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9000;
+  border: 2px dashed transparent;
+  border-radius: 6px;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.mid-detach-edge.is-active {
+  border-color: var(--mid-accent, var(--mid-link));
+  background: color-mix(in srgb, var(--mid-accent, var(--mid-link)) 6%, transparent);
+}

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -154,9 +154,18 @@ interface Mid {
   onMenuOpenFolder(cb: () => void): () => void;
   onMenuSave(cb: () => void): () => void;
   onMenuExport(cb: (format: 'md' | 'html' | 'pdf' | 'png' | 'txt' | 'docx' | 'docx-gdocs') => void): () => void;
-  // Tab persistence (#287)
-  tabsList(): Promise<{ strip_id: number; idx: number; path: string; active: number }[]>;
-  tabsReplace(rows: { strip_id: number; idx: number; path: string; active: number }[]): Promise<boolean>;
+  // Tab persistence (#287, #308). Wire format adds `window_id` so detached
+  // windows can persist independently; the renderer never sets it (main
+  // derives the scope from the IPC sender) but it surfaces in `tabsList`
+  // results for diagnostics.
+  tabsList(): Promise<{ window_id: number; strip_id: number; idx: number; path: string; active: number }[]>;
+  tabsReplace(rows: { window_id?: number; strip_id: number; idx: number; path: string; active: number }[]): Promise<boolean>;
+  // #308 — request main to spawn a new BrowserWindow with `path` as its only
+  // tab. Returns the new window's id (Electron BrowserWindow.id, not our
+  // persistence slot — the renderer doesn't need to know the slot).
+  tabsDetach(payload: { path: string; bounds?: { x?: number; y?: number } }): Promise<{ ok: boolean; windowId?: number; error?: string }>;
+  /** #308 — current window's persistence slot id (0 for main, 1+ for detached). */
+  getWindowId(): Promise<number>;
 }
 declare const window: Window & { mid: Mid };
 
@@ -6447,6 +6456,11 @@ void window.mid.readAppState().then(async state => {
   // #287 — restore the open-tabs strip from SQLite. Done after the folder
   // applies so the tree's active-row highlight has a chance to attach.
   await hydrateTabs();
+  // #308 — if this window was launched with a `detachedPath` URL hash and no
+  // persisted tabs hydrated, seed the strip with that single file so the new
+  // detached window opens directly to its source tab. Defined at the bottom
+  // of the file so the bottom block (tab-detach module) owns its lifecycle.
+  await maybeSeedFromDetachHash();
   // #303 — if the launched workspace has no warehouse, force-open the
   // onboarding modal regardless of the dismissed list. The dismissed list
   // only suppresses *during* a session (re-triggers from the welcome CTA,
@@ -6644,3 +6658,205 @@ interface ImportersMenuBridge {
   onMenuImport(cb: () => void): () => void;
 }
 ((window.mid as unknown as ImportersMenuBridge)).onMenuImport(() => void openImportersChooser());
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tab manager: window detach (#308)
+//
+// When a tab is dragged outside the window's bounds and dropped onto the OS
+// desktop (or another monitor), we ask main to spawn a fresh BrowserWindow
+// with that one file pre-loaded, then close the source tab in this window.
+// Each window owns its own SQLite slot for `open_tabs` (window-scoped by the
+// IPC sender, see main.ts), so the detached window persists independently
+// and a relaunch re-spawns it with its strip intact.
+//
+// All wiring lives at the bottom of renderer.ts so #309's split-screen patch
+// (concurrent track) doesn't conflict with the existing tab-manager block at
+// the top of the file. Detection uses a document-level `dragend` listener
+// rather than touching the per-tab handlers in renderTabstrip().
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface DetachBridge {
+  tabsDetach(payload: { path: string; bounds?: { x?: number; y?: number } }): Promise<{ ok: boolean; windowId?: number; error?: string }>;
+  getWindowId(): Promise<number>;
+}
+
+const detachBridge = window.mid as unknown as DetachBridge;
+
+/** During a tab drag, we capture the dragged tab's index + path so the
+ * dragend handler at the document level knows which row to detach if the
+ * drop lands outside the window. The per-tab dragstart handler in
+ * renderTabstrip() already sets the dataTransfer payload; we mirror it here
+ * because dataTransfer.getData() is empty during dragend in many browsers. */
+let detachPendingIdx: number | null = null;
+let detachPendingPath: string | null = null;
+
+/** Edge indicator that flashes along the active border to show the user that
+ * dropping outside will spawn a new window. The element is created lazily on
+ * first drag and reused thereafter; it lives in <body> so it overlays
+ * everything including the tabstrip. */
+let detachEdgeIndicator: HTMLDivElement | null = null;
+
+function ensureDetachEdgeIndicator(): HTMLDivElement {
+  if (detachEdgeIndicator) return detachEdgeIndicator;
+  const el = document.createElement('div');
+  el.className = 'mid-detach-edge';
+  el.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(el);
+  detachEdgeIndicator = el;
+  return el;
+}
+
+function showDetachEdge(visible: boolean): void {
+  const el = ensureDetachEdgeIndicator();
+  el.classList.toggle('is-active', visible);
+}
+
+function pointIsOutsideWindow(clientX: number, clientY: number): boolean {
+  // The renderer window's content area is `[0, innerWidth) x [0, innerHeight)`.
+  // Some browsers report `0/0` for `dragend` when the drop happens on the OS
+  // desktop or another window — treat that as outside. Otherwise check the
+  // bounds with a small slack so a near-miss (browser rounding) still counts.
+  if (clientX === 0 && clientY === 0) return true;
+  const slack = 4;
+  return (
+    clientX < -slack ||
+    clientY < -slack ||
+    clientX > window.innerWidth + slack ||
+    clientY > window.innerHeight + slack
+  );
+}
+
+/** Like `closeTabAt` but for the detach flow: don't push onto the
+ * recently-closed stack (the tab moved, it didn't close), and don't trigger
+ * the welcome state if it was the last tab — the operating system already
+ * shows the new window so the user doesn't need a fresh welcome screen. */
+function closeTabForDetach(idx: number): void {
+  if (idx < 0 || idx >= tabs.length) return;
+  tabs.splice(idx, 1);
+  if (tabs.length === 0) {
+    activeTabIndex = -1;
+    syncMirrorFromActiveTab();
+    if (currentMode === 'view') renderView();
+    else if (currentMode === 'edit') renderEdit();
+    else renderSplit();
+    renderTabstrip();
+    schedulePersistTabs();
+    return;
+  }
+  if (idx < activeTabIndex) {
+    activeTabIndex--;
+  } else if (idx === activeTabIndex) {
+    if (activeTabIndex >= tabs.length) activeTabIndex = tabs.length - 1;
+  }
+  syncMirrorFromActiveTab();
+  if (currentMode === 'view') renderView();
+  else if (currentMode === 'edit') renderEdit();
+  else renderSplit();
+  highlightActiveTreeItem();
+  updateWordCount();
+  updateSaveIndicator(true);
+  restoreScrollPosition();
+  renderTabstrip();
+  schedulePersistTabs();
+}
+
+document.addEventListener('dragstart', (ev) => {
+  // Only react if the drag started on a tab. We read dataset rather than
+  // the dataTransfer payload because the per-tab handler already populated
+  // both — and dataset is observable here without depending on the order
+  // event handlers run.
+  const target = ev.target as HTMLElement | null;
+  const tabEl = target?.closest?.('.mid-tab') as HTMLElement | null;
+  if (!tabEl) {
+    detachPendingIdx = null;
+    detachPendingPath = null;
+    return;
+  }
+  const idx = parseInt(tabEl.dataset.tabIndex ?? '', 10);
+  if (Number.isNaN(idx)) return;
+  detachPendingIdx = idx;
+  detachPendingPath = tabEl.dataset.tabPath ?? null;
+}, true);
+
+document.addEventListener('dragover', (ev) => {
+  if (detachPendingIdx == null) return;
+  // Only flash the edge once the cursor is near or past the window border —
+  // inside-strip reorders shouldn't show the detach affordance.
+  showDetachEdge(pointIsOutsideWindow(ev.clientX, ev.clientY));
+});
+
+document.addEventListener('dragend', async (ev) => {
+  // Always clear the indicator: a drop inside the strip ended the drag.
+  showDetachEdge(false);
+  const idx = detachPendingIdx;
+  const path = detachPendingPath;
+  detachPendingIdx = null;
+  detachPendingPath = null;
+  if (idx == null || !path) return;
+  if (!pointIsOutsideWindow(ev.clientX, ev.clientY)) return;
+  // Re-find the index by path because the strip may have re-rendered
+  // mid-drag (e.g. another async event) and shifted indices.
+  const liveIdx = findTabIndex(path);
+  if (liveIdx === -1) return;
+  // Detaching a sole-tab IS allowed — the origin window simply ends up with
+  // an empty strip (welcome state). The new window owns that file. The user
+  // can close either side independently.
+  // The ScreenX/ScreenY positions hint at where the user dropped, so the new
+  // window can pop near the cursor. We pass them as bounds for the new
+  // BrowserWindow — main clamps to the screen.
+  const bounds: { x?: number; y?: number } = {};
+  if (typeof ev.screenX === 'number' && ev.screenX > 0) bounds.x = Math.round(ev.screenX - 360);
+  if (typeof ev.screenY === 'number' && ev.screenY > 0) bounds.y = Math.round(ev.screenY - 80);
+  try {
+    const result = await detachBridge.tabsDetach({ path, bounds });
+    if (!result.ok) {
+      flashStatus(`Detach failed: ${result.error ?? 'unknown'}`);
+      return;
+    }
+    // Close the source tab without pushing onto recently-closed (the file
+    // didn't close — it moved windows).
+    closeTabForDetach(liveIdx);
+  } catch (err) {
+    flashStatus(`Detach failed: ${(err as Error).message}`);
+  }
+});
+
+/** Boot-time hash check for windows spawned by `mid:tabs-detach`. The new
+ * window's URL hash carries `detachedPath=<encoded>`. If we find one *and*
+ * the persisted strip for this slot is empty, seed the strip with that one
+ * file. (Re-spawned detached windows skip this branch because their strip
+ * hydrates from SQLite first.)
+ *
+ * Hash is consumed (cleared) after seeding so a refresh doesn't re-add a
+ * duplicate tab on top of the now-persisted strip. */
+async function maybeSeedFromDetachHash(): Promise<void> {
+  const raw = window.location.hash;
+  if (!raw) return;
+  const params = new URLSearchParams(raw.startsWith('#') ? raw.slice(1) : raw);
+  const detachedPath = params.get('detachedPath');
+  if (!detachedPath) return;
+  // Clear the hash so a renderer reload doesn't re-seed the same tab on top
+  // of the persisted strip. We use replaceState to avoid a navigation event.
+  try { history.replaceState(null, '', window.location.pathname); } catch { /* fine */ }
+  // If the strip already hydrated rows from SQLite (e.g. a re-spawned
+  // detached window picking up its persisted strip), respect that: the
+  // detachedPath was a one-shot from the original spawn and shouldn't fight
+  // the user's saved layout.
+  if (tabs.length > 0) return;
+  try {
+    const content = await window.mid.readFile(detachedPath);
+    loadFileContent(detachedPath, content);
+  } catch (err) {
+    console.warn('[mid] detached-path seed failed:', err);
+    flashStatus(`Could not open ${detachedPath.split('/').pop() ?? detachedPath}`);
+  }
+}
+
+// Surface the persistence slot id in the document title for diagnostics. The
+// main window keeps "Mark It Down" while detached windows append a small
+// suffix so the user can tell them apart in window managers.
+void detachBridge.getWindowId().then((slot) => {
+  if (slot && slot > 0) {
+    document.title = `Mark It Down — Window ${slot}`;
+  }
+}).catch(() => undefined);

--- a/docs/desktop-tabs.md
+++ b/docs/desktop-tabs.md
@@ -1,8 +1,8 @@
 # Desktop tabs
 
-VSCode-style multi-file tab manager for the Electron app (#287).
+VSCode-style multi-file tab manager for the Electron app (#287, #308).
 
-## What ships in v0.2.5 (MVP)
+## What ships in v0.2.5 (MVP, #287)
 
 - Tab strip above the editor when at least one file is open
 - Click any file in the tree → opens in the active strip
@@ -17,16 +17,33 @@ VSCode-style multi-file tab manager for the Electron app (#287).
 - Tabs persist across restart via the SQLite `open_tabs` table — including which
   tab was active
 
+## What ships next (#308 — window detach)
+
+- **Drag a tab outside the window's bounds** → main spawns a fresh
+  `BrowserWindow` with that one file pre-loaded as its only tab.
+- The origin window's tab is closed automatically (without pushing onto the
+  recently-closed stack — the file moved, it didn't close).
+- Each window has its own `open_tabs` slot in SQLite, so detached windows
+  persist independently. On next launch the app re-spawns one BrowserWindow
+  per persisted slot and each one rehydrates its own strip.
+- A dashed accent border lights up around the content area while the
+  cursor sits outside the window — visual cue that releasing here will
+  pop a new window.
+- Closing a detached window drops only that window's persisted rows (the
+  main window's slot is never cleared by close, so a normal quit + relaunch
+  rebuilds the main strip).
+- macOS still skips `app.quit()` when the last window closes — closing the
+  detached window doesn't take the origin down.
+
 ## Out of scope (deferred follow-ups)
 
-- **Window detach** — drag a tab outside the window to spawn a new
-  `BrowserWindow`. The IPC contract is sketched below; the wiring needs
-  main-process work that wasn't worth bundling into the MVP.
+- **Re-attach** — drag a tab from a detached window back into the main
+  window's strip to merge it back. Electron doesn't ship cross-window drag
+  out of the box, so this would need a custom `screen.getCursorScreenPoint()`
+  poll on `dragend` to find the destination window.
 - **Split-screen** — drop a tab onto the right edge of the strip to create a
   second column. The model already carries `stripId` so this is a renderer-only
-  change once the drop-target UI lands.
-
-Both follow-ups are filed as separate issues so the MVP ships green.
+  change once the drop-target UI lands. Tracked under #309.
 
 ## Layout model
 
@@ -85,20 +102,30 @@ Existing render code (`renderView`, `renderEdit`, `renderSplit`,
 
 ```sql
 CREATE TABLE open_tabs (
-  strip_id INTEGER NOT NULL,   -- 0 in MVP; reserved for split (1, 2, …)
-  idx      INTEGER NOT NULL,   -- ordering inside the strip
-  path     TEXT    NOT NULL,
-  active   INTEGER NOT NULL DEFAULT 0,  -- 1 for the focused tab in its strip
-  PRIMARY KEY (strip_id, idx)
+  window_id INTEGER NOT NULL DEFAULT 0,  -- #308 — main = 0, detached = 1+
+  strip_id  INTEGER NOT NULL,            -- 0 today; reserved for split (#309)
+  idx       INTEGER NOT NULL,            -- ordering inside the strip
+  path      TEXT    NOT NULL,
+  active    INTEGER NOT NULL DEFAULT 0,  -- 1 for the focused tab in its strip
+  PRIMARY KEY (window_id, strip_id, idx)
 );
-CREATE INDEX idx_open_tabs_strip ON open_tabs(strip_id, idx);
+CREATE INDEX idx_open_tabs_window ON open_tabs(window_id, strip_id, idx);
 ```
 
 The renderer is the source of truth: every meaningful mutation
 (open/close/move/cycle) calls `schedulePersistTabs()`, which debounces a 200ms
 snapshot and writes the entire set via `mid:tabs-replace`. We wipe-and-replace
-because the row count is small (typically <30) and the transaction keeps the
-swap atomic.
+*for that window only* because the row count is small (typically <30 per
+window) and the transaction keeps the swap atomic.
+
+The `window_id` scope is derived from the IPC sender on the main side, not
+trusted from the renderer payload. That keeps a misbehaving renderer from
+trampling another window's persisted rows.
+
+The main window always claims slot 0 (its rows pre-date the multi-window era
+and the column was added with a `DEFAULT 0` migration so existing installs
+just work). Detached windows allocate the smallest free slot ≥ 1; closing
+one releases its rows so the slot can be reused.
 
 On startup the renderer calls `mid:tabs-list`, reads each file from disk, and
 silently drops any path that no longer exists. The next persist tick collapses
@@ -108,11 +135,14 @@ the table back to the live set, so a deleted file naturally cleans itself up.
 
 | Channel              | Direction              | Payload / Result |
 |----------------------|------------------------|------------------|
-| `mid:tabs-list`      | renderer → main        | `() → OpenTabRow[]` |
-| `mid:tabs-replace`   | renderer → main        | `(rows: OpenTabRow[]) → boolean` |
+| `mid:tabs-list`      | renderer → main        | `() → OpenTabRow[]` (scoped to sender's window) |
+| `mid:tabs-replace`   | renderer → main        | `(rows: OpenTabRow[]) → boolean` (replaces sender's window's rows only) |
+| `mid:tabs-detach`    | renderer → main        | `({ path, bounds? }) → { ok, windowId?, error? }` (#308) |
+| `mid:get-window-id`  | renderer → main        | `() → number` (sender's persistence slot id; #308) |
 
 ```ts
 interface OpenTabRow {
+  window_id: number;    // present on read; ignored on write (main derives from sender)
   strip_id: number;
   idx: number;
   path: string;
@@ -122,37 +152,87 @@ interface OpenTabRow {
 
 The main process is intentionally dumb — it owns the SQLite write, nothing
 else. All ordering, dirty tracking, and active-tab arithmetic happens in the
-renderer.
+renderer. The one exception is `mid:tabs-detach`: spawning a `BrowserWindow`
+needs the main process, so the renderer asks main to do it.
 
-## Future: window detach (deferred)
+## Window detach (#308)
 
-When a tab is dragged outside the window bounds, the renderer should:
+### Renderer flow
 
-1. Detect the drag-end at a point outside `window.innerWidth/Height`
-2. `await window.mid.tabsDetach({ path, scrollTop })`
-3. Locally `closeTabAt(idx)` (without pushing onto the recently-closed stack)
+A document-level `dragend` listener (added at the bottom of `renderer.ts` so it
+doesn't conflict with the per-tab handlers in `renderTabstrip()`) watches every
+drag started on a `.mid-tab`. The dragstart capture stashes the source tab's
+`{ idx, path }` into module-scope state; the dragend handler:
 
-The proposed main-side handler:
+1. Checks `pointIsOutsideWindow(clientX, clientY)` — true when the cursor sits
+   outside `[0, innerWidth) x [0, innerHeight)` with a 4px slack, *or* when both
+   coords are zero (browsers report `0/0` when the drop lands on the OS desktop).
+2. Refuses to detach the only open tab (would just duplicate the source).
+3. Calls `window.mid.tabsDetach({ path, bounds })`. The bounds carry
+   `screenX/screenY` minus a small offset so the new window pops near the cursor.
+4. On success, runs `closeTabForDetach(idx)` — the same close path as the
+   normal close button but without pushing onto `recentlyClosedPaths` (the file
+   moved windows; `Cmd+Shift+T` should not bring it back to the source).
+
+While the cursor is outside the bounds, `.mid-detach-edge.is-active` paints a
+dashed accent border over the entire content area as the drop affordance.
+
+### Main-process flow
 
 ```ts
-ipcMain.handle('mid:tabs-detach', async (_e, payload: { path: string; scrollTop: number }) => {
-  const w = new BrowserWindow({
-    width: 720, height: 600,
-    webPreferences: { preload, contextIsolation: true, nodeIntegration: false, sandbox: true },
+ipcMain.handle('mid:tabs-detach', async (_e, payload: { path: string; bounds? }) => {
+  const win = await createWindow({
+    detachedPath: payload.path,
+    bounds: { width: 900, height: 700, x: payload.bounds?.x, y: payload.bounds?.y },
   });
-  await w.loadFile(rendererIndexPath, { query: { detachedPath: payload.path } });
-  // The renderer in the new window inspects `window.location.search` on boot
-  // and opens that single file as its only tab.
-  return { ok: true, windowId: w.id };
+  return { ok: true, windowId: win.id };
 });
 ```
 
-The detached window is a regular renderer instance with `tabs = [thatOne]`,
-so the existing strip + view/edit/split code "just works." A future enhancement
-re-attaches a tab if the user drags it back into the main window's strip — but
-that requires a cross-window drag protocol which Electron doesn't ship out of
-the box (we'd hand-roll it via `screen.getCursorScreenPoint()` polling on
-`dragend`).
+`createWindow()` was generalised: it takes an optional `detachedPath` and an
+optional explicit `slotId`. When `detachedPath` is set, the path is encoded
+into the file URL hash (`#detachedPath=...`) — hash survives `loadFile`, isn't
+part of the file:// path so CSP stays untouched, and the renderer reads it
+from `window.location.hash` on boot. The first window claims slot 0 (main);
+subsequent windows allocate the smallest free slot ≥ 1.
+
+### New-window seeding
+
+Right after `hydrateTabs()` finishes, the renderer calls
+`maybeSeedFromDetachHash()` which:
+
+1. Reads `window.location.hash` for `detachedPath`.
+2. Clears the hash with `history.replaceState` so a renderer reload doesn't
+   re-seed a duplicate tab on top of the now-persisted strip.
+3. Bails if the persisted strip already hydrated rows (re-spawned detached
+   windows on app launch take that path; the saved layout wins).
+4. Otherwise reads the file and calls `loadFileContent(path, content)` — which
+   pushes through `openTab` and `schedulePersistTabs` so the new slot is
+   populated on disk within the next 200ms tick.
+
+### Multi-window lifecycle
+
+- **Launch**: main spawns the main window (slot 0), then walks
+  `listOpenTabWindowIds()` and re-spawns one BrowserWindow per non-zero slot.
+  Each re-spawn skips the `detachedPath` argument so the renderer hydrates
+  from SQLite directly.
+- **Theme + update broadcasts**: previously sent only to `mainWindow`; now
+  iterate `BrowserWindow.getAllWindows()` so detached windows stay in sync.
+- **Close**: closing a detached window calls `clearOpenTabsForWindow(slotId)`
+  so its rows are dropped (the user explicitly closed the window; we don't
+  haunt them with stale rows on next launch). Closing the main window does
+  NOT clear slot 0 — its rows survive a quit + relaunch as before.
+- **macOS quit semantics**: unchanged — `app.on('window-all-closed')` still
+  short-circuits on darwin.
+
+### Stretch: re-attach (not implemented)
+
+Dragging a tab from a detached window back into the main window's strip would
+need a cross-window drag protocol. Electron doesn't expose one out of the box;
+the rough plan is to poll `screen.getCursorScreenPoint()` on `dragend` and
+match it against `BrowserWindow.getBounds()` to find the destination, then
+emit a custom IPC `mid:tabs-attach` to that window's renderer. Filed for a
+later iteration when the demand is real.
 
 ## Future: split-screen (deferred)
 


### PR DESCRIPTION
Closes #308

Builds on the v0.2.5 tab-manager MVP (#287, PR #310). Drag a tab past the window's edge and main spawns a fresh `BrowserWindow` with that file as its only tab; the origin window's tab is removed without polluting `Cmd+Shift+T`'s recently-closed stack (the file moved, it didn't close).

## Summary

- **Schema migration**: `open_tabs` gains `window_id` (`DEFAULT 0`) — additive ALTER so existing installs rehydrate untouched as the main window's slot 0. PK becomes `(window_id, strip_id, idx)`.
- **Main process**: `createWindow()` now accepts an optional `detachedPath` (passed via the file URL hash) and an explicit `slotId` for app-launch re-spawn. New IPCs: `mid:tabs-detach` (`{path, bounds}` → `{ok, windowId}`) and `mid:get-window-id`. The window-id scope on `mid:tabs-list` / `mid:tabs-replace` is derived from the IPC sender — never trusted from the payload, so a misbehaving renderer can't trample another window's rows. Theme + update broadcasts fan out to every `BrowserWindow`.
- **Renderer**: a document-level `dragend` (registered at the bottom of `renderer.ts` per the merge-conflict guidance with #309's split-screen track) snaps the drop point against `window.innerWidth/Height` (with 4px slack and a `0/0` fallback for OS-desktop drops). On out-of-bounds, calls `tabsDetach({path, bounds})` with `screenX/screenY` so the new window pops near the cursor, then runs `closeTabForDetach(idx)` — same shape as the normal close but skips `recentlyClosedPaths`. Visual feedback: the existing dragged-tab dim plus a new `.mid-detach-edge` overlay that paints a dashed accent border around the content area while the cursor is outside.
- **Boot seeding**: after `hydrateTabs()` finishes, `maybeSeedFromDetachHash()` reads `window.location.hash` for `detachedPath`, clears it via `replaceState`, and (only if the persisted strip was empty) calls `loadFileContent(path, content)`. Re-spawned windows hydrate from SQLite first, so saved layouts win over the spawn hint.
- **Lifecycle**: closing a detached window calls `clearOpenTabsForWindow(slotId)` so its rows are released. Slot 0 is never cleared on close (the main strip persists across quit/relaunch as before). On launch, main walks `listOpenTabWindowIds()` and spawns one `BrowserWindow` per non-zero slot — each one rehydrates its own strip.
- **Docs**: `docs/desktop-tabs.md` updated with the full multi-window lifecycle, the new IPC contract, and the renderer + main flow. The "Future: window detach (deferred)" sketch is replaced with the shipped wiring; "Future: split-screen" now points at #309.

## Acceptance criteria

- [x] Drag tab outside window → new window spawns with that single file.
- [x] Origin window loses the tab (and `Cmd+Shift+T` does NOT bring it back — it moved windows).
- [x] Both windows persist their tabs across restart (each has its own `window_id` slot).
- [x] Visual feedback during drag — existing `.is-dragging` 0.5 opacity on the source tab + new `.mid-detach-edge.is-active` dashed accent border around the content area while the cursor is outside.
- [x] Closing the new window doesn't take down the origin (existing macOS `window-all-closed` skip is unchanged).
- [x] Docs updated.

## Test plan

- [ ] Open two files, drag tab #2 onto the OS desktop. Verify new window spawns near drop point with that file as its only tab; origin keeps tab #1.
- [ ] Quit + relaunch the app. Verify both windows reopen with their respective strips intact.
- [ ] Edit a file, drag its tab outside. Verify the dirty bullet (`•`) and unsaved buffer move with it (the new window opens the file fresh from disk — by design, since we don't transfer in-memory buffer; this is documented behavior).
- [ ] Close the detached window. Verify the origin keeps running and its strip is unchanged.
- [ ] Drag tab inside the strip (existing reorder). Verify the detach edge does NOT light up — only out-of-bounds drops trigger detach.
- [ ] Drag the only open tab outside. Verify the origin enters the welcome state and the new window opens with that file.
- [ ] On macOS, close the main window with a detached one still open. Verify the dock icon stays alive (existing behavior).