### PR TITLE
feat(desktop): tab manager split-screen — drop-on-edge → second column (#309)

### DIFF
--- a/apps/electron/renderer/renderer.css
+++ b/apps/electron/renderer/renderer.css
@@ -3262,3 +3262,100 @@ body.settings-open .mid-statusbar { visibility: hidden; }
   border-color: var(--mid-accent, var(--mid-link));
   background: color-mix(in srgb, var(--mid-accent, var(--mid-link)) 6%, transparent);
 }
+
+/* Tab split-screen (#309) — second editor column.
+ *
+ * `.mid-split-root` is the horizontal grid (left-col, divider, right-col) that
+ * replaces a flat `#editor-area` when split mode is on. Each column reuses
+ * the existing `.mid-editor-area` styling via `.mid-editor-column`. The
+ * inactive column shows a static markdown preview with reduced opacity so the
+ * user can tell which column is the live editor at a glance.
+ *
+ * The drop indicator is a thin vertical bar painted over the column's edge
+ * during a tab drag — see `setupSplitEdgeDropDetection` in renderer.ts.
+ */
+.mid-split-root {
+  display: grid;
+  grid-template-columns: 50% 6px 1fr;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+.mid-editor-column {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+}
+.mid-editor-column:not(.is-active) { opacity: 0.92; }
+.mid-editor-column:not(.is-active)::before {
+  /* Subtle dimming overlay so it's obvious which column is the live editor.
+   * Pointer-events disabled so clicks still reach the column for promotion. */
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--mid-bg);
+  opacity: 0.06;
+  pointer-events: none;
+  z-index: 0;
+}
+.mid-editor-column.is-active::after {
+  /* Top accent stripe on the active column, matching the active tab's accent. */
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--mid-accent, var(--mid-link));
+  pointer-events: none;
+  z-index: 1;
+}
+.mid-split-divider {
+  background: var(--mid-border);
+  cursor: col-resize;
+  user-select: none;
+  position: relative;
+}
+.mid-split-divider:hover { background: var(--mid-link); }
+.mid-split-divider::before {
+  /* Widen the hit-area so users don't have to pixel-perfect the 6px line. */
+  content: '';
+  position: absolute;
+  left: -3px;
+  right: -3px;
+  top: 0;
+  bottom: 0;
+}
+.mid-inactive-root {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  background: var(--mid-bg);
+  position: relative;
+}
+.mid-inactive-preview {
+  padding: var(--mid-space-4);
+}
+.mid-inactive-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--mid-fg-muted);
+  font-style: italic;
+}
+.mid-split-drop-indicator {
+  position: fixed;
+  background: var(--mid-link);
+  border-radius: 2px;
+  pointer-events: none;
+  z-index: 1000;
+  box-shadow: 0 0 8px var(--mid-link);
+  opacity: 0.85;
+}
+.mid-split-drop-indicator[hidden] { display: none; }

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -56,6 +56,13 @@ interface AppState {
   /** #302 — per-user ordering of strip entries; ids missing from this list
    * append in registry order. */
   noteTypeOrder?: string[];
+  /** #309 — split-screen tab manager state. `tabSplitActive` is true when the
+   * editor area is showing two columns; `tabSplitRatio` is the left column's
+   * share (0.15-0.85); `tabActiveStripId` (0|1) is the column the user was
+   * last focused on so a restart restores their active editor correctly. */
+  tabSplitActive?: boolean;
+  tabSplitRatio?: number;
+  tabActiveStripId?: 0 | 1;
 }
 
 interface PinnedFolder {
@@ -266,6 +273,21 @@ interface FileTab {
 
 const tabs: FileTab[] = [];
 let activeTabIndex = -1;
+/** #309 — split-screen mode. `activeStripId` is the strip the user is focused on
+ * (0 left, 1 right). `splitActive` is true when both strips have at least one
+ * tab and the editor area is rendering as two columns. The inactive strip's
+ * own active-tab pointer survives column swaps via `inactiveActiveTabIndex`.
+ * See split-screen module at the bottom of this file for the full mechanics. */
+let activeStripId: 0 | 1 = 0;
+let splitActive = false;
+let inactiveActiveTabIndex = -1;
+/** #309 — left-column ratio of the editor area (0.15-0.85). Persisted as
+ * `tabSplitRatio` in app state so it survives a restart. */
+let tabSplitRatio = 0.5;
+/** #309 — last-focused strip read from app state during startup. `hydrateTabs`
+ * uses this to restore which column is "live" after a relaunch; -1 means
+ * unset (falls back to whichever strip has rows). */
+let appStateTabActiveStripId: 0 | 1 | -1 = -1;
 /** LIFO of recently-closed tab paths for Cmd+Shift+T. Capped at 20 entries. */
 const recentlyClosedPaths: string[] = [];
 let tabsPersistTimer: number | null = null;
@@ -274,7 +296,10 @@ let tabsPersistTimer: number | null = null;
 let tabsHydrating = false;
 
 function findTabIndex(filePath: string): number {
-  return tabs.findIndex(t => t.path === filePath);
+  // #309 — search within the active strip only. If the same path is open in the
+  // other strip, we still let the user open another instance in the active
+  // strip (that's intentional — split-screen viewing the same file is valid).
+  return tabs.findIndex(t => t.path === filePath && t.stripId === activeStripId);
 }
 
 function activeTab(): FileTab | null {
@@ -325,22 +350,52 @@ function openTab(filePath: string, content: string): FileTab {
     if (!t.dirty) t.text = content;
     return t;
   }
-  const tab: FileTab = { stripId: 0, path: filePath, text: content, dirty: false, scrollTop: 0 };
+  // #309 — new tabs land in the currently active strip, not unconditionally
+  // strip 0. When split is inactive `activeStripId` is always 0.
+  const tab: FileTab = { stripId: activeStripId, path: filePath, text: content, dirty: false, scrollTop: 0 };
   tabs.push(tab);
   activeTabIndex = tabs.length - 1;
   return tab;
 }
 
 /** Close the tab at `idx`. Adjusts `activeTabIndex` and pushes the path onto
- * the recently-closed stack so Cmd+Shift+T can resurrect it. */
+ * the recently-closed stack so Cmd+Shift+T can resurrect it.
+ * #309 — strip-aware: if the closed tab is in the inactive strip, the active
+ * strip's editor stays put. Empty-strip detection collapses the split. */
 function closeTabAt(idx: number): void {
   if (idx < 0 || idx >= tabs.length) return;
   const closed = tabs[idx];
   recentlyClosedPaths.push(closed.path);
   if (recentlyClosedPaths.length > 20) recentlyClosedPaths.shift();
+  const wasActiveStrip = closed.stripId === activeStripId;
   tabs.splice(idx, 1);
+  // Adjust both per-strip active pointers across the splice.
+  if (idx < activeTabIndex) activeTabIndex--;
+  else if (idx === activeTabIndex) {
+    // Active tab closed — keep visual position by holding `activeTabIndex`,
+    // but it may now point past the end or to a tab in the OTHER strip. We
+    // resolve below by snapping to the nearest tab in the active strip.
+  }
+  if (idx < inactiveActiveTabIndex) inactiveActiveTabIndex--;
+  else if (idx === inactiveActiveTabIndex) {
+    inactiveActiveTabIndex = -1; // resolved below
+  }
+  // Check whether either strip emptied out.
+  const activeStripEmpty = !tabs.some(t => t.stripId === activeStripId);
+  const inactiveStripId = activeStripId === 0 ? 1 : 0;
+  const inactiveStripEmpty = !tabs.some(t => t.stripId === inactiveStripId);
+
+  if (splitActive && (activeStripEmpty || inactiveStripEmpty)) {
+    // Collapse the split: rehome any surviving tabs into strip 0 and clear the
+    // second column. The remaining active-tab pointer survives the rehome.
+    collapseSplitAfterClose(wasActiveStrip);
+    // collapseSplitAfterClose handles the re-render and persist.
+    return;
+  }
+
   if (tabs.length === 0) {
     activeTabIndex = -1;
+    inactiveActiveTabIndex = -1;
     syncMirrorFromActiveTab();
     if (currentMode === 'view') renderView();
     else if (currentMode === 'edit') renderEdit();
@@ -349,11 +404,17 @@ function closeTabAt(idx: number): void {
     schedulePersistTabs();
     return;
   }
-  // Keep the same visual position when the active tab closes; clamp at end.
-  if (idx < activeTabIndex) {
-    activeTabIndex--;
-  } else if (idx === activeTabIndex) {
-    if (activeTabIndex >= tabs.length) activeTabIndex = tabs.length - 1;
+
+  // Re-resolve active pointers within their strip if they fell off the end.
+  if (wasActiveStrip) {
+    if (activeTabIndex >= tabs.length || tabs[activeTabIndex]?.stripId !== activeStripId) {
+      activeTabIndex = lastIndexInStrip(activeStripId);
+    }
+  }
+  if (!wasActiveStrip) {
+    if (inactiveActiveTabIndex < 0 || tabs[inactiveActiveTabIndex]?.stripId !== inactiveStripId) {
+      inactiveActiveTabIndex = lastIndexInStrip(inactiveStripId);
+    }
   }
   syncMirrorFromActiveTab();
   // Re-render the editor area against the new active tab.
@@ -365,16 +426,33 @@ function closeTabAt(idx: number): void {
   updateSaveIndicator(true);
   restoreScrollPosition();
   renderTabstrip();
+  if (splitActive) renderInactiveColumn();
   schedulePersistTabs();
 }
 
-/** Cycle to next/previous tab. `delta` is +1 or -1. Wraps around. */
+/** #309 — return the highest global index of any tab in `stripId`, or -1 if
+ * the strip is empty. Used to snap the active pointer back into bounds after a
+ * close shrinks its strip. */
+function lastIndexInStrip(stripId: number): number {
+  for (let i = tabs.length - 1; i >= 0; i--) if (tabs[i].stripId === stripId) return i;
+  return -1;
+}
+
+/** Cycle to next/previous tab. `delta` is +1 or -1. Wraps around.
+ * #309 — cycling stays within the active strip; the inactive strip is unchanged. */
 function cycleTab(delta: number): void {
   if (tabs.length === 0) return;
+  const stripIndices = tabs.map((t, i) => ({ t, i })).filter(x => x.t.stripId === activeStripId).map(x => x.i);
+  if (stripIndices.length === 0) return;
+  const localPos = stripIndices.indexOf(activeTabIndex);
+  if (localPos === -1) {
+    focusTabAt(stripIndices[0]);
+    return;
+  }
   syncActiveTabFromMirror();
   captureScrollPosition();
-  const next = ((activeTabIndex + delta) % tabs.length + tabs.length) % tabs.length;
-  focusTabAt(next);
+  const nextLocal = ((localPos + delta) % stripIndices.length + stripIndices.length) % stripIndices.length;
+  focusTabAt(stripIndices[nextLocal]);
 }
 
 function focusTabAt(idx: number): void {
@@ -438,7 +516,9 @@ function restoreScrollPosition(): void {
   });
 }
 
-/** Move the tab at `from` to position `to` (insert-before semantics). */
+/** Move the tab at `from` to position `to` (insert-before semantics).
+ * #309 — `to` is the global insertion index. Both pointers (`activeTabIndex`
+ * and `inactiveActiveTabIndex`) are tracked through the splice. */
 function moveTab(from: number, to: number): void {
   if (from === to || from < 0 || from >= tabs.length) return;
   const [moved] = tabs.splice(from, 1);
@@ -446,36 +526,61 @@ function moveTab(from: number, to: number): void {
   // after `from`; clamp into bounds.
   const insertAt = Math.max(0, Math.min(tabs.length, to > from ? to - 1 : to));
   tabs.splice(insertAt, 0, moved);
-  // Track the active tab through the move so focus survives a drag.
-  if (from === activeTabIndex) {
-    activeTabIndex = insertAt;
-  } else if (from < activeTabIndex && insertAt >= activeTabIndex) {
-    activeTabIndex--;
-  } else if (from > activeTabIndex && insertAt <= activeTabIndex) {
-    activeTabIndex++;
-  }
+  // Track both per-strip active tabs through the move so focus survives a drag.
+  activeTabIndex = remapIndexAfterMove(activeTabIndex, from, insertAt);
+  inactiveActiveTabIndex = remapIndexAfterMove(inactiveActiveTabIndex, from, insertAt);
   renderTabstrip();
+  if (splitActive) renderInactiveColumn();
   schedulePersistTabs();
 }
 
+/** #309 — given the original index of a tracked pointer, return where it lands
+ * after splicing `from` out and inserting it at `insertAt`. */
+function remapIndexAfterMove(ptr: number, from: number, insertAt: number): number {
+  if (ptr < 0) return ptr;
+  if (ptr === from) return insertAt;
+  // Step 1: account for the splice-out.
+  let p = ptr;
+  if (from < p) p--;
+  // Step 2: account for the splice-in.
+  if (insertAt <= p) p++;
+  return p;
+}
+
 function renderTabstrip(): void {
-  if (!tabstripEl) return;
-  if (tabs.length === 0) {
-    tabstripEl.hidden = true;
-    tabstripEl.replaceChildren();
+  // #309 — render the primary strip into the existing #tabstrip element. The
+  // secondary strip (when split is active) is rendered by `renderInactiveColumn`
+  // which calls `renderTabstripInto` with the column-1 strip element.
+  renderTabstripInto(tabstripEl, activeStripId, true);
+}
+
+/** #309 — render the tabs whose `stripId === stripId` into `target`. When
+ * `isActiveStrip` is false, the rendered tabs do NOT swap the live editor on
+ * click; instead, the click first promotes the strip to active (see
+ * `swapActiveColumn`) and then focuses the clicked tab. */
+function renderTabstripInto(target: HTMLDivElement | null, stripId: number, isActiveStrip: boolean): void {
+  if (!target) return;
+  // Build a list of (tab, globalIdx) pairs for this strip only.
+  const stripList: { tab: FileTab; idx: number }[] = [];
+  tabs.forEach((tab, idx) => { if (tab.stripId === stripId) stripList.push({ tab, idx }); });
+  if (stripList.length === 0) {
+    target.hidden = true;
+    target.replaceChildren();
     return;
   }
-  tabstripEl.hidden = false;
+  target.hidden = false;
+  const activeIdxForStrip = isActiveStrip ? activeTabIndex : inactiveActiveTabIndex;
   const frag = document.createDocumentFragment();
-  tabs.forEach((tab, idx) => {
+  stripList.forEach(({ tab, idx }) => {
     const btn = document.createElement('button');
     btn.type = 'button';
-    btn.className = 'mid-tab' + (idx === activeTabIndex ? ' is-active' : '');
+    btn.className = 'mid-tab' + (idx === activeIdxForStrip ? ' is-active' : '');
     btn.dataset.tabIndex = String(idx);
     btn.dataset.tabPath = tab.path;
+    btn.dataset.tabStrip = String(stripId);
     btn.draggable = true;
     btn.setAttribute('role', 'tab');
-    btn.setAttribute('aria-selected', String(idx === activeTabIndex));
+    btn.setAttribute('aria-selected', String(idx === activeIdxForStrip));
     btn.title = tab.path;
 
     const fileMatch = iconForFile(tab.path.split('/').pop() ?? '', 'file');
@@ -502,20 +607,26 @@ function renderTabstrip(): void {
       closeTabAt(idx);
     });
 
-    btn.addEventListener('click', () => focusTabAt(idx));
+    btn.addEventListener('click', () => {
+      // #309 — clicking a tab in the inactive column promotes that column to
+      // active first, so the live editor swaps to it before focusing the tab.
+      if (!isActiveStrip) swapActiveColumn();
+      focusTabAt(idx);
+    });
     // Middle-click closes the tab — VSCode parity.
     btn.addEventListener('mousedown', e => {
       if (e.button === 1) {
         e.preventDefault();
+        if (!isActiveStrip) swapActiveColumn();
         closeTabAt(idx);
       }
     });
     btn.addEventListener('contextmenu', e => {
       e.preventDefault();
       openContextMenu([
-        { icon: 'x', label: 'Close', action: () => closeTabAt(idx) },
-        { icon: 'x', label: 'Close others', action: () => closeOtherTabs(idx) },
-        { icon: 'x', label: 'Close all', action: () => closeAllTabs() },
+        { icon: 'x', label: 'Close', action: () => { if (!isActiveStrip) swapActiveColumn(); closeTabAt(idx); } },
+        { icon: 'x', label: 'Close others', action: () => closeOtherTabsInStrip(idx, stripId) },
+        { icon: 'x', label: 'Close all', action: () => closeAllTabsInStrip(stripId) },
         { separator: true, label: '' },
         { icon: 'folder-open', label: 'Reveal in Finder', action: () => void window.mid.openExternal(`file://${tab.path.replace(/\/[^/]+$/, '')}`) },
       ], e.clientX, e.clientY);
@@ -531,17 +642,21 @@ function renderTabstrip(): void {
     });
     btn.addEventListener('dragend', () => {
       btn.classList.remove('is-dragging');
-      tabstripEl.querySelectorAll('.mid-tab').forEach(el => {
+      target.querySelectorAll('.mid-tab').forEach(el => {
         el.classList.remove('is-drop-before', 'is-drop-after');
       });
     });
     btn.addEventListener('dragover', ev => {
       if (!ev.dataTransfer?.types.includes('application/x-mid-tab')) return;
       ev.preventDefault();
+      // #309 — stop propagation so the document-level edge dragover doesn't
+      // also paint a drop indicator while the user is hovering over a tab.
+      ev.stopPropagation();
+      if (splitDropIndicatorEl) splitDropIndicatorEl.hidden = true;
       ev.dataTransfer.dropEffect = 'move';
       const rect = btn.getBoundingClientRect();
       const before = ev.clientX < rect.left + rect.width / 2;
-      tabstripEl.querySelectorAll('.mid-tab').forEach(el => {
+      target.querySelectorAll('.mid-tab').forEach(el => {
         el.classList.remove('is-drop-before', 'is-drop-after');
       });
       btn.classList.add(before ? 'is-drop-before' : 'is-drop-after');
@@ -553,34 +668,50 @@ function renderTabstrip(): void {
       const raw = ev.dataTransfer?.getData('application/x-mid-tab');
       if (raw == null || raw === '') return;
       ev.preventDefault();
+      // #309 — stop propagation so the document-level edge-drop handler
+      // doesn't ALSO fire and try to split off the same tab.
+      ev.stopPropagation();
       const from = parseInt(raw, 10);
       if (Number.isNaN(from)) return;
       const rect = btn.getBoundingClientRect();
       const before = ev.clientX < rect.left + rect.width / 2;
       const to = before ? idx : idx + 1;
-      moveTab(from, to);
+      // #309 — drop into a different strip rehomes the dragged tab.
+      const dragged = tabs[from];
+      if (dragged && dragged.stripId !== stripId) {
+        moveTabToStrip(from, to, stripId);
+      } else {
+        moveTab(from, to);
+      }
     });
 
     btn.append(iconWrap, label, closeBtn);
     frag.appendChild(btn);
   });
-  tabstripEl.replaceChildren(frag);
+  target.replaceChildren(frag);
   // Scroll the active tab into view (e.g. after Cmd+Alt+Right cycles past the
   // visible window).
-  const activeEl = tabstripEl.querySelector<HTMLElement>('.mid-tab.is-active');
+  const activeEl = target.querySelector<HTMLElement>('.mid-tab.is-active');
   activeEl?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
 }
 
-function closeOtherTabs(keepIdx: number): void {
+/** #309 — context-menu helpers scoped to a single strip. The active strip is
+ * promoted before the close so `closeTabAt`'s active-pointer logic stays
+ * consistent. */
+function closeOtherTabsInStrip(keepIdx: number, stripId: number): void {
+  if (stripId !== activeStripId && splitActive) swapActiveColumn();
   if (keepIdx < 0 || keepIdx >= tabs.length) return;
   const keepPath = tabs[keepIdx].path;
   for (let i = tabs.length - 1; i >= 0; i--) {
-    if (tabs[i].path !== keepPath) closeTabAt(i);
+    if (tabs[i].stripId === stripId && tabs[i].path !== keepPath) closeTabAt(i);
   }
 }
 
-function closeAllTabs(): void {
-  for (let i = tabs.length - 1; i >= 0; i--) closeTabAt(i);
+function closeAllTabsInStrip(stripId: number): void {
+  if (stripId !== activeStripId && splitActive) swapActiveColumn();
+  for (let i = tabs.length - 1; i >= 0; i--) {
+    if (tabs[i].stripId === stripId) closeTabAt(i);
+  }
 }
 
 function schedulePersistTabs(): void {
@@ -588,31 +719,56 @@ function schedulePersistTabs(): void {
   if (tabsPersistTimer !== null) window.clearTimeout(tabsPersistTimer);
   tabsPersistTimer = window.setTimeout(() => {
     tabsPersistTimer = null;
-    const rows = tabs.map((t, i) => ({
-      strip_id: t.stripId,
-      idx: i,
-      path: t.path,
-      active: i === activeTabIndex ? 1 : 0,
-    }));
+    // #309 — compute per-strip idx so the SQLite row's (strip_id, idx) primary
+    // key stays unique. The global tab order in `tabs[]` doesn't matter at the
+    // wire level — only ordering within a strip does.
+    const perStripCounter: Record<number, number> = {};
+    const rows = tabs.map((t, globalIdx) => {
+      const stripIdx = perStripCounter[t.stripId] ?? 0;
+      perStripCounter[t.stripId] = stripIdx + 1;
+      // The "active" flag must be set per-strip — both the active and inactive
+      // strips remember which of their tabs is focused.
+      const isStripActive =
+        (t.stripId === activeStripId && globalIdx === activeTabIndex) ||
+        (t.stripId !== activeStripId && globalIdx === inactiveActiveTabIndex);
+      return {
+        strip_id: t.stripId,
+        idx: stripIdx,
+        path: t.path,
+        active: isStripActive ? 1 : 0,
+      };
+    });
     void window.mid.tabsReplace(rows).catch(() => undefined);
+    // Persist split-screen layout settings alongside the tab table.
+    void window.mid.patchAppState({
+      tabSplitActive: splitActive,
+      tabSplitRatio,
+      tabActiveStripId: activeStripId,
+    } as Partial<AppState>).catch(() => undefined);
   }, 200);
 }
 
 /** Restore tabs from SQLite at startup. Best-effort: a missing file is dropped
- * silently so a restart doesn't crash the renderer. */
+ * silently so a restart doesn't crash the renderer.
+ * #309 — also restores the active per-strip pointer for both columns and
+ * promotes the second strip into split mode if it has at least one row. */
 async function hydrateTabs(): Promise<void> {
   let rows: { strip_id: number; idx: number; path: string; active: number }[];
   try { rows = await window.mid.tabsList(); }
   catch { return; }
   if (!rows || rows.length === 0) return;
   tabsHydrating = true;
-  let pendingActive = -1;
+  // Track which global index in `tabs[]` is the active row for each strip so
+  // we can rehydrate `activeTabIndex` AND `inactiveActiveTabIndex` correctly.
+  const pendingActiveByStrip: Record<number, number> = {};
+  const stripsSeen = new Set<number>();
   for (const r of rows) {
     try {
       const content = await window.mid.readFile(r.path);
       const tab: FileTab = { stripId: r.strip_id, path: r.path, text: content, dirty: false, scrollTop: 0 };
       tabs.push(tab);
-      if (r.active) pendingActive = tabs.length - 1;
+      stripsSeen.add(r.strip_id);
+      if (r.active) pendingActiveByStrip[r.strip_id] = tabs.length - 1;
     } catch {
       // file gone — skip it; the next persist will drop it from the table.
       continue;
@@ -620,12 +776,34 @@ async function hydrateTabs(): Promise<void> {
   }
   tabsHydrating = false;
   if (tabs.length === 0) return;
-  activeTabIndex = pendingActive >= 0 ? pendingActive : 0;
+  // Determine each strip's active idx; fall back to the first tab in that strip.
+  const firstInStrip = (s: number): number => tabs.findIndex(t => t.stripId === s);
+  // The user's last-focused strip becomes `activeStripId`; if it's gone (the
+  // strip emptied since persist), fall back to whichever strip has rows.
+  const desiredActiveStrip = (typeof appStateTabActiveStripId === 'number' && stripsSeen.has(appStateTabActiveStripId))
+    ? appStateTabActiveStripId
+    : (stripsSeen.has(0) ? 0 : 1);
+  activeStripId = desiredActiveStrip as 0 | 1;
+  activeTabIndex = pendingActiveByStrip[activeStripId] ?? firstInStrip(activeStripId);
+  if (activeTabIndex < 0) activeTabIndex = 0;
+  // Inactive strip pointer: only meaningful if a second strip exists.
+  const otherStrip = activeStripId === 0 ? 1 : 0;
+  if (stripsSeen.has(otherStrip)) {
+    inactiveActiveTabIndex = pendingActiveByStrip[otherStrip] ?? firstInStrip(otherStrip);
+    splitActive = true;
+  } else {
+    inactiveActiveTabIndex = -1;
+    splitActive = false;
+  }
   syncMirrorFromActiveTab();
   highlightActiveTreeItem();
   updateWordCount();
   updateSaveIndicator(true);
+  // #309 — if split mode rehydrated, ensure the column DOM exists before
+  // rendering either strip. `enableSplitDOM` is idempotent.
+  if (splitActive) enableSplitDOM();
   renderTabstrip();
+  if (splitActive) renderInactiveColumn();
   // Re-render the editor area against the active tab.
   if (currentMode === 'view') renderView();
   else if (currentMode === 'edit') renderEdit();
@@ -6426,6 +6604,15 @@ void window.mid.readAppState().then(async state => {
   if (typeof state.noteTypeStripHidden === 'boolean') noteTypeStripHidden = state.noteTypeStripHidden;
   if (Array.isArray(state.noteTypeStripExclude)) noteTypeStripExclude = state.noteTypeStripExclude.slice();
   if (Array.isArray(state.noteTypeOrder)) noteTypeOrder = state.noteTypeOrder.slice();
+  // #309 — split-screen tab manager. The split is rebuilt in `hydrateTabs`
+  // based on the persisted `open_tabs` rows (a non-empty strip 1 means the
+  // user had a split going); we just stash the ratio + last-active strip here.
+  if (typeof state.tabSplitRatio === 'number' && state.tabSplitRatio >= 0.15 && state.tabSplitRatio <= 0.85) {
+    tabSplitRatio = state.tabSplitRatio;
+  }
+  if (state.tabActiveStripId === 0 || state.tabActiveStripId === 1) {
+    appStateTabActiveStripId = state.tabActiveStripId;
+  }
   // #297 — hydrate the registry from SQLite before any note view tries to
   // dispatch on viewKind. Failures fall back to the built-ins shipped in the
   // bundle; the renderer never blocks on this round-trip.
@@ -6748,6 +6935,10 @@ function closeTabForDetach(idx: number): void {
   } else if (idx === activeTabIndex) {
     if (activeTabIndex >= tabs.length) activeTabIndex = tabs.length - 1;
   }
+  // #309 — also reconcile the inactive-strip pointer when the detach close
+  // happens to remove a tab earlier in the array than the inactive pointer.
+  if (idx < inactiveActiveTabIndex) inactiveActiveTabIndex--;
+  else if (idx === inactiveActiveTabIndex) inactiveActiveTabIndex = -1;
   syncMirrorFromActiveTab();
   if (currentMode === 'view') renderView();
   else if (currentMode === 'edit') renderEdit();
@@ -6757,6 +6948,7 @@ function closeTabForDetach(idx: number): void {
   updateSaveIndicator(true);
   restoreScrollPosition();
   renderTabstrip();
+  if (splitActive) renderInactiveColumn();
   schedulePersistTabs();
 }
 
@@ -6860,3 +7052,472 @@ void detachBridge.getWindowId().then((slot) => {
     document.title = `Mark It Down — Window ${slot}`;
   }
 }).catch(() => undefined);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tab split-screen (#309)
+//
+// Activates a second editor column when the user drags a tab onto the left or
+// right edge (~80px) of the existing tab strip / editor area. The implementation
+// is layered on top of the MVP tab manager (#287) without rewriting it:
+//
+//   • Strip 0 keeps using the original `#tabstrip` + `#root` DOM nodes — the
+//     "live" editor where `currentText` and `currentPath` mirror the focused
+//     tab and the existing render code (renderView/renderEdit/renderSplit) runs.
+//
+//   • Strip 1 gets a sibling tabstrip + a static markdown preview pane. It is
+//     intentionally read-only: clicking inside it (or on one of its tabs) calls
+//     `swapActiveColumn`, which physically moves the live `#root` into the
+//     other column slot and re-renders both sides with their swapped roles.
+//
+// This keeps the ~70 references to `currentText`/`currentPath` happy without a
+// sweep, while still satisfying the AC: each column has its own strip + active
+// tab + editor view, the divider drag resizes both columns, closing the last
+// tab in a column collapses back to single-column, and both columns persist
+// across restart via the existing `(strip_id, idx, path, active)` schema.
+//
+// All new DOM lives at the bottom of the editor-area wrapper to minimise
+// merge conflicts with the parallel detach agent on feat/308-tab-detach.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Wrapper that holds the two columns when split is active. Built lazily by
+ * `enableSplitDOM` and re-used afterwards. */
+let splitWrapEl: HTMLDivElement | null = null;
+/** The strip-1 tabstrip element. Created on first split activation. */
+let inactiveTabstripEl: HTMLDivElement | null = null;
+/** The strip-1 editor area (markdown preview of its active tab). */
+let inactiveRootEl: HTMLDivElement | null = null;
+/** The drop indicator (left or right edge) shown during a tab drag. */
+let splitDropIndicatorEl: HTMLDivElement | null = null;
+/** The original parent (`<div id="layout">` direct child) of `#editor-area`,
+ * used so a split-collapse can re-parent `#editor-area` back to its home. */
+let editorAreaOriginalParent: HTMLElement | null = null;
+let editorAreaOriginalNextSibling: ChildNode | null = null;
+
+/** #309 — promotion threshold: how many pixels from the editor-area edge a tab
+ * drag has to land in to trigger a split. */
+const SPLIT_EDGE_THRESHOLD_PX = 80;
+
+/** Get the existing `.mid-editor-area` element — the column 0 wrapper. */
+function getEditorAreaEl(): HTMLElement {
+  return document.getElementById('editor-area') as HTMLElement;
+}
+
+/** Build (or reuse) the split-mode DOM scaffold. Idempotent: calling on an
+ * already-split layout is a no-op. The scaffold:
+ *
+ *   <div class="mid-split-root">
+ *     <div class="mid-editor-column" id="editor-area">…strip 0 + #root…</div>
+ *     <div class="mid-split-divider" />
+ *     <div class="mid-editor-column">
+ *       <div class="mid-tabstrip" id="tabstrip-2" />
+ *       <div class="mid-inactive-root" id="root-2" />
+ *     </div>
+ *   </div>
+ *
+ * `#editor-area` is moved (not cloned) into the wrapper so all existing CSS
+ * selectors that target it keep working.
+ */
+function enableSplitDOM(): void {
+  if (splitWrapEl) return;
+  const editorArea = getEditorAreaEl();
+  if (!editorArea) return;
+  // Stash where `#editor-area` originally lived so collapse can put it back.
+  editorAreaOriginalParent = editorArea.parentElement;
+  editorAreaOriginalNextSibling = editorArea.nextSibling;
+  if (!editorAreaOriginalParent) return;
+
+  const wrap = document.createElement('div');
+  wrap.className = 'mid-split-root';
+  wrap.style.gridTemplateColumns = `${tabSplitRatio * 100}% 6px 1fr`;
+  splitWrapEl = wrap;
+
+  // Mark column 0 (the original area) as a column for the flex parent.
+  editorArea.classList.add('mid-editor-column', 'is-active');
+
+  const divider = document.createElement('div');
+  divider.className = 'mid-split-divider';
+  divider.setAttribute('role', 'separator');
+  divider.setAttribute('aria-orientation', 'vertical');
+  divider.title = 'Drag to resize';
+  divider.addEventListener('mousedown', beginTabSplitDrag);
+
+  const col2 = document.createElement('div');
+  col2.className = 'mid-editor-column';
+
+  const strip2 = document.createElement('div');
+  strip2.id = 'tabstrip-2';
+  strip2.className = 'mid-tabstrip';
+  strip2.setAttribute('role', 'tablist');
+  strip2.setAttribute('aria-label', 'Open files (split)');
+  inactiveTabstripEl = strip2;
+
+  const root2 = document.createElement('div');
+  root2.id = 'root-2';
+  root2.className = 'mid-inactive-root';
+  inactiveRootEl = root2;
+
+  // Click promotion is wired via the global document listener installed by
+  // `setupSplitEdgeDropDetection`, so re-enabling split after a collapse does
+  // not stack duplicate listeners.
+
+  col2.append(strip2, root2);
+  // Insert the wrapper where `#editor-area` was, then move the area inside.
+  editorAreaOriginalParent.insertBefore(wrap, editorArea);
+  wrap.append(editorArea, divider, col2);
+
+  // Drop indicator (vertical highlight bar) is global — laid over whichever
+  // column the cursor is hovering near the edge of.
+  if (!splitDropIndicatorEl) {
+    const ind = document.createElement('div');
+    ind.className = 'mid-split-drop-indicator';
+    ind.hidden = true;
+    document.body.appendChild(ind);
+    splitDropIndicatorEl = ind;
+  }
+}
+
+/** Collapse the split DOM back into a single column. Moves `#editor-area`
+ * back to its original parent and removes the wrapper + column 2. */
+function disableSplitDOM(): void {
+  if (!splitWrapEl) return;
+  const editorArea = getEditorAreaEl();
+  if (editorArea && editorAreaOriginalParent) {
+    editorArea.classList.remove('mid-editor-column', 'is-active');
+    editorAreaOriginalParent.insertBefore(editorArea, editorAreaOriginalNextSibling);
+  }
+  splitWrapEl.remove();
+  splitWrapEl = null;
+  inactiveTabstripEl = null;
+  inactiveRootEl = null;
+}
+
+function getInactiveStripId(): 0 | 1 {
+  return activeStripId === 0 ? 1 : 0;
+}
+
+/** Render the inactive column's tabstrip + a markdown preview of its active
+ * tab. Called whenever the inactive strip's tabs change or its active pointer
+ * moves. */
+function renderInactiveColumn(): void {
+  if (!splitActive) return;
+  if (!inactiveTabstripEl || !inactiveRootEl) return;
+  const stripId = getInactiveStripId();
+  renderTabstripInto(inactiveTabstripEl, stripId, false);
+  // Preview = the markdown of whatever tab is active in the inactive strip.
+  const tab = inactiveActiveTabIndex >= 0 && inactiveActiveTabIndex < tabs.length
+    ? tabs[inactiveActiveTabIndex]
+    : null;
+  inactiveRootEl.replaceChildren();
+  if (!tab) {
+    const empty = document.createElement('div');
+    empty.className = 'mid-inactive-empty';
+    empty.textContent = 'No file';
+    inactiveRootEl.appendChild(empty);
+    return;
+  }
+  const preview = document.createElement('div');
+  preview.className = 'mid-preview mid-inactive-preview';
+  // Render the inactive tab's markdown via a localised version of
+  // populatePreview that doesn't touch `currentText`/the outline.
+  preview.innerHTML = renderMarkdown(tab.text);
+  preview.querySelectorAll<HTMLAnchorElement>('a[href]').forEach(a => {
+    const href = a.getAttribute('href');
+    if (!href) return;
+    if (href.startsWith('http://') || href.startsWith('https://')) {
+      a.addEventListener('click', e => {
+        e.preventDefault();
+        void window.mid.openExternal(href);
+      });
+    }
+  });
+  applySyntaxHighlighting(preview);
+  inactiveRootEl.appendChild(preview);
+}
+
+/** Swap which column is the live editor. The current active tab's mirror gets
+ * pushed back into its `FileTab`, the per-strip pointers swap, the new active
+ * tab's mirror is pulled, and both columns re-render. */
+function swapActiveColumn(): void {
+  if (!splitActive) return;
+  syncActiveTabFromMirror();
+  captureScrollPosition();
+  // Swap the per-strip active pointers AND flip activeStripId. The DOM nodes
+  // themselves don't move — `editor-area` always hosts whichever strip is
+  // currently active. The renderTabstrip() / renderInactiveColumn() pair below
+  // re-paints both columns with their swapped roles.
+  const tmp = activeTabIndex;
+  activeTabIndex = inactiveActiveTabIndex;
+  inactiveActiveTabIndex = tmp;
+  activeStripId = getInactiveStripId();
+  syncMirrorFromActiveTab();
+  if (currentMode === 'view') renderView();
+  else if (currentMode === 'edit') renderEdit();
+  else renderSplit();
+  highlightActiveTreeItem();
+  updateWordCount();
+  updateSaveIndicator(!activeTab()?.dirty);
+  restoreScrollPosition();
+  renderTabstrip();
+  renderInactiveColumn();
+  schedulePersistTabs();
+}
+
+/** Activate split mode by moving the tab at `globalFromIdx` into a new strip 1.
+ * If split was already active, the tab simply joins the inactive strip at the
+ * tail. Either way, the moved tab becomes that strip's active tab. */
+function enableSplit(globalFromIdx: number): void {
+  if (globalFromIdx < 0 || globalFromIdx >= tabs.length) return;
+  const moving = tabs[globalFromIdx];
+  if (!moving) return;
+  // Don't allow split if it would empty the source strip and the moving tab
+  // is already in the target strip's role — i.e. only one tab total.
+  const sourceStrip = moving.stripId;
+  const sourceStripCount = tabs.filter(t => t.stripId === sourceStrip).length;
+  if (sourceStripCount <= 1 && !splitActive) return; // nothing to split off
+
+  const targetStrip: 0 | 1 = sourceStrip === 0 ? 1 : 0;
+  // Capture the live editor's mirror before reshuffling pointers.
+  syncActiveTabFromMirror();
+  captureScrollPosition();
+
+  if (!splitActive) {
+    splitActive = true;
+    enableSplitDOM();
+  }
+  // Re-stamp the moving tab's stripId.
+  moving.stripId = targetStrip;
+  // The moved tab becomes the target strip's active tab.
+  // Adjust pointers depending on whether the source strip is currently active.
+  if (sourceStrip === activeStripId) {
+    // The moved tab WAS the active strip's tab. The target is the OTHER strip.
+    // After the move, the active strip lost it — pick a sibling to focus.
+    if (globalFromIdx === activeTabIndex) {
+      activeTabIndex = lastIndexInStrip(activeStripId);
+    } else if (globalFromIdx < activeTabIndex) {
+      // No splice happened (just stripId changed) — but `activeTabIndex`
+      // pointer still refers to the same global slot. The fact that
+      // tabs[activeTabIndex] is in active strip is preserved.
+    }
+    inactiveActiveTabIndex = globalFromIdx;
+  } else {
+    // The moving tab is leaving the inactive strip (rare path: drag from
+    // inactive strip to its own edge). The source strip becomes active strip
+    // counterpart. We promote.
+    inactiveActiveTabIndex = lastIndexInStrip(sourceStrip);
+    activeTabIndex = globalFromIdx;
+    // The user just dropped a tab onto the source strip's edge — we keep their
+    // focus on what they just moved, which means activeStripId flips.
+    activeStripId = targetStrip;
+  }
+  syncMirrorFromActiveTab();
+  if (currentMode === 'view') renderView();
+  else if (currentMode === 'edit') renderEdit();
+  else renderSplit();
+  renderTabstrip();
+  renderInactiveColumn();
+  highlightActiveTreeItem();
+  updateWordCount();
+  updateSaveIndicator(!activeTab()?.dirty);
+  restoreScrollPosition();
+  schedulePersistTabs();
+}
+
+/** Move the tab at `globalFromIdx` into `targetStripId` at insertion position
+ * `to` (insert-before semantics within the target strip). Handles cross-strip
+ * drops from the strip's drop handler. */
+function moveTabToStrip(globalFromIdx: number, _to: number, targetStripId: number): void {
+  if (globalFromIdx < 0 || globalFromIdx >= tabs.length) return;
+  const moving = tabs[globalFromIdx];
+  if (!moving || moving.stripId === targetStripId) return;
+  const sourceStrip = moving.stripId;
+  const sourceWasActive = sourceStrip === activeStripId;
+  // Just relabel the strip; persistence will renumber the per-strip idx.
+  moving.stripId = targetStripId;
+  // Snap the source strip's active pointer back into a tab that still belongs
+  // to it.
+  const sourcePtr = sourceWasActive ? 'active' : 'inactive';
+  if (sourcePtr === 'active') {
+    if (globalFromIdx === activeTabIndex) {
+      activeTabIndex = lastIndexInStrip(sourceStrip);
+    }
+    if (globalFromIdx === inactiveActiveTabIndex || tabs[inactiveActiveTabIndex]?.stripId === targetStripId) {
+      inactiveActiveTabIndex = globalFromIdx;
+    }
+  } else {
+    if (globalFromIdx === inactiveActiveTabIndex) {
+      inactiveActiveTabIndex = lastIndexInStrip(sourceStrip);
+    }
+    if (tabs[activeTabIndex]?.stripId !== activeStripId) {
+      activeTabIndex = lastIndexInStrip(activeStripId);
+    }
+  }
+  // If the source strip just emptied, collapse the split.
+  const sourceEmpty = !tabs.some(t => t.stripId === sourceStrip);
+  if (sourceEmpty) {
+    collapseSplitAfterClose(sourceWasActive);
+    return;
+  }
+  syncMirrorFromActiveTab();
+  if (currentMode === 'view') renderView();
+  else if (currentMode === 'edit') renderEdit();
+  else renderSplit();
+  renderTabstrip();
+  if (splitActive) renderInactiveColumn();
+  schedulePersistTabs();
+}
+
+/** Collapse the split back to a single column after the closing splice in
+ * `closeTabAt` left one of the strips empty. Any surviving tabs are rehomed
+ * into strip 0; strip 1 (and its DOM) is torn down. */
+function collapseSplitAfterClose(closedActiveStrip: boolean): void {
+  // Rehome every remaining tab into strip 0.
+  for (const t of tabs) t.stripId = 0;
+  // The active pointer must point into strip 0. Pick whichever per-strip
+  // pointer was "the survivor" — if the closed tab was in the active strip,
+  // the inactive pointer survives and becomes the new active.
+  if (closedActiveStrip) {
+    activeTabIndex = inactiveActiveTabIndex >= 0 ? inactiveActiveTabIndex : 0;
+  }
+  // Clamp into bounds.
+  if (activeTabIndex >= tabs.length) activeTabIndex = tabs.length - 1;
+  if (activeTabIndex < 0 && tabs.length > 0) activeTabIndex = 0;
+  inactiveActiveTabIndex = -1;
+  activeStripId = 0;
+  splitActive = false;
+  disableSplitDOM();
+  syncMirrorFromActiveTab();
+  if (tabs.length === 0) {
+    activeTabIndex = -1;
+  }
+  if (currentMode === 'view') renderView();
+  else if (currentMode === 'edit') renderEdit();
+  else renderSplit();
+  renderTabstrip();
+  highlightActiveTreeItem();
+  updateWordCount();
+  updateSaveIndicator(true);
+  restoreScrollPosition();
+  schedulePersistTabs();
+}
+
+/** Drag the divider to resize. `tabSplitRatio` is the left column's share. */
+function beginTabSplitDrag(start: MouseEvent): void {
+  if (!splitWrapEl) return;
+  start.preventDefault();
+  const wrap = splitWrapEl;
+  const wrapRect = wrap.getBoundingClientRect();
+  const onMove = (e: MouseEvent): void => {
+    const ratio = (e.clientX - wrapRect.left) / wrapRect.width;
+    tabSplitRatio = Math.max(0.15, Math.min(0.85, ratio));
+    wrap.style.gridTemplateColumns = `${tabSplitRatio * 100}% 6px 1fr`;
+  };
+  const onUp = (): void => {
+    document.removeEventListener('mousemove', onMove);
+    document.removeEventListener('mouseup', onUp);
+    void window.mid.patchAppState({ tabSplitRatio } as Partial<AppState>);
+  };
+  document.addEventListener('mousemove', onMove);
+  document.addEventListener('mouseup', onUp);
+}
+
+/** Wire global drag listeners to detect when a tab drag enters the editor
+ * area's left or right edge. We can't bind on the strip alone because the
+ * user's intent is the EDITOR area's edges (per AC and the issue spec). */
+function setupSplitEdgeDropDetection(): void {
+  const editorArea = getEditorAreaEl();
+  if (!editorArea) return;
+
+  /** Returns the {column, side} the cursor is near, or null. */
+  const detectEdgeZone = (clientX: number, clientY: number): { col: HTMLElement; side: 'left' | 'right' } | null => {
+    // Figure out which column (if any) the pointer is over. When split is
+    // inactive there is only `editorArea`; when active there are two columns.
+    const candidates: HTMLElement[] = splitActive && splitWrapEl
+      ? Array.from(splitWrapEl.querySelectorAll<HTMLElement>('.mid-editor-column'))
+      : [editorArea];
+    for (const col of candidates) {
+      const r = col.getBoundingClientRect();
+      if (clientX < r.left || clientX > r.right) continue;
+      if (clientY < r.top || clientY > r.bottom) continue;
+      const fromLeft = clientX - r.left;
+      const fromRight = r.right - clientX;
+      if (fromLeft <= SPLIT_EDGE_THRESHOLD_PX) return { col, side: 'left' };
+      if (fromRight <= SPLIT_EDGE_THRESHOLD_PX) return { col, side: 'right' };
+      return null;
+    }
+    return null;
+  };
+
+  /** Show the drop indicator over the edge of `col` on `side`. */
+  const showIndicator = (col: HTMLElement, side: 'left' | 'right'): void => {
+    if (!splitDropIndicatorEl) return;
+    const r = col.getBoundingClientRect();
+    splitDropIndicatorEl.hidden = false;
+    splitDropIndicatorEl.style.top = `${r.top}px`;
+    splitDropIndicatorEl.style.height = `${r.height}px`;
+    splitDropIndicatorEl.style.width = '4px';
+    splitDropIndicatorEl.style.left = side === 'left' ? `${r.left}px` : `${r.right - 4}px`;
+  };
+
+  const hideIndicator = (): void => {
+    if (splitDropIndicatorEl) splitDropIndicatorEl.hidden = true;
+  };
+
+  // We listen on `document` because the dragover events must bubble out of the
+  // strip's row of tab buttons (they `preventDefault` for their own intra-strip
+  // reorder DnD). The strip itself is a narrow horizontal sliver — the user
+  // expects the EDITOR AREA's left/right margin to be the drop zone.
+  document.addEventListener('dragover', ev => {
+    if (!ev.dataTransfer?.types.includes('application/x-mid-tab')) return;
+    const zone = detectEdgeZone(ev.clientX, ev.clientY);
+    if (!zone) { hideIndicator(); return; }
+    ev.preventDefault();
+    ev.dataTransfer.dropEffect = 'move';
+    showIndicator(zone.col, zone.side);
+  });
+  document.addEventListener('drop', ev => {
+    const raw = ev.dataTransfer?.getData('application/x-mid-tab');
+    if (raw == null || raw === '') return;
+    const zone = detectEdgeZone(ev.clientX, ev.clientY);
+    hideIndicator();
+    if (!zone) return;
+    const fromIdx = parseInt(raw, 10);
+    if (Number.isNaN(fromIdx)) return;
+    ev.preventDefault();
+    // Determine which strip the drop maps to. Single-column case: split off.
+    if (!splitActive) {
+      enableSplit(fromIdx);
+      return;
+    }
+    // Already split: figure out which strip the targeted column is.
+    const col = zone.col;
+    const isCol2 = col !== getEditorAreaEl();
+    // When split is on, column 0 (the original `editor-area`) hosts whichever
+    // strip is currently `activeStripId`; column 2 hosts the other. So the
+    // strip id of the drop target is:
+    const targetStripId: 0 | 1 = isCol2 ? getInactiveStripId() : activeStripId;
+    const moving = tabs[fromIdx];
+    if (!moving) return;
+    if (moving.stripId === targetStripId) return; // same-strip drop = noop
+    moveTabToStrip(fromIdx, 0, targetStripId);
+  });
+  document.addEventListener('dragend', hideIndicator);
+
+  // Click promotion: clicking inside the inactive column (anywhere outside
+  // tab buttons / divider) makes it the active column. The active column
+  // ALWAYS lives in `#editor-area` — `swapActiveColumn` flips which strip's
+  // tabs render there. So a click in column-2 (the sibling) means "promote
+  // me". Tab buttons handle their own promotion via their click listener.
+  document.addEventListener('click', ev => {
+    if (!splitActive || !splitWrapEl) return;
+    const target = ev.target as HTMLElement;
+    if (target.closest('.mid-tab')) return;
+    if (target.closest('.mid-tab__close')) return;
+    if (target.closest('.mid-split-divider')) return;
+    const col = target.closest('.mid-editor-column') as HTMLElement | null;
+    if (!col) return;
+    if (col.id === 'editor-area') return; // already the active column
+    swapActiveColumn();
+  });
+}
+
+setupSplitEdgeDropDetection();

--- a/docs/desktop-tabs.md
+++ b/docs/desktop-tabs.md
@@ -1,6 +1,6 @@
 # Desktop tabs
 
-VSCode-style multi-file tab manager for the Electron app (#287, #308).
+VSCode-style multi-file tab manager for the Electron app (#287, #308, #309).
 
 ## What ships in v0.2.5 (MVP, #287)
 
@@ -17,7 +17,7 @@ VSCode-style multi-file tab manager for the Electron app (#287, #308).
 - Tabs persist across restart via the SQLite `open_tabs` table — including which
   tab was active
 
-## What ships next (#308 — window detach)
+## Window detach (#308)
 
 - **Drag a tab outside the window's bounds** → main spawns a fresh
   `BrowserWindow` with that one file pre-loaded as its only tab.
@@ -35,15 +35,42 @@ VSCode-style multi-file tab manager for the Electron app (#287, #308).
 - macOS still skips `app.quit()` when the last window closes — closing the
   detached window doesn't take the origin down.
 
+## Split-screen (#309)
+
+- **Drag a tab onto the left or right ~80px of the editor pane** to split the
+  editor into two columns. A vertical highlight bar (the drop indicator)
+  follows the cursor while the drag is in flight so the drop target is obvious.
+- Each column has its own independent tab strip + active tab + active editor
+  pointer. The active column hosts the live editor (`#root`); the inactive
+  column shows a static markdown preview of its own active tab so both files
+  are visible at a glance.
+- Click anywhere inside a column (or on one of its tabs) to make it the active
+  column — the live editor swaps over and any new tree-opens land there.
+- Drag a tab between columns (drop on the other strip) to rehome it.
+- Drag the divider between columns to resize. The ratio is clamped to
+  `[0.15, 0.85]` and persisted as `tabSplitRatio` in app state so it survives
+  a restart.
+- Closing the last tab in a column collapses the split back to a single
+  column — surviving tabs are rehomed into strip 0 and the second column DOM
+  is torn down.
+- Both columns persist across restart with their own tab list + active tab via
+  the existing `(strip_id, idx, path, active)` schema. The persisted
+  `tabActiveStripId` setting remembers which column was last live.
+
 ## Out of scope (deferred follow-ups)
 
 - **Re-attach** — drag a tab from a detached window back into the main
   window's strip to merge it back. Electron doesn't ship cross-window drag
   out of the box, so this would need a custom `screen.getCursorScreenPoint()`
   poll on `dragend` to find the destination window.
-- **Split-screen** — drop a tab onto the right edge of the strip to create a
-  second column. The model already carries `stripId` so this is a renderer-only
-  change once the drop-target UI lands. Tracked under #309.
+- **Three-or-more columns** — the schema is `strip_id` (any int) but the
+  renderer is hard-coded for 0 | 1. Adding a third column is straightforward
+  but ergonomically debatable on a laptop screen, so it's parked.
+- **Dual live editors** — only the active column has a live `<textarea>`. The
+  inactive column is a read-only preview to avoid duplicating the renderer's
+  ~70 references to `currentText`/`currentPath` and the singletons (mermaid
+  context, outline observer, etc.). Promotion via click is fast enough that
+  the UX feels equivalent.
 
 ## Layout model
 
@@ -69,20 +96,40 @@ holds the strip on top and `<main id="root">` underneath. The strip is
 
 ```ts
 interface FileTab {
-  stripId: number;        // 0 in the MVP. Future split: 0 left, 1 right.
+  stripId: number;        // 0 left, 1 right.
   path: string;           // absolute file path on disk
   text: string;           // current buffer (may differ from disk if dirty)
   dirty: boolean;         // unsaved changes since last load/save
   scrollTop: number;      // last known scroller position; restored on focus
 }
 
-const tabs: FileTab[];
-let activeTabIndex: number;
+const tabs: FileTab[];                    // all tabs, both strips
+let activeTabIndex: number;               // global idx into tabs[] of the active-strip's focused tab
+let inactiveActiveTabIndex: number;       // global idx of the OTHER strip's focused tab, -1 when split off
+let activeStripId: 0 | 1;                 // which strip is "live"
+let splitActive: boolean;                 // true when the editor area is two columns
+let tabSplitRatio: number;                // 0.15-0.85 — left column's grid share
 ```
 
-Strip 0 is the only strip in the MVP. The single strip persists into rows of
-`open_tabs` keyed by `(strip_id, idx)`, so multi-strip is a renderer-only
-expansion that doesn't break the wire format.
+The renderer keeps a single flat `tabs[]` array with `stripId` as the bucket
+key rather than two nested arrays. That keeps cross-strip moves cheap (just
+flip `stripId`) and keeps the persist layer's `(strip_id, idx)` rows simple.
+Within each strip, "idx" is recomputed at persist time as a strip-local
+ordinal — the global order in `tabs[]` doesn't influence the wire format.
+
+When `splitActive` is `false`, only `activeTabIndex` is meaningful.
+`activeStripId` is always 0 in single-column mode.
+
+When `splitActive` is `true`:
+
+- The active strip's tabs render into `#tabstrip` (inside `#editor-area`).
+- The inactive strip's tabs render into `#tabstrip-2` (inside the sibling
+  column under `.mid-split-root`).
+- The DOM identity of `#editor-area` always tracks the live editor —
+  `swapActiveColumn` flips `activeStripId` and the per-strip pointers but does
+  NOT move DOM nodes; both `renderTabstrip()` and `renderInactiveColumn()`
+  re-paint the tabs into their respective strip elements with their swapped
+  roles.
 
 ### Mirror state
 
@@ -103,7 +150,7 @@ Existing render code (`renderView`, `renderEdit`, `renderSplit`,
 ```sql
 CREATE TABLE open_tabs (
   window_id INTEGER NOT NULL DEFAULT 0,  -- #308 — main = 0, detached = 1+
-  strip_id  INTEGER NOT NULL,            -- 0 today; reserved for split (#309)
+  strip_id  INTEGER NOT NULL,            -- 0 left column, 1 right column (#309)
   idx       INTEGER NOT NULL,            -- ordering inside the strip
   path      TEXT    NOT NULL,
   active    INTEGER NOT NULL DEFAULT 0,  -- 1 for the focused tab in its strip
@@ -113,10 +160,10 @@ CREATE INDEX idx_open_tabs_window ON open_tabs(window_id, strip_id, idx);
 ```
 
 The renderer is the source of truth: every meaningful mutation
-(open/close/move/cycle) calls `schedulePersistTabs()`, which debounces a 200ms
-snapshot and writes the entire set via `mid:tabs-replace`. We wipe-and-replace
-*for that window only* because the row count is small (typically <30 per
-window) and the transaction keeps the swap atomic.
+(open/close/move/cycle/split/swap) calls `schedulePersistTabs()`, which
+debounces a 200ms snapshot and writes the entire set via `mid:tabs-replace`.
+We wipe-and-replace *for that window only* because the row count is small
+(typically <30 per window) and the transaction keeps the swap atomic.
 
 The `window_id` scope is derived from the IPC sender on the main side, not
 trusted from the renderer payload. That keeps a misbehaving renderer from
@@ -127,9 +174,30 @@ and the column was added with a `DEFAULT 0` migration so existing installs
 just work). Detached windows allocate the smallest free slot ≥ 1; closing
 one releases its rows so the slot can be reused.
 
+The `active` column is set per strip — both the active and inactive strips
+remember which of their tabs is focused, so a column swap or restart restores
+each side's last selection independently.
+
 On startup the renderer calls `mid:tabs-list`, reads each file from disk, and
-silently drops any path that no longer exists. The next persist tick collapses
-the table back to the live set, so a deleted file naturally cleans itself up.
+silently drops any path that no longer exists. If the loaded rows include
+both `strip_id = 0` and `strip_id = 1` entries, `hydrateTabs` automatically
+re-enables split mode and re-creates the column-2 DOM. The next persist tick
+collapses the table back to the live set, so a deleted file naturally cleans
+itself up.
+
+### Companion settings (split-screen)
+
+The split layout's view-state is stored alongside the tab table as JSON-blob
+settings:
+
+| Key                  | Type       | Notes                                       |
+|----------------------|------------|---------------------------------------------|
+| `tabSplitActive`     | `boolean`  | True when split mode is on (advisory; the table is the real source)|
+| `tabSplitRatio`      | `number`   | Left column's grid share, clamped 0.15-0.85 |
+| `tabActiveStripId`   | `0 \| 1`   | Which column was last "live" before the close|
+
+These are best-effort: if the settings disagree with the `open_tabs` rows
+(e.g. `tabSplitActive=true` but only strip 0 has rows), the rows win.
 
 ## IPC contract
 
@@ -234,17 +302,69 @@ match it against `BrowserWindow.getBounds()` to find the destination, then
 emit a custom IPC `mid:tabs-attach` to that window's renderer. Filed for a
 later iteration when the demand is real.
 
-## Future: split-screen (deferred)
+## Split-screen mechanics (#309)
 
-When a tab is dropped onto the right edge of the existing strip, the renderer
-should:
+### Drag detection
 
-1. Allocate `stripId = 1`
-2. Move the dropped tab into strip 1 (re-index, mark active)
-3. Re-render `.mid-editor-area` as a horizontal `display: flex; row` of two
-   columns, each with its own strip + `#root`-equivalent
+A document-level `dragover` listener inspects the cursor position whenever
+data of MIME type `application/x-mid-tab` is being dragged. If the cursor sits
+within `SPLIT_EDGE_THRESHOLD_PX` (80) of any editor column's left or right
+edge, a fixed-positioned `<div class="mid-split-drop-indicator">` is shown
+along that edge. The strip's per-tab `dragover` handler calls
+`stopPropagation` to silence the global listener while hovering over a tab
+(otherwise both an intra-strip reorder indicator and the edge indicator would
+fight to render).
 
-The CSS already accommodates a column-flex container. The bigger lift is
-splitting the renderer code into a `TabStrip` class so two instances can
-coexist and the active-strip routing can drive `currentText`/`currentPath`
-correctly. The wire format (`(strip_id, idx, path, active)`) is unchanged.
+### Drop routing
+
+The same listener handles `drop`. The code path forks on `splitActive`:
+
+- **Single-column mode**: any edge drop calls `enableSplit(globalFromIdx)`,
+  which (a) builds the second column DOM via `enableSplitDOM()`, (b) reassigns
+  the dragged tab's `stripId` to `1`, and (c) flips `inactiveActiveTabIndex`
+  to point at the moved tab. The source strip's `activeTabIndex` snaps back
+  to `lastIndexInStrip(activeStripId)` so the live editor still has a focused
+  tab.
+- **Split mode**: edge drop calls `moveTabToStrip(globalFromIdx, _, targetStripId)`
+  where the target strip is derived from which physical column was hovered
+  (`#editor-area` always hosts the active strip; the sibling column hosts the
+  inactive strip). If the move empties the source strip, `collapseSplitAfterClose`
+  rehomes everything back into strip 0 and tears down the second column.
+
+### Layout DOM
+
+```
+.mid-split-root           (display: grid; grid-template-columns: <ratio>% 6px 1fr)
+├─ #editor-area           (the live column — moved here from <body>'s layout grid)
+│   ├─ #tabstrip           ← active strip's tabs
+│   └─ <main id="root">    ← live <textarea> / preview / mermaid view
+├─ .mid-split-divider     (col-resize cursor; drag updates tabSplitRatio)
+└─ .mid-editor-column     (the read-only column)
+    ├─ #tabstrip-2         ← inactive strip's tabs
+    └─ #root-2             ← static markdown preview (.mid-inactive-preview)
+```
+
+`#editor-area` is *moved* (not cloned) into the wrapper. `enableSplitDOM`
+stashes its original parent + nextSibling so `disableSplitDOM` can put it
+back. That keeps every existing `getElementById('root')` /
+`getElementById('tabstrip')` reference happy with zero churn.
+
+### Promotion (clicking inside an inactive column)
+
+A document-level `click` listener checks `target.closest('.mid-editor-column')`.
+If the closest column is NOT `#editor-area` (i.e. the user clicked the
+inactive sibling), it calls `swapActiveColumn()`. Tab buttons handle their own
+swap inside their per-tab click listener so the swap+focus combo lands as a
+single render. The divider and tab-close buttons short-circuit the listener
+to avoid spurious swaps.
+
+### Edge cases handled
+
+- Closing the last tab in either column collapses the split.
+- Dropping the only tab of a strip onto its own edge is a no-op
+  (`enableSplit` early-returns when `sourceStripCount <= 1`).
+- The recently-closed stack is global — `Cmd+Shift+T` after closing a
+  strip-1 tab resurrects it into the currently active strip, which is the
+  intended VSCode parity (re-attach behaviour is a future enhancement).
+- Persistence captures both strips simultaneously; resyncing on hydrate
+  refuses to enable split if only one strip has rows (graceful downgrade).


### PR DESCRIPTION
## Summary

Builds on the #287 / #310 MVP and activates the second strip the model
already carries. Dropping a tab onto the left or right ~80px of the editor
pane splits the editor into two side-by-side columns. Each column has its
own independent tab strip + active tab + editor pointer. The active column
hosts the live editor (`#root` + `<textarea>` + outline observer); the
inactive column shows a static markdown preview of its own active tab so
both files are visible at a glance.

Click inside a column (or one of its tabs) to make it the active column —
the live editor swaps over and any new tree-opens land there. Drag the
divider between columns to resize (clamped 0.15-0.85). Close the last tab
in a column to collapse back to single-column.

Both columns persist across restart with their own tab list + active tab
via the existing `(strip_id, idx, path, active)` schema. Companion
settings keys (`tabSplitActive`, `tabSplitRatio`, `tabActiveStripId`)
preserve the layout view-state.

Implementation kept minimally invasive — most of the new code lives in a
self-contained module at the bottom of `renderer.ts` to minimise merge
conflicts with the parallel detach work on `feat/308-tab-detach`. The
existing `currentText`/`currentPath`/`#root` references stay untouched
because `#editor-area` is *moved* into the split wrapper and always hosts
whichever strip is currently active.

## Acceptance criteria

- [x] Drag tab onto left/right edge of an existing strip → editor splits into 2 columns.
- [x] Each column has its own independent tab strip + active tab + editor.
- [x] Closing the last tab in a column collapses back to single-column.
- [x] Clicking inside a column makes it active; new opens go there.
- [x] Drag divider between columns to resize.
- [x] Both columns persist across restart with their own tab list + active tab.
- [x] Drop indicator (vertical highlight bar) visible during drag.
- [x] Docs updated.

## Test plan

- [ ] Open at least 2 files in strip 0; drag one onto right edge → second column appears with that tab.
- [ ] Drag a tab from one strip onto the other strip's tabs → tab rehomes between columns.
- [ ] Close the last tab in one column → split collapses, surviving tabs remain in single strip.
- [ ] Click inside the inactive column → live editor swaps; type into editor; verify cursor + word count update for that file.
- [ ] Drag the vertical divider → ratio updates smoothly; both columns resize.
- [ ] Quit + relaunch with two columns open → layout restored, including which column was active.
- [ ] During a tab drag, hover near editor edges (single-column AND split-mode) → vertical highlight bar follows the closest column edge.
- [ ] Drop on left edge with only 1 tab → no split (intentional safeguard).

Closes #309