### PR TITLE
fix(desktop): blocking onboarding + local-folder warehouse + MCP status sync (#314, #316)

### DIFF
--- a/apps/electron/main.ts
+++ b/apps/electron/main.ts
@@ -683,6 +683,14 @@ ipcMain.handle('mid:repo-status', async (_e, workspace: string) => {
 });
 
 ipcMain.handle('mid:repo-connect', async (_e, workspace: string, repoSlug: string) => {
+  // #314 — local-folder warehouses use the `local:<path>` prefix. Skip every
+  // git remote step and just confirm the target folder exists; the workspace
+  // doesn't need to be a git repo at all for local-only sync.
+  if (repoSlug.startsWith('local:')) {
+    const targetPath = repoSlug.slice('local:'.length);
+    try { await fs.mkdir(targetPath, { recursive: true }); } catch { /* fine */ }
+    return { url: `file://${targetPath}` };
+  }
   // 1. Ensure git initialized
   try {
     await runGit(workspace, ['rev-parse', '--git-dir']);
@@ -1003,19 +1011,34 @@ function startMCP(): void {
         ELECTRON_RUN_AS_NODE: '1',
       },
     });
+    // Provisionally start. Re-evaluate after 500ms so an early crash flips
+    // the tray to 'error' instead of staying stuck on 'running' (#316).
     setMCPStatus('running');
+    setTimeout(() => {
+      if (mcpProcess && !mcpProcess.killed && mcpProcess.exitCode === null) {
+        // Still alive — refresh the menu so the running label is correct
+        // even if the renderer wasn't ready when the first paint happened.
+        rebuildTrayMenu();
+        console.log('[mid] MCP server alive', { pid: mcpProcess.pid });
+      }
+    }, 500);
     mcpProcess.stderr?.on('data', chunk => {
       stderrTail = (stderrTail + chunk.toString()).slice(-500);
+      // Surface the MCP child's stderr in the main-process console so a real
+      // failure mode is visible during development / packaged testing (#316).
+      console.warn('[mid][mcp]', chunk.toString().trim());
     });
     mcpProcess.on('error', e => {
       mcpProcess = null;
       setMCPStatus('error', e.message);
+      console.error('[mid] MCP fork error:', e.message);
     });
     mcpProcess.on('exit', code => {
       mcpProcess = null;
       if (code !== 0 && mcpStatus !== 'stopped') {
         const detail = stderrTail.trim().split('\n').slice(-1)[0] || `code ${code}`;
         setMCPStatus('error', detail);
+        console.error('[mid] MCP exited with non-zero code:', code, detail);
       } else {
         setMCPStatus('stopped');
       }

--- a/apps/electron/renderer/renderer.ts
+++ b/apps/electron/renderer/renderer.ts
@@ -3185,7 +3185,7 @@ async function dismissOnboardingForCurrentWorkspace(): Promise<void> {
   await window.mid.patchAppState({ warehouseOnboardingDismissed: [...prev, wsId] });
 }
 
-async function openWarehouseOnboarding(force = false): Promise<void> {
+async function openWarehouseOnboarding(force = false, blocking = false): Promise<void> {
   if (!currentFolder) {
     flashStatus('Open a folder before configuring a warehouse');
     return;
@@ -3207,6 +3207,11 @@ async function openWarehouseOnboarding(force = false): Promise<void> {
   const closeBtn = document.getElementById('mid-onboarding-close') as HTMLButtonElement;
   const backBtn = document.getElementById('mid-onboarding-back') as HTMLButtonElement;
   const nextBtn = document.getElementById('mid-onboarding-next') as HTMLButtonElement;
+  // #314 — when launched as blocking middleware (no warehouse yet), the user
+  // cannot dismiss with Skip / X / Esc / backdrop. The flow only ends when
+  // a warehouse is persisted (github or local).
+  skipBtn.hidden = blocking;
+  closeBtn.hidden = blocking;
 
   const state: OnboardingState = {
     step: 'gh',
@@ -3242,8 +3247,12 @@ async function openWarehouseOnboarding(force = false): Promise<void> {
     onboardingActive = false;
   };
 
-  const onSkip = (): void => closeOnboarding(true);
-  const onCancel = (e: Event): void => { e.preventDefault(); closeOnboarding(true); };
+  const onSkip = (): void => { if (!blocking) closeOnboarding(true); };
+  const onCancel = (e: Event): void => {
+    e.preventDefault();
+    // Esc / backdrop is honored as Skip ONLY when not blocking.
+    if (!blocking) closeOnboarding(true);
+  };
 
   const renderError = (): string => state.error
     ? `<div class="mid-onboarding-error">${escapeHTML(state.error)}</div>`
@@ -3378,6 +3387,13 @@ async function openWarehouseOnboarding(force = false): Promise<void> {
         <div class="mid-onboarding-list" id="mid-onboarding-repo-list"></div>
         <div class="mid-onboarding-status">${state.repos.length} repo${state.repos.length === 1 ? '' : 's'} loaded</div>
       </div>
+      <div class="mid-onboarding-card">
+        <div class="mid-onboarding-card-title">${iconHTML('folder', 'mid-icon--sm')} Or use a local folder</div>
+        <p class="mid-onboarding-card-hint">No GitHub. Notes sync to a folder you pick — works for users who only want local backup or use a different sync mechanism (iCloud / Dropbox / Syncthing).</p>
+        <div class="mid-onboarding-actions">
+          <button class="mid-btn" data-onboarding-action="pick-local">${iconHTML('folder', 'mid-icon--sm')} Pick a folder…</button>
+        </div>
+      </div>
       ${renderError()}
     `;
     const slugInput = body.querySelector<HTMLInputElement>('#mid-onboarding-create-slug');
@@ -3428,6 +3444,14 @@ async function openWarehouseOnboarding(force = false): Promise<void> {
       const m = /github\.com[:/]([^/]+\/[^/.]+?)(?:\.git)?\/?$/.exec(url);
       const finalSlug = m ? m[1] : slugRaw;
       await persistAndConnect(finalSlug);
+    });
+    body.querySelector<HTMLButtonElement>('[data-onboarding-action="pick-local"]')?.addEventListener('click', async () => {
+      // #314 — local-folder warehouse. Persisted with `repo: 'local:<path>'`
+      // so the rest of the system can detect non-GitHub warehouses by prefix
+      // and skip remote-only operations (push / pull / device-flow).
+      const picked = await window.mid.openFolderDialog();
+      if (!picked) return;
+      await persistAndConnect(`local:${picked.folderPath}`);
     });
     nextBtn.onclick = (): void => {
       if (state.selectedRepo) void persistAndConnect(state.selectedRepo);
@@ -6455,7 +6479,9 @@ void window.mid.readAppState().then(async state => {
     try {
       const existing = await window.mid.warehousesList(currentFolder);
       if (existing.length === 0) {
-        await openWarehouseOnboarding(true);
+        // #314 — blocking onboarding: app cannot proceed without a warehouse
+        // (github repo OR local folder). User can change later from settings.
+        await openWarehouseOnboarding(true, /* blocking */ true);
       }
     } catch (err) { console.debug('[mid] launch onboarding gate error:', err); }
   }


### PR DESCRIPTION
Closes #314 #316. Partially addresses #315 (just the local-folder path; full settings rebuild is a follow-up).